### PR TITLE
Replace unexpected NBSP with spaces in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 ```
 ├── features
 ├── plugins
-│   ├── org.ruyisdk.core
-│   ├── org.ruyisdk.devices
-│   ├── org.ruyisdk.news
-│   ├── org.ruyisdk.packages
-│   ├── org.ruyisdk.intro
-│   ├── org.ruyisdk.ruyi
-│   └── org.ruyisdk.ui
+│   ├── org.ruyisdk.core
+│   ├── org.ruyisdk.devices
+│   ├── org.ruyisdk.news
+│   ├── org.ruyisdk.packages
+│   ├── org.ruyisdk.intro
+│   ├── org.ruyisdk.ruyi
+│   └── org.ruyisdk.ui
 └── README.md
 
 ```


### PR DESCRIPTION
I noticed that the `README.md` contains some NBSP (U+00A0). I think they should be replaced with spaces (U+0020).