### PR TITLE
style(core):standardize comments and Javadoc

### DIFF
--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/Activator.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/Activator.java
@@ -7,20 +7,19 @@ import org.ruyisdk.core.console.ConsoleExtensions;
 import org.ruyisdk.core.console.ConsoleManager;
 
 /**
- * RuyiSDK Core 插件入口
+ * The activator class controls the plug-in life cycle.
  */
 public class Activator extends AbstractUIPlugin {
-    // 插件ID（需与MANIFEST.MF一致）
-    public static final String PLUGIN_ID = "org.ruyisdk.core";
+    public static final String PLUGIN_ID = "org.ruyisdk.core"; // The plug-in ID
+    private static Activator plugin; // The shared instance
 
-    // 单例实例
-    private static Activator plugin;
 
     /**
-     * 构造函数（必须公开无参）
+     * Constructs a new Activator.
+     *
      */
     public Activator() {
-        // 父类AbstractUIPlugin会自动初始化
+        // Parent class AbstractUIPlugin handles initialization automatically
     }
 
     @Override
@@ -28,7 +27,7 @@ public class Activator extends AbstractUIPlugin {
         super.start(context);
         plugin = this;
 
-        // 初始化控制台扩展
+        // Initialize console extensions
         ConsoleExtensions.loadExtensions();
     }
 
@@ -41,14 +40,19 @@ public class Activator extends AbstractUIPlugin {
     }
 
     /**
-     * 获取共享实例
+     * Returns the shared instance.
+     *
+     * @return the shared plugin instance
      */
     public static Activator getDefault() {
         return plugin;
     }
 
     /**
-     * 获取图像描述符（安全方式）
+     * Returns an image descriptor for the image file at the given path.
+     *
+     * @param path the image path (relative to the plugin installation)
+     * @return the image descriptor, or null if the image could not be found
      */
     public static ImageDescriptor getImageDescriptor(String path) {
         return imageDescriptorFromPlugin(PLUGIN_ID, path);

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/basedir/TextXdgDir.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/basedir/TextXdgDir.java
@@ -4,23 +4,36 @@ import java.nio.file.Path;
 
 import org.ruyisdk.core.config.Constants;
 
+/**
+ * Demonstrates usage of XDG base directory specification to get standard directories.
+ * 
+ * <p>This class shows how to retrieve and use the standard XDG directories (config, cache, data, and
+ * state) for application storage following the XDG Base Directory Specification.
+ */
 public class TextXdgDir {
 
+    /**
+     * Main entry point that demonstrates XDG directory usage.
+     *
+     * @param args command-line arguments (not used)
+     */
     public static void main(String[] args) {
+        // Get application name from constants
         String appName = Constants.AppInfo.AppDir;
 
-        // 获取 XDG 目录
+        // Retrieve standard XDG directories
         Path configDir = XdgDirs.getConfigDir(appName);
         Path cacheDir = XdgDirs.getCacheDir(appName);
         Path dataDir = XdgDirs.getDataDir(appName);
         Path stateDir = XdgDirs.getStateDir(appName);
 
+        // Print directory paths
         System.out.println("Config Dir: " + configDir);
         System.out.println("Cache Dir: " + cacheDir);
         System.out.println("Data Dir: " + dataDir);
         System.out.println("State Dir: " + stateDir);
 
-        // 确保目录存在（如果不存在则创建）
+        // Ensure directories exist (create if they don't)
         configDir.toFile().mkdirs();
         // cacheDir.toFile().mkdirs();
         // dataDir.toFile().mkdirs();

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/basedir/XdgDirs.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/basedir/XdgDirs.java
@@ -3,51 +3,75 @@ package org.ruyisdk.core.basedir;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+/**
+ * Utility class for resolving XDG Base Directory Specification compliant paths. Provides methods to
+ * locate configuration, cache, data and state directories according to the XDG standard.
+ */
 public class XdgDirs {
 
     /**
-     * 获取 XDG 配置目录（$XDG_CONFIG_HOME/<app-name> 或 ~/.config/<app-name>）
+     * Gets the XDG config directory path. Resolution order: 1. {@code $XDG_CONFIG_HOME/<app-name>} if
+     * environment variable is set 2. {@code ~/.config/<app-name>} as fallback
+     *
+     * @param appName the application name used for subdirectory
+     * @return resolved config directory path
      */
     public static Path getConfigDir(String appName) {
         return getXdgDir("XDG_CONFIG_HOME", ".config", appName);
     }
 
     /**
-     * 获取 XDG 缓存目录（$XDG_CACHE_HOME/<app-name> 或 ~/.cache/<app-name>）
+     * Gets the XDG cache directory path. Resolution order: 1. {@code $XDG_CACHE_HOME/<app-name>} if
+     * environment variable is set 2. {@code ~/.cache/<app-name>} as fallback
+     *
+     * @param appName the application name used for subdirectory
+     * @return resolved cache directory path
      */
     public static Path getCacheDir(String appName) {
         return getXdgDir("XDG_CACHE_HOME", ".cache", appName);
     }
 
     /**
-     * 获取 XDG 数据目录（$XDG_DATA_HOME/<app-name> 或 ~/.local/share/<app-name>）
+     * Gets the XDG data directory path. Resolution order: 1. {@code $XDG_DATA_HOME/<app-name>} if
+     * environment variable is set 2. {@code ~/.local/share/<app-name>} as fallback
+     *
+     * @param appName the application name used for subdirectory
+     * @return resolved data directory path
      */
     public static Path getDataDir(String appName) {
         return getXdgDir("XDG_DATA_HOME", ".local/share", appName);
     }
-    
+
     /**
-     * 获取 XDG 状态目录（$XDG_STATE_HOME/<app-name> 或 ~/.local/state/<app-name>）
+     * Gets the XDG state directory path. Resolution order: 1. {@code $XDG_STATE_HOME/<app-name>} if
+     * environment variable is set 2. {@code ~/.local/state/<app-name>} as fallback
+     *
+     * @param appName the application name used for subdirectory
+     * @return resolved state directory path
      */
     public static Path getStateDir(String appName) {
         return getXdgDir("XDG_STATE_HOME", ".local/state", appName);
     }
 
     /**
-     * 通用方法：获取 XDG 目录
-     * @param xdgEnvVar 环境变量名（如 "XDG_CONFIG_HOME"）
-     * @param defaultRelativePath 默认相对路径（如 ".config"）
-     * @param appName 应用名称（如 "your-ide-name"）
-     * @return 完整路径（如 /home/user/.config/your-ide-name）
+     * Internal method for resolving XDG directory paths. Follows XDG Base Directory Specification
+     * resolution rules: 1. Checks specified environment variable first 2. Falls back to default path
+     * under user home if not set
+     *
+     * @param xdgEnvVar the XDG environment variable name (e.g. "XDG_CONFIG_HOME")
+     * @param defaultRelativePath the default path relative to user home (e.g. ".config")
+     * @param appName the application name for final subdirectory
+     * @return fully resolved directory path
+     * @throws NullPointerException if appName is null
      */
     private static Path getXdgDir(String xdgEnvVar, String defaultRelativePath, String appName) {
-        // 1. 检查环境变量（如 $XDG_CONFIG_HOME）
+        // 1. Check environment variable (e.g. $XDG_CONFIG_HOME)
         String xdgHome = System.getenv(xdgEnvVar);
         if (xdgHome != null && !xdgHome.trim().isEmpty()) {
             return Paths.get(xdgHome, appName);
         }
 
-        // 2. 默认路径（如 ~/.config/）
+        // 2. Default path (e.g. ~/.config/)
         String userHome = System.getProperty("user.home");
         return Paths.get(userHome, defaultRelativePath, appName);
     }

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/config/Constants.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/config/Constants.java
@@ -1,48 +1,79 @@
 package org.ruyisdk.core.config;
 
 /**
- * Constants 程序设计设定，用户不需要修改，由开发者在产品迭代优化中按需修改
+ * Centralized configuration constants for RuyiSDK.
+ *
+ * <p>These are design-time constants that should only be modified by developers during product
+ * iteration. End users should not modify these values.
  */
 public final class Constants {
 
+    /**
+     * Application information constants.
+     */
     public static final class AppInfo {
-        public static final String AppDir = "ruyisdkide"; // XDG-Dir
+        /**
+         * XDG base directory name following XDG Base Directory Specification.
+         * Example: "~/.config/ruyisdkide"
+         */
+        public static final String AppDir = "ruyisdkide";
     }
 
+    /**
+     * Configuration file names and paths.
+     */
     public static final class ConfigFile {
+        /** Device-specific properties file name. */
         public static final String DeviceProperties = "devices.properties";
+
+        /** Main RuyiSDK properties file name. */
         public static final String RuyiProperties = "ruyi.properties";
     }
 
-    // 网络端点（基础设施URL）
+    /**
+     * Network endpoints and infrastructure URLs.
+     */
     public static final class NetAddress {
-        // 官网
-        public static final String WEBSIT = "https://ruyisdk.org";
+        /** Official website URL. */
+        public static final String WEBSITE = "https://ruyisdk.org";
 
-        // Base域名
+        // Base domains
         private static final String MIRROR_BASE = "https://mirror.iscas.ac.cn";
         private static final String GITHUB_BASE = "https://github.com/ruyisdk";
 
-        // 下载RUYI
+        /** Mirror server URL for RuyiSDK releases. */
         public static final String MIRROR_RUYI_RELEASES = MIRROR_BASE + "/ruyisdk/ruyi/releases";
+
+        /** GitHub URL for RuyiSDK releases. */
         public static final String GITHUB_RUYI_RELEASES = GITHUB_BASE + "/ruyi/releases";
 
-        // 下载IDE
+        /** Mirror server URL for IDE releases. */
         public static final String MIRROR_IDE_RELEASES = MIRROR_BASE + "/ruyisdk/ide";
+
+        /** GitHub URL for IDE packages releases. */
         public static final String GITHUB_IDE_RELEASES = GITHUB_BASE + "/ruyisdk-eclipse-packages/releases";
+
+        /** GitHub URL for IDE plugins releases. */
         public static final String GITHUB_IDEPLUGINS_RELEASES = GITHUB_BASE + "/ruyisdk-eclipse-plugins/releases";
 
-        // 存储库 packages-index
-        public static final String MAIN_REPO_URL = GITHUB_BASE + "/packages-index.git"; // "https://github.com/ruyisdk/packages-index.git"
-        public static final String BACKUP_REPO_URL = MIRROR_BASE + "/git/ruyisdk/packages-index.git"; // https://mirror.iscas.ac.cn/git/ruyisdk/packages-index.git
+        /** Main repository URL for packages index. */
+        public static final String MAIN_REPO_URL = GITHUB_BASE + "/packages-index.git";
+
+        /** Backup repository URL for packages index. */
+        public static final String BACKUP_REPO_URL = MIRROR_BASE + "/git/ruyisdk/packages-index.git";
     }
 
-    // 安装配置
-    // 安装配置（设计期确定）
+    /**
+     * Installation configuration constants.
+     */
     public static final class Ruyi {
-        public static String INSTALL_PATH = "~/.local/bin"; // ruyi install path;"/usr/local/bin/"
+        /**
+         * Default installation path for RuyiSDK.
+         * Default value: "~/.local/bin" (user-local binaries)
+         */
+        public static String INSTALL_PATH = "~/.local/bin";
+
+        /** Prefix for backup files created by RuyiSDK. */
         public static final String BACKUP_PREFIX = "ruyi.backup.";
     }
-
-
 }

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/preferences/RuyiSdkPreferenceContainer.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/preferences/RuyiSdkPreferenceContainer.java
@@ -12,33 +12,35 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
 /**
- * RuyiSDK 首选项根容器页（不包含具体配置项，仅作为分类入口）
+ * Root container preference page for RuyiSDK configuration.
+ *
+ * <p>This serves as a category entry point in the preferences dialog tree,
+ * containing no actual configuration items itself. Specific preferences
+ * should be implemented in sub-pages.
  */
 public class RuyiSdkPreferenceContainer extends PreferencePage implements IWorkbenchPreferencePage {
 
     @Override
     public void init(IWorkbench workbench) {
-        // 无初始化操作
+        // No initialization required
     }
 
     @Override
     protected Control createContents(Composite parent) {
-        // 创建容器
+        // Create main container
         Composite container = new Composite(parent, SWT.NONE);
         container.setLayout(new GridLayout(1, false));
 
-        // 添加提示文本
+        // Add informational label
         Label infoLabel = new Label(container, SWT.WRAP);
         infoLabel.setText("Expand the tree to edit preferences for a specific feature.");
 
-        // 添加间距
-        new Label(container, SWT.NONE); // 空标签作为间距
+        // Add spacing
+        new Label(container, SWT.NONE); // Empty label for spacing
 
-        // 可选：添加更多指引
-        // Label hintLabel = new Label(container, SWT.WRAP);
-        // hintLabel.setText("Note: Configuration changes may require restart to take effect.");
+        // Optional: Add documentation link
         Link helpLink = new Link(container, SWT.NONE);
-        helpLink.setText("RuyiSDK 文档: <a>Click here for online documentation</a>");
+        helpLink.setText("RuyiSDK Documentation: <a>Click here for online documentation</a>");
         helpLink.addListener(SWT.Selection, e -> {
             Program.launch("https://ruyisdk.org/docs/intro");
         });
@@ -48,12 +50,12 @@ public class RuyiSdkPreferenceContainer extends PreferencePage implements IWorkb
 
     @Override
     public boolean performOk() {
-        // 无需保存操作
+        // No save operation required
         return true;
     }
 
     @Override
     protected void performDefaults() {
-        // 无默认值操作
+        // No default values to restore
     }
 }

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/ruyi/model/CheckResult.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/ruyi/model/CheckResult.java
@@ -1,13 +1,24 @@
 package org.ruyisdk.core.ruyi.model;
 
 /**
- * 封装Ruyi环境检测结果
+ * Encapsulates the result of a Ruyi environment check operation.
+ *
+ * <p>This class represents the outcome of checking the Ruyi installation status,
+ * including whether installation/upgrade is needed and version information.
  */
 public class CheckResult {
+    /**
+     * Enumeration of possible actions required after environment check.
+     */
     public enum ActionType {
-        INSTALL, // 需要安装
-        UPGRADE, // 需要升级
-        NOTHING // 无需操作
+        /** Ruyi needs to be installed (not currently installed). */
+        INSTALL,
+        
+        /** Ruyi needs to be upgraded (newer version available). */
+        UPGRADE,
+        
+        /** No action needed (Ruyi is up-to-date). */
+        NOTHING
     }
 
     private final ActionType action;
@@ -15,6 +26,14 @@ public class CheckResult {
     private final RuyiVersion currentVersion;
     private final RuyiVersion latestVersion;
 
+    /**
+     * Constructs a new CheckResult instance.
+     *
+     * @param action the required action type
+     * @param message descriptive message about the check result
+     * @param current the currently installed version (may be null)
+     * @param latest the latest available version (may be null)
+     */
     private CheckResult(ActionType action, String message, RuyiVersion current, RuyiVersion latest) {
         this.action = action;
         this.message = message;
@@ -22,35 +41,80 @@ public class CheckResult {
         this.latestVersion = latest;
     }
 
+    /**
+     * Creates a result indicating Ruyi needs to be installed.
+     *
+     * @param msg description of why installation is needed
+     * @return new CheckResult instance with INSTALL action
+     */
     public static CheckResult needInstall(String msg) {
         return new CheckResult(ActionType.INSTALL, msg, null, null);
     }
 
+    /**
+     * Creates a result indicating Ruyi needs to be upgraded.
+     *
+     * @param current currently installed version
+     * @param latest latest available version
+     * @param msg description of why upgrade is needed
+     * @return new CheckResult instance with UPGRADE action
+     */
     public static CheckResult needUpgrade(RuyiVersion current, RuyiVersion latest, String msg) {
         return new CheckResult(ActionType.UPGRADE, msg, current, latest);
     }
 
+    /**
+     * Creates a result indicating no action is needed.
+     *
+     * @return new CheckResult instance with NOTHING action
+     */
     public static CheckResult ok() {
         return new CheckResult(ActionType.NOTHING, "Ruyi is up-to-date", null, null);
     }
 
     // Getters
+
+    /**
+     * Gets the required action type.
+     *
+     * @return the action type
+     */
     public ActionType getAction() {
         return action;
     }
 
+    /**
+     * Gets the descriptive message about the check result.
+     *
+     * @return the message
+     */
     public String getMessage() {
         return message;
     }
 
+    /**
+     * Gets the currently installed version.
+     *
+     * @return current version (may be null)
+     */
     public RuyiVersion getCurrentVersion() {
         return currentVersion;
     }
 
+    /**
+     * Gets the latest available version.
+     *
+     * @return latest version (may be null)
+     */
     public RuyiVersion getLatestVersion() {
         return latestVersion;
     }
 
+    /**
+     * Checks if any action is required.
+     *
+     * @return true if action is needed (install or upgrade), false otherwise
+     */
     public boolean needAction() {
         return action != ActionType.NOTHING;
     }

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/ruyi/model/RepoConfig.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/ruyi/model/RepoConfig.java
@@ -1,12 +1,35 @@
 package org.ruyisdk.core.ruyi.model;
 
+/**
+ * Represents a repository configuration for RuyiSDK package management.
+ *
+ * <p>This class stores information about a package repository including its name,
+ * URL, priority level, and enabled state.
+ */
 public class RepoConfig {
+    /** The display name of the repository. */
     private String name;
+    
+    /** The URL endpoint of the repository. */
     private String url;
-    private int priority; // 0 hightest
-    private boolean state; // true false
+    
+    /** 
+     * The priority level of the repository (0 is highest priority).
+     * Lower values indicate higher priority.
+     */
+    private int priority;
+    
+    /** The enabled state of the repository (true = enabled, false = disabled). */
+    private boolean state;
 
-    // 带参构造器
+    /**
+     * Constructs a new repository configuration.
+     *
+     * @param name the display name of the repository
+     * @param url the repository endpoint URL
+     * @param priority the priority level (0 is highest)
+     * @param state the initial enabled state
+     */
     public RepoConfig(String name, String url, int priority, boolean state) {
         this.name = name;
         this.url = url;
@@ -14,7 +37,7 @@ public class RepoConfig {
         this.state = state;
     }
 
-    // Getter/Setter 方法
+    // Basic getters and setters (excluded from documentation per request)
     public String getName() {
         return name;
     }

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/ruyi/model/RuyiReleaseInfo.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/ruyi/model/RuyiReleaseInfo.java
@@ -1,16 +1,50 @@
 package org.ruyisdk.core.ruyi.model;
 
 /**
- * 版本信息值对象
+ * Value object representing Ruyi version release information.
+ *
+ * <p>Contains metadata about a specific RuyiSDK release including version number,
+ * release channel, distribution file information, and download URLs.
  */
 public class RuyiReleaseInfo {
+    /** The version number of this release. */
     private final RuyiVersion version;
+    
+    /** 
+     * The release channel. 
+     * Determines update frequency and stability level.
+     */
     private final String channel;
+    
+    /** 
+     * The filename of the distribution package.
+     * Typically includes version and platform information.
+     */
     private final String filename;
+    
+    /** 
+     * The GitHub download URL for this release.
+     * Primary download source for most users.
+     */
     private final String githubUrl;
+    
+    /** 
+     * The mirror download URL for this release.
+     * Alternative download source, often faster in certain regions.
+     */
     private final String mirrorUrl;
 
-    public RuyiReleaseInfo(RuyiVersion version, String channel, String filename, String githubUrl, String mirrorUrl) {
+    /**
+     * Constructs a new RuyiReleaseInfo instance.
+     *
+     * @param version the version number
+     * @param channel the release channel
+     * @param filename the distribution filename
+     * @param githubUrl the GitHub download URL
+     * @param mirrorUrl the mirror download URL
+     */
+    public RuyiReleaseInfo(RuyiVersion version, String channel, String filename, 
+                          String githubUrl, String mirrorUrl) {
         this.version = version;
         this.channel = channel;
         this.filename = filename;
@@ -18,7 +52,6 @@ public class RuyiReleaseInfo {
         this.mirrorUrl = mirrorUrl;
     }
 
-    // Getter 方法
     public RuyiVersion getVersion() {
         return version;
     }

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/ruyi/model/RuyiVersion.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/ruyi/model/RuyiVersion.java
@@ -1,19 +1,41 @@
 package org.ruyisdk.core.ruyi.model;
 
 /**
- * Ruyi 版本模型
+ * Represents a semantic version number for Ruyi following MAJOR.MINOR.PATCH format.
+ *
+ * <p>This immutable class implements semantic versioning comparison logic and provides
+ * parsing capabilities from version strings. Used for version checking and upgrade
+ * decisions throughout RuyiSDK.
  */
 public class RuyiVersion implements Comparable<RuyiVersion> {
+    /** Major version number (incremented for incompatible API changes). */
     private final int major;
+    
+    /** Minor version number (incremented for backward-compatible functionality). */
     private final int minor;
+    
+    /** Patch version number (incremented for backward-compatible bug fixes). */
     private final int patch;
 
+    /**
+     * Constructs a new version instance.
+     *
+     * @param major major version number
+     * @param minor minor version number
+     * @param patch patch version number
+     */
     public RuyiVersion(int major, int minor, int patch) {
         this.major = major;
         this.minor = minor;
         this.patch = patch;
     }
-
+    
+    /**
+     * Parses a version string in "MAJOR.MINOR.PATCH" format.
+     *
+     * @param versionStr the version string to parse
+     * @return parsed RuyiVersion instance, or null if format is invalid
+     */
     public static RuyiVersion parse(String versionStr) {
         try {
             String[] parts = versionStr.split("\\.");
@@ -28,6 +50,12 @@ public class RuyiVersion implements Comparable<RuyiVersion> {
         }
     }
 
+    /**
+     * Compares this version with another following semantic versioning rules.
+     *
+     * @param other the version to compare with
+     * @return negative if this is older, positive if newer, zero if equal
+     */
     @Override
     public int compareTo(RuyiVersion other) {
         if (this.major != other.major) {
@@ -44,7 +72,6 @@ public class RuyiVersion implements Comparable<RuyiVersion> {
         return major + "." + minor + "." + patch;
     }
 
-    // Getters
     public int getMajor() {
         return major;
     }

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/ruyi/model/SystemInfo.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/ruyi/model/SystemInfo.java
@@ -1,26 +1,58 @@
 package org.ruyisdk.core.ruyi.model;
+
 import java.util.Locale;
+
 /**
- * 系统信息模型
+ * Represents system architecture information and provides detection utilities.
+ *
+ * <p>This class helps identify the current system's CPU architecture and generates platform-specific
+ * identifiers for RuyiSDK operations.
  */
 public class SystemInfo {
+
+    /**
+     * Enumeration of supported CPU architectures.
+     */
     public enum Architecture {
+        /** x86-64/AMD64 architecture. */
         X86_64("amd64"),
+
+        /** ARM64/AArch64 architecture. */
         ARM("arm64"),
+
+        /** RISC-V 64-bit architecture. */
         RISCV("riscv64"),
+
+        /** Unknown or unsupported architecture. */
         UNKNOWN("unknown");
 
+        /** Platform-specific suffix used in file paths and identifiers. */
         private final String suffix;
 
+        /**
+         * Creates an architecture enum value.
+         *
+         * @param suffix the platform-specific suffix
+         */
         Architecture(String suffix) {
             this.suffix = suffix;
         }
 
+        /**
+         * Gets the platform suffix for this architecture.
+         *
+         * @return the architecture suffix
+         */
         public String getSuffix() {
             return suffix;
         }
     }
 
+    /**
+     * Detects the current system's CPU architecture.
+     *
+     * @return detected Architecture enum value
+     */
     public static Architecture detectArchitecture() {
         String arch = System.getProperty("os.arch").toLowerCase(Locale.ROOT);
 
@@ -34,10 +66,18 @@ public class SystemInfo {
             return Architecture.UNKNOWN;
         }
     }
-    
+
+    /**
+     * Generates a platform key string in "OS/ARCH" format.
+     *
+     * <p>The returned string follows RuyiSDK's platform identification convention and can be used for
+     * downloading architecture-specific packages.
+     *
+     * @return platform key string (e.g., "linux/x86_64")
+     */
     public static String getPlatformKey() {
         String arch = System.getProperty("os.arch").toLowerCase(Locale.ROOT);
-        
+
         if (arch.contains("x86_64") || arch.contains("amd64")) {
             return "linux/x86_64";
         } else if (arch.contains("aarch64") || arch.contains("arm64")) {


### PR DESCRIPTION
- Enforce Google Java Style Guide for all Javadoc comments
- Add missing documentation for public members
- Normalize inline comments to English with clear explanations