### PR TITLE
fix: update DeviceLabelProvider switch expression

### DIFF
--- a/plugins/org.ruyisdk.devices/src/org/ruyisdk/devices/providers/DeviceLabelProvider.java
+++ b/plugins/org.ruyisdk.devices/src/org/ruyisdk/devices/providers/DeviceLabelProvider.java
@@ -9,20 +9,14 @@ public class DeviceLabelProvider extends LabelProvider implements ITableLabelPro
     @Override
     public String getColumnText(Object element, int columnIndex) {
         Device device = (Device) element;
-        switch (columnIndex) {
-            case 0:
-                return device.getName();
-            case 1:
-                return device.getChip();
-            case 2:
-                return device.getVendor();
-            case 3:
-                return device.getVersion();
-            case 4:
-                return device.isDefault() ? "Default" : "";
-            default:
-                return "";
-        }
+        return switch (columnIndex) {
+            case 0 -> device.getName();
+            case 1 -> device.getChip();
+            case 2 -> device.getVendor();
+            case 3 -> device.getVersion();
+            case 4 -> device.isDefault() ? "Default" : "";
+            default -> "";
+        };
     }
 
     @Override


### PR DESCRIPTION
Refactoring lengthy switch-case statements into modern Java switch expressions (Java 14+).