### PR TITLE
style:rename classes to comply with abbreviation capitalization rules

### DIFF
--- a/plugins/org.ruyisdk.core/plugin.xml
+++ b/plugins/org.ruyisdk.core/plugin.xml
@@ -5,7 +5,7 @@
 	<extension point="org.eclipse.ui.preferencePages">
 		<page id="org.ruyisdk.preferences.root"
 			name="RuyiSDK"
-			class="org.ruyisdk.core.preferences.RuyiSDKPreferenceContainer"
+			class="org.ruyisdk.core.preferences.RuyiSdkPreferenceContainer"
 			icon="icons/ruyisdk-icon16.png">
 		</page>
 	</extension>

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/basedir/TextXdgDir.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/basedir/TextXdgDir.java
@@ -4,16 +4,16 @@ import java.nio.file.Path;
 
 import org.ruyisdk.core.config.Constants;
 
-public class TextXDGDir {
+public class TextXdgDir {
 
     public static void main(String[] args) {
         String appName = Constants.AppInfo.AppDir;
 
         // 获取 XDG 目录
-        Path configDir = XDGDirs.getConfigDir(appName);
-        Path cacheDir = XDGDirs.getCacheDir(appName);
-        Path dataDir = XDGDirs.getDataDir(appName);
-        Path stateDir = XDGDirs.getStateDir(appName);
+        Path configDir = XdgDirs.getConfigDir(appName);
+        Path cacheDir = XdgDirs.getCacheDir(appName);
+        Path dataDir = XdgDirs.getDataDir(appName);
+        Path stateDir = XdgDirs.getStateDir(appName);
 
         System.out.println("Config Dir: " + configDir);
         System.out.println("Cache Dir: " + cacheDir);

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/basedir/XdgDirs.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/basedir/XdgDirs.java
@@ -3,7 +3,7 @@ package org.ruyisdk.core.basedir;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-public class XDGDirs {
+public class XdgDirs {
 
     /**
      * 获取 XDG 配置目录（$XDG_CONFIG_HOME/<app-name> 或 ~/.config/<app-name>）

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/console/ConsoleExtensions.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/console/ConsoleExtensions.java
@@ -18,15 +18,15 @@ public class ConsoleExtensions {
             try {
                 Object ext = config.createExecutableExtension("class");
                 if (ext instanceof ConsoleExtension) {
-                    ((ConsoleExtension) ext).init(RuyiSDKConsole.getInstance());
+                    ((ConsoleExtension) ext).init(RuyiSdkConsole.getInstance());
                 }
             } catch (CoreException e) {
-                RuyiSDKConsole.getInstance().logError("Failed to load console extension: " + e.getMessage());
+                RuyiSdkConsole.getInstance().logError("Failed to load console extension: " + e.getMessage());
             }
         }
     }
 
     public interface ConsoleExtension {
-        void init(RuyiSDKConsole console);
+        void init(RuyiSdkConsole console);
     }
 }

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/console/ConsoleManager.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/console/ConsoleManager.java
@@ -11,7 +11,7 @@ public class ConsoleManager {
     
     public static void showConsole() {
         IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
-        RuyiSDKConsole console = RuyiSDKConsole.getInstance();
+        RuyiSdkConsole console = RuyiSdkConsole.getInstance();
         
         // 避免重复添加
         IConsole[] existing = consoleManager.getConsoles();
@@ -27,6 +27,6 @@ public class ConsoleManager {
 
     public static void dispose() {
         ConsolePlugin.getDefault().getConsoleManager()
-            .removeConsoles(new IConsole[]{ RuyiSDKConsole.getInstance().getConsole() });
+            .removeConsoles(new IConsole[]{ RuyiSdkConsole.getInstance().getConsole() });
     }
 }

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/console/RuyiSdkConsole.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/console/RuyiSdkConsole.java
@@ -9,7 +9,7 @@ import org.eclipse.ui.console.MessageConsoleStream;
 /**
  * RuyiSDK 专属控制台（单例模式）
  */
-public class RuyiSDKConsole {
+public class RuyiSdkConsole {
     private static final String CONSOLE_NAME = "RuyiSDK";
     private static final String CONSOLE_TYPE = "org.ruyisdk.console";
 
@@ -18,7 +18,7 @@ public class RuyiSDKConsole {
 
     // 静态内部类实现懒加载单例
     private static class Holder {
-        static final RuyiSDKConsole INSTANCE = new RuyiSDKConsole();
+        static final RuyiSdkConsole INSTANCE = new RuyiSdkConsole();
     }
 
     private final MessageConsole console;
@@ -28,7 +28,7 @@ public class RuyiSDKConsole {
     private MessageConsoleStream commandStream;
 
     // 私有构造函数
-    private RuyiSDKConsole() {
+    private RuyiSdkConsole() {
         this.console = new MessageConsole(CONSOLE_NAME, CONSOLE_TYPE, ImageDescriptor.getMissingImageDescriptor(),
                         true);
 
@@ -39,7 +39,7 @@ public class RuyiSDKConsole {
     /**
      * 获取单例实例（线程安全）
      */
-    public static RuyiSDKConsole getInstance() {
+    public static RuyiSdkConsole getInstance() {
         return Holder.INSTANCE;
     }
 

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/console/TestConsole.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/console/TestConsole.java
@@ -4,8 +4,8 @@ public class TestConsole {
 
     public static void main(String[] args) {
         // 在任何插件中直接调用
-        RuyiSDKConsole.getInstance().logInfo("Device connected successfully");
-        RuyiSDKConsole.getInstance().logError("Failed to flash device");
+        RuyiSdkConsole.getInstance().logInfo("Device connected successfully");
+        RuyiSdkConsole.getInstance().logError("Failed to flash device");
 
         // 快捷显示控制台（首次调用会自动创建）
         ConsoleManager.showConsole();

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/preferences/RuyiSdkPreferenceContainer.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/preferences/RuyiSdkPreferenceContainer.java
@@ -14,7 +14,7 @@ import org.eclipse.ui.IWorkbenchPreferencePage;
 /**
  * RuyiSDK 首选项根容器页（不包含具体配置项，仅作为分类入口）
  */
-public class RuyiSDKPreferenceContainer extends PreferencePage implements IWorkbenchPreferencePage {
+public class RuyiSdkPreferenceContainer extends PreferencePage implements IWorkbenchPreferencePage {
 
     @Override
     public void init(IWorkbench workbench) {

--- a/plugins/org.ruyisdk.devices/src/org/ruyisdk/devices/Activator.java
+++ b/plugins/org.ruyisdk.devices/src/org/ruyisdk/devices/Activator.java
@@ -3,7 +3,7 @@ package org.ruyisdk.devices;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 import org.ruyisdk.core.console.ConsoleManager;
-import org.ruyisdk.core.console.RuyiSDKConsole;
+import org.ruyisdk.core.console.RuyiSdkConsole;
 
 /**
  * The activator class controls the plug-in life cycle
@@ -30,7 +30,7 @@ public class Activator extends AbstractUIPlugin {
 //		// (可选)启动时自动打开控制台
 //        ConsoleManager.showConsole();
         
-        RuyiSDKConsole.getInstance().logInfo("Devices Plugin " + getBundle().getVersion()+" Activated !");
+        RuyiSdkConsole.getInstance().logInfo("Devices Plugin " + getBundle().getVersion()+" Activated !");
 	}
 
 	@Override

--- a/plugins/org.ruyisdk.devices/src/org/ruyisdk/devices/services/PropertiesService.java
+++ b/plugins/org.ruyisdk.devices/src/org/ruyisdk/devices/services/PropertiesService.java
@@ -10,13 +10,13 @@ import java.nio.file.Paths;
 import java.nio.file.Files;
 import java.io.InputStream;
 import java.io.OutputStream;
-import org.ruyisdk.core.basedir.XDGDirs;
+import org.ruyisdk.core.basedir.XdgDirs;
 import org.ruyisdk.devices.model.Device;
-import org.ruyisdk.core.console.RuyiSDKConsole;
+import org.ruyisdk.core.console.RuyiSdkConsole;
 import org.ruyisdk.core.config.Constants;
 
 public class PropertiesService {
-	private static final Path FILE_PATH = Paths.get(XDGDirs.getConfigDir(Constants.AppInfo.AppDir).toString(), Constants.ConfigFile.DeviceProperties);  //devices.properties
+	private static final Path FILE_PATH = Paths.get(XdgDirs.getConfigDir(Constants.AppInfo.AppDir).toString(), Constants.ConfigFile.DeviceProperties);  //devices.properties
 	private static final String DEFAULT_DEVICE_KEY = "default_device";
 	 
 	public List<Device> loadDevices() {
@@ -86,12 +86,12 @@ public class PropertiesService {
 		try (OutputStream output = new FileOutputStream(FILE_PATH.toString())) {
 			properties.store(output, "RuyiSDK Devices Configuration");
 			
-			RuyiSDKConsole.getInstance().logInfo("Devices is successfully stored to file :"+FILE_PATH.toString());
+			RuyiSdkConsole.getInstance().logInfo("Devices is successfully stored to file :"+FILE_PATH.toString());
 			
 		} catch (IOException e) {
 			e.printStackTrace();
 			
-			RuyiSDKConsole.getInstance().logError("Devices storage failure!");
+			RuyiSdkConsole.getInstance().logError("Devices storage failure!");
 		} 
 	}
 }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiProperties.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiProperties.java
@@ -10,16 +10,16 @@ import java.nio.file.StandardOpenOption;
 import java.util.Properties;
 import java.util.Locale;
 
-import org.ruyisdk.core.basedir.XDGDirs;
+import org.ruyisdk.core.basedir.XdgDirs;
 import org.ruyisdk.core.config.Constants;
 import org.ruyisdk.core.config.Constants.AppInfo;
 import org.ruyisdk.core.config.Constants.ConfigFile;
 import org.ruyisdk.core.config.Constants.Ruyi;
-import org.ruyisdk.core.console.RuyiSDKConsole;
+import org.ruyisdk.core.console.RuyiSdkConsole;
 import org.ruyisdk.ruyi.util.RuyiFileUtils;
 
 public class RuyiProperties {
-	private static final Path CONFIG_DIR = XDGDirs.getConfigDir(Constants.AppInfo.AppDir);
+	private static final Path CONFIG_DIR = XdgDirs.getConfigDir(Constants.AppInfo.AppDir);
     private static final Path FILE_PATH = CONFIG_DIR.resolve(Constants.ConfigFile.RuyiProperties);
     private static final Properties props = loadConfig();
     
@@ -167,7 +167,7 @@ public class RuyiProperties {
 
     // 错误处理
     private static void handleConfigError(String message, Exception e) {
-        RuyiSDKConsole.getInstance().logError(message + ": " + e.getMessage());
+        RuyiSdkConsole.getInstance().logError(message + ": " + e.getMessage());
 //        if (Constants.DEBUG_MODE) {
 //            e.printStackTrace();
 //        }


### PR DESCRIPTION
Rename classes with consecutive capital letters in abbreviations:
- `RuyiSDKConsole` → `RuyiSdkConsole`
- `RuyiSDKPreferenceContainer` → `RuyiSdkPreferenceContainer`
- `TextXDGDir` → `TextXdgDir`
- `XDGDirs` → `XdgDirs`