### PR TITLE
feat(news): auto load news after opening news view; refactor: fix code style consistency and improve readability

### DIFF
--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/Activator.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/Activator.java
@@ -2,7 +2,7 @@ package org.ruyisdk.news;
 
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
-import org.ruyisdk.news.model.DataFetchService;
+import org.ruyisdk.news.model.NewsFetchService;
 import org.ruyisdk.news.model.NewsManager;
 
 /**
@@ -16,13 +16,13 @@ public class Activator extends AbstractUIPlugin {
     // The shared instance
     private static Activator plugin;
     private static NewsManager newsManager;
-    private static DataFetchService service;
+    private static NewsFetchService service;
 
     public NewsManager getNewsManager() {
         return newsManager;
     }
 
-    public DataFetchService getService() {
+    public NewsFetchService getService() {
         return service;
     }
 
@@ -37,7 +37,7 @@ public class Activator extends AbstractUIPlugin {
         plugin = this;
 
         newsManager = new NewsManager();
-        service = new DataFetchService();
+        service = new NewsFetchService();
     }
 
     @Override

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsFetchService.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsFetchService.java
@@ -10,7 +10,7 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.ruyisdk.ruyi.services.RuyiCli;
 
 /** Service for fetching news data via the Ruyi CLI. */
-public class DataFetchService {
+public class NewsFetchService {
     /** Fetches news details asynchronously. */
     public void fetchNewsDetailsAsync(String id, Consumer<String> callback) {
         fetchNewsDetailsAsync(id, callback, null);

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsManager.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsManager.java
@@ -1,6 +1,5 @@
 package org.ruyisdk.news.model;
 
-import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
@@ -10,16 +9,9 @@ import java.util.List;
  * Manages a list of news items and notifies listeners on changes.
  */
 public class NewsManager {
-    private List<NewsItem> newsList;
-    private PropertyChangeSupport propertyChangeSupport;
+    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
 
-    /**
-     * Creates a new {@link NewsManager}.
-     */
-    public NewsManager() {
-        newsList = new ArrayList<>();
-        propertyChangeSupport = new PropertyChangeSupport(this);
-    }
+    private final List<NewsItem> newsList = new ArrayList<>();
 
     /**
      * Adds a property change listener.
@@ -27,7 +19,7 @@ public class NewsManager {
      * @param listener the listener
      */
     public void addPropertyChangeListener(PropertyChangeListener listener) {
-        propertyChangeSupport.addPropertyChangeListener(listener);
+        pcs.addPropertyChangeListener(listener);
     }
 
     /**
@@ -36,7 +28,7 @@ public class NewsManager {
      * @param listener the listener
      */
     public void removePropertyChangeListener(PropertyChangeListener listener) {
-        propertyChangeSupport.removePropertyChangeListener(listener);
+        pcs.removePropertyChangeListener(listener);
     }
 
     /**
@@ -46,7 +38,7 @@ public class NewsManager {
      */
     public void addNews(NewsItem news) {
         newsList.add(news);
-        propertyChangeSupport.firePropertyChange("newsList", null, newsList);
+        pcs.firePropertyChange("newsList", null, newsList);
     }
 
     /**
@@ -56,7 +48,7 @@ public class NewsManager {
      */
     public void removeNews(NewsItem news) {
         newsList.remove(news);
-        propertyChangeSupport.firePropertyChange("newsList", null, newsList);
+        pcs.firePropertyChange("newsList", null, newsList);
     }
 
     /**
@@ -78,29 +70,7 @@ public class NewsManager {
         int index = newsList.indexOf(oldNews);
         if (index != -1) {
             newsList.set(index, newNews);
-            propertyChangeSupport.firePropertyChange("newsList", null, newsList);
-        }
-    }
-
-    /**
-     * Adds a listener for news list changes.
-     *
-     * @param taskListener the listener
-     */
-    public void addNewsListener(NewsListener taskListener) {
-        // TODO Auto-generated method stub
-        propertyChangeSupport.addPropertyChangeListener(taskListener);
-    }
-
-    /**
-     * A listener for news list changes.
-     */
-    public static class NewsListener implements PropertyChangeListener {
-        /** {@inheritDoc} */
-        @Override
-        public void propertyChange(PropertyChangeEvent evt) {
-            // TODO Auto-generated method stub
-
+            pcs.firePropertyChange("newsList", null, newsList);
         }
     }
 }

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/viewmodel/NewsDetailsViewModel.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/viewmodel/NewsDetailsViewModel.java
@@ -1,6 +1,6 @@
 package org.ruyisdk.news.viewmodel;
 
-import org.ruyisdk.news.model.DataFetchService;
+import org.ruyisdk.news.model.NewsFetchService;
 import org.ruyisdk.news.model.NewsItem;
 
 /**
@@ -8,7 +8,7 @@ import org.ruyisdk.news.model.NewsItem;
  */
 public class NewsDetailsViewModel {
 
-    private DataFetchService service;
+    private NewsFetchService service;
 
     private boolean isFetching = false;
 
@@ -19,7 +19,7 @@ public class NewsDetailsViewModel {
      * @param service the service used to fetch news details
      */
 
-    public NewsDetailsViewModel(DataFetchService service) {
+    public NewsDetailsViewModel(NewsFetchService service) {
         this.service = service;
     }
 

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/viewmodel/NewsListViewModel.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/viewmodel/NewsListViewModel.java
@@ -7,7 +7,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import org.eclipse.core.databinding.observable.list.IObservableList;
 import org.eclipse.core.databinding.observable.list.WritableList;
-import org.ruyisdk.news.model.DataFetchService;
+import org.ruyisdk.news.model.NewsFetchService;
 import org.ruyisdk.news.model.NewsItem;
 
 /**
@@ -17,11 +17,10 @@ public class NewsListViewModel {
     private boolean isFetching = false;
     private String infoText = UpdatingState.notUpdated;
 
-    private DataFetchService service;
+    private NewsFetchService service;
 
-    private final PropertyChangeSupport changeSupport = new PropertyChangeSupport(this);
-    private final IObservableList<NewsItem> observableNewsList =
-                    new WritableList<NewsItem>(new ArrayList<NewsItem>(), NewsItem.class);
+    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+    private final IObservableList<NewsItem> observableNewsList = new WritableList<>(new ArrayList<>(), NewsItem.class);
 
     private class UpdatingState {
         private static final String notUpdated = "Not Updated, yet";
@@ -34,7 +33,7 @@ public class NewsListViewModel {
      *
      * @param service the service used to fetch news
      */
-    public NewsListViewModel(DataFetchService service) {
+    public NewsListViewModel(NewsFetchService service) {
         this.service = service;
     }
 
@@ -54,7 +53,7 @@ public class NewsListViewModel {
      * @param listener the listener
      */
     public void addPropertyChangeListener(PropertyChangeListener listener) {
-        changeSupport.addPropertyChangeListener(listener);
+        pcs.addPropertyChangeListener(listener);
     }
 
     /**
@@ -63,7 +62,7 @@ public class NewsListViewModel {
      * @param listener the listener
      */
     public void removePropertyChangeListener(PropertyChangeListener listener) {
-        changeSupport.removePropertyChangeListener(listener);
+        pcs.removePropertyChangeListener(listener);
     }
 
     /**
@@ -81,7 +80,7 @@ public class NewsListViewModel {
      * @param infoText the info text
      */
     public void setInfoText(String infoText) {
-        changeSupport.firePropertyChange("infoText", this.infoText, this.infoText = infoText);
+        pcs.firePropertyChange("infoText", this.infoText, this.infoText = infoText);
     }
 
     /**
@@ -90,7 +89,7 @@ public class NewsListViewModel {
      * @param isFetching whether a fetch operation is in progress
      */
     public void setFetching(boolean isFetching) {
-        changeSupport.firePropertyChange("fetching", this.isFetching, this.isFetching = isFetching);
+        pcs.firePropertyChange("fetching", this.isFetching, this.isFetching = isFetching);
     }
 
     /**

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/views/NewsView.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/views/NewsView.java
@@ -156,9 +156,11 @@ public class NewsView extends ViewPart {
         }
 
         detailTextBox = new Text(middleComposite, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL | SWT.WRAP);
-        final var gridData = new GridData(GridData.FILL_HORIZONTAL | GridData.FILL_VERTICAL);
-        gridData.heightHint = 100;
-        detailTextBox.setLayoutData(gridData);
+        {
+            final var gridData = new GridData(GridData.FILL_HORIZONTAL | GridData.FILL_VERTICAL);
+            gridData.heightHint = 100;
+            detailTextBox.setLayoutData(gridData);
+        }
 
         updateButton = new Button(bottomComposite, SWT.PUSH);
         updateButton.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING));

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvService.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvService.java
@@ -54,15 +54,15 @@ public class VenvService {
             return List.of();
         }
         final Set<String> out = new LinkedHashSet<>();
-        for (Venv venv : venvs) {
+        for (final var venv : venvs) {
             if (venv == null) {
                 continue;
             }
-            final String p = venv.getPath();
+            final var p = venv.getPath();
             if (p == null) {
                 continue;
             }
-            final String trimmed = p.trim();
+            final var trimmed = p.trim();
             if (trimmed.isEmpty()) {
                 continue;
             }
@@ -76,7 +76,7 @@ public class VenvService {
             return List.of();
         }
         final var out = new ArrayList<Path>();
-        for (String p : pathStrings) {
+        for (final var p : pathStrings) {
             if (p == null || p.trim().isEmpty()) {
                 continue;
             }
@@ -138,24 +138,25 @@ public class VenvService {
     }
 
     private List<Venv> fetchVenvs() {
-        final var profiles = listProfiles();
+        final var profileInfos = listProfiles();
         final Map<String, String> profileQuirks = new HashMap<>();
-        for (var p : profiles) {
-            profileQuirks.put(p.getName(), p.getQuirks());
+        for (final var profileInfo : profileInfos) {
+            profileQuirks.put(profileInfo.getName(), profileInfo.getQuirks());
         }
 
-        final var venvs = listVenvs();
+        final var venvInfos = listVenvs();
         final var out = new ArrayList<Venv>();
-        for (var v : venvs) {
-            final var quirks = profileQuirks.getOrDefault(v.getProfile(), "");
-            out.add(new Venv(v.getPath(), v.getProfile(), v.getSysroot(), v.getActivated(), quirks));
+        for (final var venvInfo : venvInfos) {
+            final var quirks = profileQuirks.getOrDefault(venvInfo.getProfile(), "");
+            out.add(new Venv(venvInfo.getPath(), venvInfo.getProfile(), venvInfo.getSysroot(), venvInfo.getActivated(),
+                            quirks));
         }
         return out;
     }
 
     /** Fetches venvs asynchronously and passes them to the callback. */
     public void fetchVenvsAsync(Consumer<List<Venv>> callback) {
-        Job fetchJob = new Job("Fetching virtual environments") {
+        final var fetchJob = new Job("Fetching virtual environments") {
             @Override
             protected IStatus run(IProgressMonitor monitor) {
                 List<Venv> result;
@@ -177,7 +178,7 @@ public class VenvService {
         }
 
         final var out = new ArrayList<Venv>();
-        for (Path projectPath : projectPaths) {
+        for (final var projectPath : projectPaths) {
             if (projectPath == null) {
                 continue;
             }
@@ -186,11 +187,11 @@ public class VenvService {
             }
             try (Stream<Path> children = Files.list(projectPath)) {
                 children.filter(Objects::nonNull).filter(Files::isDirectory).forEach(childDir -> {
-                    final Path toml = childDir.resolve(VENV_CONFIG_FILE_NAME);
+                    final var toml = childDir.resolve(VENV_CONFIG_FILE_NAME);
                     if (!Files.isRegularFile(toml)) {
                         return;
                     }
-                    final DetectedVenvConfig cfg = parseVenvConfigBestEffort(toml);
+                    final var cfg = parseVenvConfigBestEffort(toml);
                     out.add(new Venv(childDir.toString(), cfg.profile, cfg.sysroot, projectPath.toString()));
                 });
             } catch (Exception e) {
@@ -202,7 +203,7 @@ public class VenvService {
 
     /** Detects project venvs asynchronously and passes them to the callback. */
     public void detectProjectVenvsAsync(Consumer<List<Venv>> callback) {
-        Job detectJob = new Job("Detecting virtual environments") {
+        final var detectJob = new Job("Detecting virtual environments") {
             @Override
             protected IStatus run(IProgressMonitor monitor) {
                 List<Venv> result;
@@ -221,7 +222,7 @@ public class VenvService {
 
     /** Deletes venv directories asynchronously and reports completion through the callback. */
     public void deleteVenvDirectoriesAsync(List<String> venvDirectoryPaths, Consumer<Exception> callback) {
-        Job deleteJob = new Job("Deleting virtual environments") {
+        final var deleteJob = new Job("Deleting virtual environments") {
             @Override
             protected IStatus run(IProgressMonitor monitor) {
                 try {
@@ -261,12 +262,12 @@ public class VenvService {
         String sysroot = "";
         boolean inConfig = false;
         try {
-            for (String rawLine : Files.readAllLines(tomlPath, StandardCharsets.UTF_8)) {
-                String line = rawLine == null ? "" : rawLine.trim();
+            for (final var rawLine : Files.readAllLines(tomlPath, StandardCharsets.UTF_8)) {
+                var line = rawLine == null ? "" : rawLine.trim();
                 if (line.isEmpty()) {
                     continue;
                 }
-                int commentIdx = line.indexOf('#');
+                final var commentIdx = line.indexOf('#');
                 if (commentIdx >= 0) {
                     line = line.substring(0, commentIdx).trim();
                     if (line.isEmpty()) {
@@ -280,12 +281,12 @@ public class VenvService {
                 if (!inConfig) {
                     continue;
                 }
-                int eq = line.indexOf('=');
+                final var eq = line.indexOf('=');
                 if (eq <= 0) {
                     continue;
                 }
-                String key = line.substring(0, eq).trim();
-                String val = line.substring(eq + 1).trim();
+                final var key = line.substring(0, eq).trim();
+                var val = line.substring(eq + 1).trim();
                 val = unquote(val);
                 if ("profile".equals(key)) {
                     profile = val;
@@ -303,10 +304,10 @@ public class VenvService {
         if (val == null) {
             return "";
         }
-        String s = val.trim();
+        final var s = val.trim();
         if (s.length() >= 2) {
-            char first = s.charAt(0);
-            char last = s.charAt(s.length() - 1);
+            final var first = s.charAt(0);
+            final var last = s.charAt(s.length() - 1);
             if ((first == '"' && last == '"') || (first == '\'' && last == '\'')) {
                 return s.substring(1, s.length() - 1);
             }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
@@ -22,54 +22,45 @@ public class VenvListViewModel {
     private boolean canDelete = false;
 
     private final VenvService service;
-    private final IObservableList<Venv> observableVenvList = new WritableList<Venv>(new ArrayList<Venv>(), Venv.class);
-    private final IObservableList<Venv> selectedVenvs = new WritableList<Venv>(new ArrayList<Venv>(), Venv.class);
-
+    private final IObservableList<Venv> observableVenvList = new WritableList<>(new ArrayList<>(), Venv.class);
+    private final IObservableList<Venv> selectedVenvs = new WritableList<>(new ArrayList<>(), Venv.class);
 
     /**
      * Creates a new view model.
      *
      * @param service the venv service
      */
-
     public VenvListViewModel(VenvService service) {
         this.service = service;
         selectedVenvs.addListChangeListener((IListChangeListener<Venv>) event -> updateCanDelete());
     }
-
 
     /**
      * Returns the observable list of detected venvs.
      *
      * @return the observable venv list
      */
-
     public IObservableList<Venv> getVenvList() {
         return observableVenvList;
     }
-
 
     /**
      * Returns the observable list of selected venvs.
      *
      * @return the observable list of selected venvs
      */
-
     public IObservableList<Venv> getSelectedVenvs() {
         return selectedVenvs;
     }
-
 
     /**
      * Returns whether delete is currently allowed.
      *
      * @return whether delete is currently allowed
      */
-
     public boolean isCanDelete() {
         return canDelete;
     }
-
 
     private void setCanDelete(boolean canDelete) {
         if (this.canDelete == canDelete) {
@@ -78,45 +69,37 @@ public class VenvListViewModel {
         pcs.firePropertyChange("canDelete", this.canDelete, this.canDelete = canDelete);
     }
 
-
     /**
      * Adds a property change listener.
      *
      * @param listener the listener
      */
-
     public void addPropertyChangeListener(PropertyChangeListener listener) {
         pcs.addPropertyChangeListener(listener);
     }
-
 
     /**
      * Removes a property change listener.
      *
      * @param listener the listener
      */
-
     public void removePropertyChangeListener(PropertyChangeListener listener) {
         pcs.removePropertyChangeListener(listener);
     }
-
 
     private void setFetching(boolean isFetching) {
         this.isFetching = isFetching;
         updateCanDelete();
     }
 
-
     private void updateCanDelete() {
         setCanDelete(!isFetching && !getSelectedVenvDirectoryPaths().isEmpty());
     }
 
-
     /**
      * Triggers an asynchronous refresh of the detected venv list.
      */
-
-    public void onRefreshVenvList() {
+    public void onRefreshVenvListAsync() {
         if (isFetching) {
             return;
         }
@@ -131,30 +114,26 @@ public class VenvListViewModel {
         });
     }
 
-
     /**
      * Returns the selected venv directory paths.
      *
      * @return the selected venv directory paths
      */
-
     public List<String> getSelectedVenvDirectoryPaths() {
         return service.getVenvDirectoryPathsFromVenvs(new ArrayList<>(selectedVenvs));
     }
-
 
     /**
      * Deletes the selected venv directories.
      *
      * @param callback callback invoked with an error, or {@code null} on success
      */
-
     public void onDeleteSelectedVenvDirectories(Consumer<Exception> callback) {
         if (isFetching) {
             return;
         }
 
-        final List<String> venvPaths = getSelectedVenvDirectoryPaths();
+        final var venvPaths = getSelectedVenvDirectoryPaths();
         if (venvPaths.isEmpty()) {
             if (callback != null) {
                 callback.accept(null);
@@ -167,7 +146,7 @@ public class VenvListViewModel {
             observableVenvList.getRealm().asyncExec(() -> {
                 setFetching(false);
                 if (err == null) {
-                    onRefreshVenvList();
+                    onRefreshVenvListAsync();
                 }
                 if (callback != null) {
                     callback.accept(err);

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
@@ -41,7 +41,7 @@ public class VenvWizardViewModel {
 
     /** Available sysroot selection strategies. */
     public enum SysrootOption {
-        NO_SYSROOT, DEFAULT_SYSROOT, FROM_TOOLCHAIN
+        NONE_SYSROOT, DEFAULT_SYSROOT, FOREIGN_TOOLCHAIN
     }
 
     /** Creates a new view model instance. */
@@ -57,13 +57,13 @@ public class VenvWizardViewModel {
     }
 
     private void updateSummaryText() {
-        String old = this.summaryText;
+        final var old = this.summaryText;
         this.summaryText = buildSummaryText();
         pcs.firePropertyChange("summaryText", old, this.summaryText);
     }
 
     private void recomputeConfigurationPageComplete() {
-        boolean old = this.configurationPageComplete;
+        final var old = this.configurationPageComplete;
         this.configurationPageComplete = computeConfigurationPageComplete();
         pcs.firePropertyChange("configurationPageComplete", old, this.configurationPageComplete);
     }
@@ -105,12 +105,12 @@ public class VenvWizardViewModel {
     }
 
     private String buildSummaryText() {
-        StringBuilder sb = new StringBuilder();
+        final var sb = new StringBuilder();
         sb.append("Profile: ");
         if (selectedProfileIndex >= 0 && selectedProfileIndex < profiles.size()) {
-            Profile profile = profiles.get(selectedProfileIndex);
+            final var profile = profiles.get(selectedProfileIndex);
             sb.append(profile.getName());
-            String quirks = profile.getQuirks();
+            final var quirks = profile.getQuirks();
             if (quirks != null && !quirks.isEmpty()) {
                 sb.append(" (quirks: ").append(quirks).append(")");
             }
@@ -119,7 +119,7 @@ public class VenvWizardViewModel {
 
         sb.append("Toolchain: ");
         if (selectedToolchainIndex >= 0 && selectedToolchainIndex < toolchains.size()) {
-            Toolchain toolchain = toolchains.get(selectedToolchainIndex);
+            final var toolchain = toolchains.get(selectedToolchainIndex);
             sb.append(toolchain.getName());
             final var versions = toolchain.getVersions();
             if (selectedToolchainVersionIndex >= 0 && versions != null
@@ -133,7 +133,7 @@ public class VenvWizardViewModel {
         if (!emulatorEnabled) {
             sb.append("disabled");
         } else if (selectedEmulatorIndex >= 0 && selectedEmulatorIndex < emulators.size()) {
-            Emulator emulator = emulators.get(selectedEmulatorIndex);
+            final var emulator = emulators.get(selectedEmulatorIndex);
             sb.append(emulator.getName());
             final var versions = emulator.getVersions();
             if (selectedEmulatorVersionIndex >= 0 && versions != null
@@ -153,24 +153,24 @@ public class VenvWizardViewModel {
             toolchains.clear();
             emulators.clear();
 
-            final var rp = service.listProfiles();
-            if (rp != null) {
-                for (var pi : rp) {
-                    profiles.add(new Profile(pi.getName(), pi.getQuirks()));
+            final var profileInfos = service.listProfiles();
+            if (profileInfos != null) {
+                for (final var profileInfo : profileInfos) {
+                    profiles.add(new Profile(profileInfo.getName(), profileInfo.getQuirks()));
                 }
             }
 
-            final var rt = service.listToolchains();
-            if (rt != null) {
-                for (var ti : rt) {
-                    toolchains.add(new Toolchain(ti.getName(), ti.getVersions()));
+            final var toolchainInfos = service.listToolchains();
+            if (toolchainInfos != null) {
+                for (final var toolchainInfo : toolchainInfos) {
+                    toolchains.add(new Toolchain(toolchainInfo.getName(), toolchainInfo.getVersions()));
                 }
             }
 
-            final var re = service.listEmulators();
-            if (re != null) {
-                for (var ei : re) {
-                    emulators.add(new Emulator(ei.getName(), ei.getVersions()));
+            final var emulatorInfos = service.listEmulators();
+            if (emulatorInfos != null) {
+                for (final var emulatorInfo : emulatorInfos) {
+                    emulators.add(new Emulator(emulatorInfo.getName(), emulatorInfo.getVersions()));
                 }
             }
         } catch (Exception ex) {
@@ -180,11 +180,11 @@ public class VenvWizardViewModel {
 
     /** Updates the CLI index and refreshes view model data. */
     public RuyiCli.RunResult updateIndex() {
-        final var r = service.updateIndex();
+        final var result = service.updateIndex();
         refreshListsBestEffort();
         recomputeDerivedState();
         pcs.firePropertyChange("dataRefreshed", null, Boolean.TRUE);
-        return r;
+        return result;
     }
 
     private RuyiCli.RunResult installToolchain(String name, String version) {
@@ -197,8 +197,8 @@ public class VenvWizardViewModel {
                         || selectedToolchainVersionIndex < 0) {
             return new RuyiCli.RunResult(-1, "No toolchain selected");
         }
-        String name = toolchains.get(selectedToolchainIndex).getName();
-        String version = toolchains.get(selectedToolchainIndex).getVersions().get(selectedToolchainVersionIndex);
+        final var name = toolchains.get(selectedToolchainIndex).getName();
+        final var version = toolchains.get(selectedToolchainIndex).getVersions().get(selectedToolchainVersionIndex);
         return installToolchain(name, version);
     }
 
@@ -215,8 +215,8 @@ public class VenvWizardViewModel {
                         || selectedEmulatorVersionIndex < 0) {
             return new RuyiCli.RunResult(-1, "Emulator enabled but not selected");
         }
-        String name = emulators.get(selectedEmulatorIndex).getName();
-        String version = emulators.get(selectedEmulatorIndex).getVersions().get(selectedEmulatorVersionIndex);
+        final var name = emulators.get(selectedEmulatorIndex).getName();
+        final var version = emulators.get(selectedEmulatorIndex).getVersions().get(selectedEmulatorVersionIndex);
         return installEmulator(name, version);
     }
 
@@ -227,11 +227,11 @@ public class VenvWizardViewModel {
 
     /** Creates a virtual environment using the current wizard selections. */
     public RuyiCli.RunResult createVenv() {
-        String parent = this.venvLocation;
+        final var parent = this.venvLocation;
         if (parent == null || parent.trim().isEmpty()) {
             return new RuyiCli.RunResult(-1, "Venv parent path is empty");
         }
-        String name = this.venvName;
+        final var name = this.venvName;
         if (name == null || name.trim().isEmpty()) {
             return new RuyiCli.RunResult(-1, "Venv name is empty");
         }
@@ -240,8 +240,8 @@ public class VenvWizardViewModel {
                         || selectedToolchainVersionIndex < 0) {
             return new RuyiCli.RunResult(-1, "No toolchain selected");
         }
-        String toolchainName = toolchains.get(selectedToolchainIndex).getName();
-        String toolchainVersion =
+        final var toolchainName = toolchains.get(selectedToolchainIndex).getName();
+        final var toolchainVersion =
                         toolchains.get(selectedToolchainIndex).getVersions().get(selectedToolchainVersionIndex);
 
         String profile = null;
@@ -260,8 +260,8 @@ public class VenvWizardViewModel {
             emulatorVersion = emulators.get(selectedEmulatorIndex).getVersions().get(selectedEmulatorVersionIndex);
         }
 
-        File tgt = new File(parent, name);
-        String path = tgt.getPath();
+        final var target = new File(parent, name);
+        final var path = target.getPath();
         return createVenv(path, toolchainName, toolchainVersion, profile, emulatorName, emulatorVersion);
     }
 
@@ -277,7 +277,7 @@ public class VenvWizardViewModel {
 
     /** Sets the selected profile index. */
     public void setSelectedProfileIndex(int index) {
-        int old = this.selectedProfileIndex;
+        final var old = this.selectedProfileIndex;
         this.selectedProfileIndex = index;
         pcs.firePropertyChange("selectedProfileIndex", old, this.selectedProfileIndex);
         recomputeDerivedState();
@@ -295,7 +295,7 @@ public class VenvWizardViewModel {
 
     /** Sets the selected toolchain index. */
     public void setSelectedToolchainIndex(int index) {
-        int old = this.selectedToolchainIndex;
+        final var old = this.selectedToolchainIndex;
         this.selectedToolchainIndex = index;
         pcs.firePropertyChange("selectedToolchainIndex", old, this.selectedToolchainIndex);
         if (old != index) {
@@ -311,7 +311,7 @@ public class VenvWizardViewModel {
 
     /** Sets the selected toolchain version index. */
     public void setSelectedToolchainVersionIndex(int index) {
-        int old = this.selectedToolchainVersionIndex;
+        final var old = this.selectedToolchainVersionIndex;
         this.selectedToolchainVersionIndex = index;
         pcs.firePropertyChange("selectedToolchainVersionIndex", old, this.selectedToolchainVersionIndex);
         recomputeDerivedState();
@@ -329,7 +329,7 @@ public class VenvWizardViewModel {
 
     /** Sets the selected emulator index. */
     public void setSelectedEmulatorIndex(int index) {
-        int old = this.selectedEmulatorIndex;
+        final var old = this.selectedEmulatorIndex;
         this.selectedEmulatorIndex = index;
         pcs.firePropertyChange("selectedEmulatorIndex", old, this.selectedEmulatorIndex);
         if (old != index) {
@@ -345,7 +345,7 @@ public class VenvWizardViewModel {
 
     /** Sets the selected emulator version index. */
     public void setSelectedEmulatorVersionIndex(int index) {
-        int old = this.selectedEmulatorVersionIndex;
+        final var old = this.selectedEmulatorVersionIndex;
         this.selectedEmulatorVersionIndex = index;
         pcs.firePropertyChange("selectedEmulatorVersionIndex", old, this.selectedEmulatorVersionIndex);
         recomputeDerivedState();
@@ -358,7 +358,7 @@ public class VenvWizardViewModel {
 
     /** Enables or disables emulator selection. */
     public void setEmulatorEnabled(boolean enabled) {
-        boolean old = this.emulatorEnabled;
+        final var old = this.emulatorEnabled;
         this.emulatorEnabled = enabled;
         pcs.firePropertyChange("emulatorEnabled", old, this.emulatorEnabled);
         if (!enabled) {
@@ -375,7 +375,7 @@ public class VenvWizardViewModel {
 
     /** Sets the sysroot selection option. */
     public void setSysrootOption(SysrootOption option) {
-        SysrootOption old = this.sysrootOption;
+        final var old = this.sysrootOption;
         this.sysrootOption = option;
         pcs.firePropertyChange("sysrootOption", old, this.sysrootOption);
         recomputeDerivedState();
@@ -387,9 +387,9 @@ public class VenvWizardViewModel {
     }
 
     /** Sets the configured venv parent directory. */
-    public void setVenvLocation(String loc) {
-        String old = this.venvLocation;
-        this.venvLocation = loc == null ? "" : loc;
+    public void setVenvLocation(String location) {
+        final var old = this.venvLocation;
+        this.venvLocation = location == null ? "" : location;
         pcs.firePropertyChange("venvLocation", old, this.venvLocation);
     }
 
@@ -403,7 +403,7 @@ public class VenvWizardViewModel {
         final Runnable update = () -> {
             projectRootPaths.clear();
             if (paths != null) {
-                for (String path : paths) {
+                for (final var path : paths) {
                     if (path == null || path.trim().isEmpty()) {
                         continue;
                     }
@@ -425,7 +425,7 @@ public class VenvWizardViewModel {
 
     /** Sets the venv directory name. */
     public void setVenvName(String name) {
-        String old = this.venvName;
+        final var old = this.venvName;
         this.venvName = name == null ? "" : name;
         pcs.firePropertyChange("venvName", old, this.venvName);
     }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
@@ -15,16 +15,16 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-import org.ruyisdk.ruyi.services.RuyiCli;
 import org.ruyisdk.venv.viewmodel.VenvWizardViewModel;
 
 /**
  * Wizard to create a new virtual environment.
  */
 public class VenvWizard extends Wizard {
+    private final VenvWizardViewModel viewModel;
+
     private WizardConfigPage configurationPage;
     private WizardLocationPage locationPage;
-    private final VenvWizardViewModel viewModel;
 
     /**
      * Creates a wizard.
@@ -41,28 +41,28 @@ public class VenvWizard extends Wizard {
     @Override
     public void addPages() {
         try {
-            ProgressMonitorDialog pmd = new ProgressMonitorDialog(getShell());
+            final var pmd = new ProgressMonitorDialog(getShell());
             if (pmd.getShell() != null) {
                 pmd.getShell().setText("Updating package index");
             }
             pmd.run(true, true, monitor -> {
                 monitor.beginTask("Updating package index...", 100);
-                RuyiCli.RunResult ur = viewModel.updateIndex();
-                if (ur == null) {
+                final var result = viewModel.updateIndex();
+                if (result == null) {
                     throw new InvocationTargetException(new Exception("Update returned no result"));
                 }
-                if (ur.getExitCode() != 0) {
-                    throw new InvocationTargetException(new Exception(ur.getOutput() == null ? "" : ur.getOutput()));
+                if (result.getExitCode() != 0) {
+                    throw new InvocationTargetException(new Exception(result.getOutput()));
                 }
                 monitor.worked(100);
             });
         } catch (InvocationTargetException e) {
-            String detail = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
-            openSelectableError("Package Index Update Failed", "Failed to update package index; wizard will abort.",
+            final var detail = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+            displaySelectableError("Package Index Update Failed", "Failed to update package index; wizard will abort.",
                             detail == null ? "" : detail);
             return;
         } catch (InterruptedException e) {
-            openSelectableError("Package Index Update Cancelled", "Update was cancelled; wizard will abort.", "");
+            displaySelectableError("Package Index Update Cancelled", "Update was cancelled; wizard will abort.", "");
             return;
         }
 
@@ -79,41 +79,46 @@ public class VenvWizard extends Wizard {
 
     @Override
     public boolean performFinish() {
-        IRunnableWithProgress op = monitor -> {
+        final IRunnableWithProgress operation = monitor -> {
             monitor.subTask("install toolchain");
-            RuyiCli.RunResult rc = viewModel.installToolchain();
-            if (rc.getExitCode() != 0) {
-                throw new InvocationTargetException(new Exception(
-                                "Failed to install toolchain:" + System.lineSeparator() + rc.getOutput()));
+            {
+                final var result = viewModel.installToolchain();
+                if (result.getExitCode() != 0) {
+                    throw new InvocationTargetException(
+                                    new Exception("Failed to install toolchain:\n" + result.getOutput()));
+                }
             }
 
             if (viewModel.isEmulatorEnabled()) {
                 monitor.subTask("install emulator");
-                RuyiCli.RunResult erc = viewModel.installEmulator();
-                if (erc.getExitCode() != 0) {
-                    throw new InvocationTargetException(new Exception(
-                                    "Failed to install emulator:" + System.lineSeparator() + erc.getOutput()));
+                final var result = viewModel.installEmulator();
+                if (result.getExitCode() != 0) {
+                    throw new InvocationTargetException(
+                                    new Exception("Failed to install emulator:\n" + result.getOutput()));
                 }
             }
 
             monitor.subTask("create venv");
-            RuyiCli.RunResult vrc = viewModel.createVenv();
-            if (vrc.getExitCode() != 0) {
-                throw new InvocationTargetException(new Exception("Failed to create venv, exit=" + vrc.getExitCode()
-                                + System.lineSeparator() + vrc.getOutput()));
+            {
+                final var result = viewModel.createVenv();
+                if (result.getExitCode() != 0) {
+                    final var errorMessage =
+                                    "Failed to create venv, exit=" + result.getExitCode() + "\n" + result.getOutput();
+                    throw new InvocationTargetException(new Exception(errorMessage));
+                }
             }
         };
 
         try {
-            getContainer().run(true, true, op);
+            getContainer().run(true, true, operation);
             return true;
         } catch (InvocationTargetException e) {
-            String detail = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+            var detail = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
             if (detail == null) {
                 detail = "";
             }
-            String top = "Unable to complete virtual environment setup — see details below.";
-            openSelectableError("Virtual Environment Setup Failed", top, detail);
+            final var msg = "Unable to complete virtual environment setup — see details below.";
+            displaySelectableError("Virtual Environment Setup Failed", msg, detail);
             return false;
         } catch (InterruptedException e) {
             MessageDialog.openError(getShell(), "Cancelled", "Operation was cancelled");
@@ -121,29 +126,34 @@ public class VenvWizard extends Wizard {
         }
     }
 
-    private void openSelectableError(String title, String message, String details) {
-        Dialog dlg = new Dialog(getShell()) {
+    private void displaySelectableError(String title, String message, String details) {
+        final var dialog = new Dialog(getShell()) {
             @Override
             protected Control createDialogArea(Composite parent) {
-                Composite comp = (Composite) super.createDialogArea(parent);
-                comp.setLayout(new GridLayout(1, false));
+                final var composite = (Composite) super.createDialogArea(parent);
+                composite.setLayout(new GridLayout(1, false));
 
-                Text msgText = new Text(comp, SWT.BORDER | SWT.READ_ONLY | SWT.WRAP | SWT.V_SCROLL);
+                final var msgText = new Text(composite, SWT.BORDER | SWT.READ_ONLY | SWT.WRAP | SWT.V_SCROLL);
+                {
+                    var gridData = new GridData(GridData.FILL_HORIZONTAL);
+                    gridData.heightHint = 80;
+                    msgText.setLayoutData(gridData);
+                }
                 msgText.setText(message == null ? "" : message);
-                GridData mgd = new GridData(GridData.FILL_HORIZONTAL);
-                mgd.heightHint = 80;
-                msgText.setLayoutData(mgd);
 
-                Label dlabel = new Label(comp, SWT.NONE);
-                dlabel.setText("Details:");
+                final var detailsLabel = new Label(composite, SWT.NONE);
+                detailsLabel.setText("Details:");
 
-                Text detailsText = new Text(comp, SWT.BORDER | SWT.READ_ONLY | SWT.MULTI | SWT.V_SCROLL | SWT.H_SCROLL);
+                final var detailsText = new Text(composite,
+                                SWT.BORDER | SWT.READ_ONLY | SWT.MULTI | SWT.V_SCROLL | SWT.H_SCROLL);
+                {
+                    var gridData = new GridData(GridData.FILL_HORIZONTAL);
+                    gridData.heightHint = 120;
+                    detailsText.setLayoutData(gridData);
+                }
                 detailsText.setText(details == null ? "" : details);
-                GridData dgd = new GridData(GridData.FILL_BOTH);
-                dgd.heightHint = 240;
-                detailsText.setLayoutData(dgd);
 
-                return comp;
+                return composite;
             }
 
             @Override
@@ -162,6 +172,6 @@ public class VenvWizard extends Wizard {
                 createButton(parent, IDialogConstants.OK_ID, IDialogConstants.OK_LABEL, true);
             }
         };
-        dlg.open();
+        dialog.open();
     }
 }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
@@ -1,5 +1,6 @@
 package org.ruyisdk.venv.views;
 
+import java.util.List;
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.UpdateValueStrategy;
 import org.eclipse.core.databinding.beans.typed.BeanProperties;
@@ -33,6 +34,25 @@ public class WizardConfigPage extends WizardPage {
     private final VenvWizardViewModel viewModel;
     private DataBindingContext dbc;
 
+    private Composite container;
+    private Composite profileComposite;
+    private Composite toolchainComposite;
+    private Composite emulatorHeader;
+    private Composite emulatorComposite;
+    private Group sysrootGroup;
+
+    private TableViewer profileTableViewer;
+    private TableViewer toolchainNamesViewer;
+    private TableViewer toolchainVersionsViewer;
+    private Button emulatorCheckBox;
+    private Table emulatorNames;
+    private TableViewer emulatorNamesViewer;
+    private Table emulatorVersions;
+    private TableViewer emulatorVersionsViewer;
+    private Button sysrootDefaultRadio;
+    private Button sysrootNoneRadio;
+    private Button sysrootForeignRadio;
+
     WizardConfigPage(VenvWizardViewModel viewModel) {
         super("configurationPage");
         this.viewModel = viewModel;
@@ -42,10 +62,207 @@ public class WizardConfigPage extends WizardPage {
 
     @Override
     public void createControl(Composite parent) {
+        createLayouts(parent);
+        addControls();
+        registerEvents();
+
+        // initialize states
+        updatePageComplete();
+    }
+
+    private void createLayouts(Composite parent) {
+        container = new Composite(parent, SWT.NONE);
+        container.setLayout(new GridLayout(1, false));
+
+        profileComposite = new Composite(container, SWT.NONE);
+        profileComposite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        {
+            var gridLayout = new GridLayout(1, false);
+            gridLayout.marginWidth = 0;
+            profileComposite.setLayout(gridLayout);
+        }
+
+        toolchainComposite = new Composite(container, SWT.NONE);
+        toolchainComposite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        {
+            var gridLayout = new GridLayout(2, false);
+            gridLayout.marginWidth = 0;
+            toolchainComposite.setLayout(gridLayout);
+        }
+
+        emulatorHeader = new Composite(container, SWT.NONE);
+        emulatorHeader.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        {
+            var gridLayout = new GridLayout(2, false);
+            gridLayout.marginWidth = 0;
+            emulatorHeader.setLayout(gridLayout);
+        }
+
+        emulatorComposite = new Composite(container, SWT.NONE);
+        emulatorComposite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        {
+            var gridLayout = new GridLayout(2, false);
+            gridLayout.marginWidth = 0;
+            emulatorComposite.setLayout(gridLayout);
+        }
+
+        sysrootGroup = new Group(container, SWT.NONE);
+        sysrootGroup.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        sysrootGroup.setText("");
+        {
+            var gridLayout = new GridLayout(3, false);
+            gridLayout.marginWidth = 0;
+            sysrootGroup.setLayout(gridLayout);
+        }
+
+        setControl(container);
+    }
+
+    private void addControls() {
+        // profiles
+        {
+            final var profileLabel = new Label(profileComposite, SWT.NONE);
+            profileLabel.setText("Profiles");
+
+            profileTableViewer = new TableViewer(profileComposite, SWT.BORDER | SWT.FULL_SELECTION);
+            final var profileTable = profileTableViewer.getTable();
+            {
+                final var gridData = new GridData(GridData.FILL_HORIZONTAL);
+                gridData.heightHint = 150;
+                profileTable.setLayoutData(gridData);
+            }
+            profileTable.setHeaderVisible(true);
+            profileTable.setLinesVisible(true);
+
+            {
+                final var column = new TableViewerColumn(profileTableViewer, SWT.LEFT);
+                column.getColumn().setText("Name");
+                column.getColumn().setWidth(200);
+                column.setLabelProvider(new ColumnLabelProvider() {
+                    @Override
+                    public String getText(Object element) {
+                        return ((Profile) element).getName();
+                    }
+                });
+            }
+            {
+                final var column = new TableViewerColumn(profileTableViewer, SWT.LEFT);
+                column.getColumn().setText("Needed Quirks");
+                column.getColumn().setWidth(400);
+                column.setLabelProvider(new ColumnLabelProvider() {
+                    @Override
+                    public String getText(Object element) {
+                        final var q = ((Profile) element).getQuirks();
+                        return q == null ? "" : q;
+                    }
+                });
+            }
+
+            profileTableViewer.setContentProvider(ArrayContentProvider.getInstance());
+            profileTableViewer.setInput(viewModel.getProfiles());
+        }
+
+        // toolchains
+        {
+            final var tcLabel = new Label(toolchainComposite, SWT.NONE);
+            {
+                final var gridData = new GridData();
+                gridData.horizontalSpan = 2;
+                tcLabel.setLayoutData(gridData);
+            }
+            tcLabel.setText("Toolchains");
+
+            toolchainNamesViewer = new TableViewer(toolchainComposite, SWT.BORDER | SWT.FULL_SELECTION);
+            final var tcNames = toolchainNamesViewer.getTable();
+            {
+                final var gridData = new GridData(GridData.FILL_BOTH);
+                gridData.heightHint = 120;
+                gridData.widthHint = 300;
+                tcNames.setLayoutData(gridData);
+            }
+            tcNames.setHeaderVisible(false);
+            tcNames.setLinesVisible(true);
+
+            toolchainVersionsViewer = new TableViewer(toolchainComposite, SWT.BORDER | SWT.FULL_SELECTION);
+            final var tcVersions = toolchainVersionsViewer.getTable();
+            {
+                final var gridData = new GridData(GridData.FILL_BOTH);
+                gridData.heightHint = 120;
+                gridData.widthHint = 300;
+                tcVersions.setLayoutData(gridData);
+            }
+            tcVersions.setHeaderVisible(false);
+            tcVersions.setLinesVisible(true);
+
+            toolchainNamesViewer.setContentProvider(ArrayContentProvider.getInstance());
+            toolchainNamesViewer.setLabelProvider(new ColumnLabelProvider() {
+                @Override
+                public String getText(Object element) {
+                    return ((Toolchain) element).getName();
+                }
+            });
+            toolchainNamesViewer.setInput(viewModel.getToolchains());
+
+            toolchainVersionsViewer.setContentProvider(ArrayContentProvider.getInstance());
+            toolchainVersionsViewer.setLabelProvider(new ColumnLabelProvider());
+        }
+
+        // emulators
+        {
+            final var emLabelTitle = new Label(emulatorHeader, SWT.NONE);
+            emLabelTitle.setText("Emulators");
+            final var emLabelGd = new GridData(SWT.FILL, SWT.CENTER, true, false);
+            emLabelTitle.setLayoutData(emLabelGd);
+            emulatorCheckBox = new Button(emulatorHeader, SWT.CHECK);
+            emulatorCheckBox.setText("Enable");
+            emulatorCheckBox.setLayoutData(new GridData(SWT.END, SWT.CENTER, false, false));
+
+            emulatorNamesViewer = new TableViewer(emulatorComposite, SWT.BORDER | SWT.FULL_SELECTION);
+            emulatorNames = emulatorNamesViewer.getTable();
+            emulatorNames.setHeaderVisible(false);
+            emulatorNames.setLinesVisible(true);
+            final var enData = new GridData(GridData.FILL_BOTH);
+            enData.heightHint = 80;
+            enData.widthHint = 300;
+            emulatorNames.setLayoutData(enData);
+
+            emulatorVersionsViewer = new TableViewer(emulatorComposite, SWT.BORDER | SWT.FULL_SELECTION);
+            emulatorVersions = emulatorVersionsViewer.getTable();
+            emulatorVersions.setHeaderVisible(false);
+            emulatorVersions.setLinesVisible(true);
+            final var evData = new GridData(GridData.FILL_BOTH);
+            evData.heightHint = 80;
+            evData.widthHint = 300;
+            emulatorVersions.setLayoutData(evData);
+
+            emulatorNamesViewer.setContentProvider(ArrayContentProvider.getInstance());
+            emulatorNamesViewer.setLabelProvider(new ColumnLabelProvider() {
+                @Override
+                public String getText(Object element) {
+                    return ((Emulator) element).getName();
+                }
+            });
+            emulatorNamesViewer.setInput(viewModel.getEmulators());
+
+            emulatorVersionsViewer.setContentProvider(ArrayContentProvider.getInstance());
+            emulatorVersionsViewer.setLabelProvider(new ColumnLabelProvider());
+        }
+
+        // sysroot
+        {
+            sysrootDefaultRadio = new Button(sysrootGroup, SWT.RADIO);
+            sysrootDefaultRadio.setText("With sysroot");
+            sysrootNoneRadio = new Button(sysrootGroup, SWT.RADIO);
+            sysrootNoneRadio.setText("Without sysroot");
+            sysrootForeignRadio = new Button(sysrootGroup, SWT.RADIO);
+            sysrootForeignRadio.setText("Use sysroot from specified package");
+            sysrootForeignRadio.setEnabled(false); // TODO: implement this option later
+        }
+    }
+
+    private void registerEvents() {
         dbc = new DataBindingContext();
 
-        Composite container = new Composite(parent, SWT.NONE);
-        container.setLayout(new GridLayout(1, false));
         container.addDisposeListener(e -> {
             if (dbc != null) {
                 dbc.dispose();
@@ -53,342 +270,211 @@ public class WizardConfigPage extends WizardPage {
             }
         });
 
-        Label profileLabel = new Label(container, SWT.NONE);
-        profileLabel.setText("Profile");
-
-        TableViewer profileViewer = new TableViewer(container, SWT.BORDER | SWT.FULL_SELECTION);
-        Table profileTable = profileViewer.getTable();
-        profileTable.setHeaderVisible(true);
-        profileTable.setLinesVisible(true);
-        profileTable.setBackground(container.getDisplay().getSystemColor(SWT.COLOR_WHITE));
-        GridData pd = new GridData(GridData.FILL_HORIZONTAL);
-        pd.heightHint = 150;
-        profileTable.setLayoutData(pd);
-
-        TableViewerColumn pc1 = new TableViewerColumn(profileViewer, SWT.LEFT);
-        pc1.getColumn().setText("Name");
-        pc1.getColumn().setWidth(200);
-        pc1.setLabelProvider(new ColumnLabelProvider() {
-            @Override
-            public String getText(Object element) {
-                return ((Profile) element).getName();
-            }
-        });
-        TableViewerColumn pc2 = new TableViewerColumn(profileViewer, SWT.LEFT);
-        pc2.getColumn().setText("Needed Quirks");
-        pc2.getColumn().setWidth(200);
-        pc2.setLabelProvider(new ColumnLabelProvider() {
-            @Override
-            public String getText(Object element) {
-                final String q = ((Profile) element).getQuirks();
-                return q == null ? "" : q;
-            }
-        });
-
-        profileViewer.setContentProvider(ArrayContentProvider.getInstance());
-        profileViewer.setInput(viewModel.getProfiles());
-
-        Label tcLabel = new Label(container, SWT.NONE);
-        tcLabel.setText("Toolchains");
-
-        Composite tcComposite = new Composite(container, SWT.NONE);
-        tcComposite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-        GridLayout tcLayout = new GridLayout(2, false);
-        tcLayout.marginWidth = 0;
-        tcComposite.setLayout(tcLayout);
-
-        TableViewer tcNamesViewer = new TableViewer(tcComposite, SWT.BORDER | SWT.FULL_SELECTION);
-        Table tcNames = tcNamesViewer.getTable();
-        tcNames.setHeaderVisible(false);
-        tcNames.setLinesVisible(true);
-        tcNames.setBackground(container.getDisplay().getSystemColor(SWT.COLOR_WHITE));
-        GridData tnData = new GridData(GridData.FILL_BOTH);
-        tnData.heightHint = 120;
-        tnData.widthHint = 300;
-        tcNames.setLayoutData(tnData);
-
-        TableViewer tcVersionsViewer = new TableViewer(tcComposite, SWT.BORDER | SWT.FULL_SELECTION);
-        Table tcVersions = tcVersionsViewer.getTable();
-        tcVersions.setHeaderVisible(false);
-        tcVersions.setLinesVisible(true);
-        tcVersions.setBackground(container.getDisplay().getSystemColor(SWT.COLOR_WHITE));
-        GridData tvData = new GridData(GridData.FILL_BOTH);
-        tvData.heightHint = 120;
-        tvData.widthHint = 300;
-        tcVersions.setLayoutData(tvData);
-
-        tcNamesViewer.setContentProvider(ArrayContentProvider.getInstance());
-        tcNamesViewer.setLabelProvider(new ColumnLabelProvider() {
-            @Override
-            public String getText(Object element) {
-                return ((Toolchain) element).getName();
-            }
-        });
-        tcNamesViewer.setInput(viewModel.getToolchains());
-
-        tcVersionsViewer.setContentProvider(ArrayContentProvider.getInstance());
-        tcVersionsViewer.setLabelProvider(new ColumnLabelProvider());
-
-        Composite emHeader = new Composite(container, SWT.NONE);
-        GridLayout ehLayout = new GridLayout(2, false);
-        ehLayout.marginWidth = 0;
-        emHeader.setLayout(ehLayout);
-        emHeader.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-        Label emLabelTitle = new Label(emHeader, SWT.NONE);
-        emLabelTitle.setText("Emulator");
-        GridData emLabelGd = new GridData(SWT.FILL, SWT.CENTER, true, false);
-        emLabelTitle.setLayoutData(emLabelGd);
-        Button emulatorCheckBox = new Button(emHeader, SWT.CHECK);
-        emulatorCheckBox.setText("Enable");
-        GridData emChkGd = new GridData(SWT.END, SWT.CENTER, false, false);
-        emulatorCheckBox.setLayoutData(emChkGd);
-
-        Composite emComposite = new Composite(container, SWT.NONE);
-        emComposite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-        GridLayout emLayout = new GridLayout(2, false);
-        emLayout.marginWidth = 0;
-        emComposite.setLayout(emLayout);
-
-        TableViewer emulatorNamesViewer = new TableViewer(emComposite, SWT.BORDER | SWT.FULL_SELECTION);
-        Table emulatorNames = emulatorNamesViewer.getTable();
-        emulatorNames.setHeaderVisible(false);
-        emulatorNames.setLinesVisible(true);
-        emulatorNames.setBackground(container.getDisplay().getSystemColor(SWT.COLOR_WHITE));
-        GridData enData = new GridData(GridData.FILL_BOTH);
-        enData.heightHint = 80;
-        enData.widthHint = 300;
-        emulatorNames.setLayoutData(enData);
-
-        TableViewer emulatorVersionsViewer = new TableViewer(emComposite, SWT.BORDER | SWT.FULL_SELECTION);
-        Table emulatorVersions = emulatorVersionsViewer.getTable();
-        emulatorVersions.setHeaderVisible(false);
-        emulatorVersions.setLinesVisible(true);
-        emulatorVersions.setBackground(container.getDisplay().getSystemColor(SWT.COLOR_WHITE));
-        GridData evData = new GridData(GridData.FILL_BOTH);
-        evData.heightHint = 80;
-        evData.widthHint = 300;
-        emulatorVersions.setLayoutData(evData);
-
-        emulatorNamesViewer.setContentProvider(ArrayContentProvider.getInstance());
-        emulatorNamesViewer.setLabelProvider(new ColumnLabelProvider() {
-            @Override
-            public String getText(Object element) {
-                return ((Emulator) element).getName();
-            }
-        });
-        emulatorNamesViewer.setInput(viewModel.getEmulators());
-
-        emulatorVersionsViewer.setContentProvider(ArrayContentProvider.getInstance());
-        emulatorVersionsViewer.setLabelProvider(new ColumnLabelProvider());
-
-        Group sysrootGroup = new Group(container, SWT.NONE);
-        sysrootGroup.setText("");
-        GridLayout rg = new GridLayout(3, false);
-        rg.marginWidth = 0;
-        sysrootGroup.setLayout(rg);
-        sysrootGroup.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-
-        Button rbDefault = new Button(sysrootGroup, SWT.RADIO);
-        rbDefault.setText("With sysroot");
-        Button rbNo = new Button(sysrootGroup, SWT.RADIO);
-        rbNo.setText("Without sysroot");
-        Button rbOther = new Button(sysrootGroup, SWT.RADIO);
-        rbOther.setText("Use sysroot from specified package");
-
-        var emulatorEnabledObservable = BeanProperties
-                        .value(VenvWizardViewModel.class, "emulatorEnabled", Boolean.class).observe(viewModel);
-        dbc.bindValue(WidgetProperties.buttonSelection().observe(emulatorCheckBox), emulatorEnabledObservable);
-        dbc.bindValue(WidgetProperties.enabled().observe(emulatorNames), emulatorEnabledObservable);
-        dbc.bindValue(WidgetProperties.enabled().observe(emulatorVersions), emulatorEnabledObservable);
-
-        final SelectObservableValue<VenvWizardViewModel.SysrootOption> sysrootSelection = new SelectObservableValue<>();
-        sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.DEFAULT_SYSROOT,
-                        WidgetProperties.buttonSelection().observe(rbDefault));
-        sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.NO_SYSROOT,
-                        WidgetProperties.buttonSelection().observe(rbNo));
-        sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.FROM_TOOLCHAIN,
-                        WidgetProperties.buttonSelection().observe(rbOther));
-        dbc.bindValue(sysrootSelection, BeanProperties
-                        .value(VenvWizardViewModel.class, "sysrootOption", VenvWizardViewModel.SysrootOption.class)
-                        .observe(viewModel));
-
-        // Selection bindings: bind viewer selections to viewmodel index properties.
-        final var profileSelection = ViewerProperties.singleSelection(Profile.class).observe(profileViewer);
-        final UpdateValueStrategy<Profile, Integer> profileToIndex = new UpdateValueStrategy<>();
-        profileToIndex.setConverter(new Converter<Profile, Integer>(Profile.class, Integer.class) {
-            @Override
-            public Integer convert(Profile fromObject) {
-                if (fromObject == null) {
-                    return Integer.valueOf(-1);
+        // profiles
+        {
+            final var profileSelection = ViewerProperties.singleSelection(Profile.class).observe(profileTableViewer);
+            final var profileIndexObservable = BeanProperties
+                            .value(VenvWizardViewModel.class, "selectedProfileIndex", Integer.class).observe(viewModel);
+            final var profileToIndex = new UpdateValueStrategy<Profile, Integer>();
+            profileToIndex.setConverter(new Converter<Profile, Integer>(Profile.class, Integer.class) {
+                @Override
+                public Integer convert(Profile fromObject) {
+                    if (fromObject == null) {
+                        return Integer.valueOf(-1);
+                    }
+                    return Integer.valueOf(viewModel.getProfiles().indexOf(fromObject));
                 }
-                return Integer.valueOf(viewModel.getProfiles().indexOf(fromObject));
-            }
-        });
-        final UpdateValueStrategy<Integer, Profile> indexToProfile = new UpdateValueStrategy<>();
-        indexToProfile.setConverter(new Converter<Integer, Profile>(Integer.class, Profile.class) {
-            @Override
-            public Profile convert(Integer fromObject) {
-                int idx = ((Integer) fromObject).intValue();
-                return idx >= 0 && idx < viewModel.getProfiles().size() ? viewModel.getProfiles().get(idx) : null;
-            }
-        });
-        dbc.bindValue(profileSelection, BeanProperties
-                        .value(VenvWizardViewModel.class, "selectedProfileIndex", Integer.class).observe(viewModel),
-                        profileToIndex, indexToProfile);
-
-        final var toolchainSelection = ViewerProperties.singleSelection(Toolchain.class).observe(tcNamesViewer);
-        final UpdateValueStrategy<Toolchain, Integer> toolchainToIndex = new UpdateValueStrategy<>();
-        toolchainToIndex.setConverter(new Converter<Toolchain, Integer>(Toolchain.class, Integer.class) {
-            @Override
-            public Integer convert(Toolchain fromObject) {
-                if (fromObject == null) {
-                    return Integer.valueOf(-1);
+            });
+            final var indexToProfile = new UpdateValueStrategy<Integer, Profile>();
+            indexToProfile.setConverter(new Converter<Integer, Profile>(Integer.class, Profile.class) {
+                @Override
+                public Profile convert(Integer fromObject) {
+                    final var idx = ((Integer) fromObject).intValue();
+                    return idx >= 0 && idx < viewModel.getProfiles().size() ? viewModel.getProfiles().get(idx) : null;
                 }
-                return Integer.valueOf(viewModel.getToolchains().indexOf(fromObject));
-            }
-        });
-        final UpdateValueStrategy<Integer, Toolchain> indexToToolchain = new UpdateValueStrategy<>();
-        indexToToolchain.setConverter(new Converter<Integer, Toolchain>(Integer.class, Toolchain.class) {
-            @Override
-            public Toolchain convert(Integer fromObject) {
-                int idx = ((Integer) fromObject).intValue();
-                return idx >= 0 && idx < viewModel.getToolchains().size() ? viewModel.getToolchains().get(idx) : null;
-            }
-        });
-        dbc.bindValue(toolchainSelection, BeanProperties
-                        .value(VenvWizardViewModel.class, "selectedToolchainIndex", Integer.class).observe(viewModel),
-                        toolchainToIndex, indexToToolchain);
-
-        final var toolchainIndexObservable = BeanProperties
-                        .value(VenvWizardViewModel.class, "selectedToolchainIndex", Integer.class).observe(viewModel);
-        toolchainIndexObservable.addValueChangeListener(e -> {
-            final int idx = viewModel.getSelectedToolchainIndex();
-            if (idx >= 0 && idx < viewModel.getToolchains().size()) {
-                tcVersionsViewer.setInput(viewModel.getToolchains().get(idx).getVersions());
-            } else {
-                tcVersionsViewer.setInput(java.util.List.of());
-            }
-        });
-        // initialize versions viewer input
-        if (viewModel.getSelectedToolchainIndex() >= 0
-                        && viewModel.getSelectedToolchainIndex() < viewModel.getToolchains().size()) {
-            tcVersionsViewer.setInput(
-                            viewModel.getToolchains().get(viewModel.getSelectedToolchainIndex()).getVersions());
-        } else {
-            tcVersionsViewer.setInput(java.util.List.of());
+            });
+            dbc.bindValue(profileSelection, profileIndexObservable, profileToIndex, indexToProfile);
         }
 
-        final var toolchainVersionSelection = ViewerProperties.singleSelection(String.class).observe(tcVersionsViewer);
-        final UpdateValueStrategy<String, Integer> toolchainVersionToIndex = new UpdateValueStrategy<>();
-        toolchainVersionToIndex.setConverter(new Converter<String, Integer>(String.class, Integer.class) {
-            @Override
-            public Integer convert(String fromObject) {
-                final int idx = viewModel.getSelectedToolchainIndex();
-                if (idx < 0 || idx >= viewModel.getToolchains().size()) {
-                    return Integer.valueOf(-1);
+        // toolchain names
+        {
+            final var toolchainSelection =
+                            ViewerProperties.singleSelection(Toolchain.class).observe(toolchainNamesViewer);
+            final var toolchainIndexObservable =
+                            BeanProperties.value(VenvWizardViewModel.class, "selectedToolchainIndex", Integer.class)
+                                            .observe(viewModel);
+            final var toolchainToIndex = new UpdateValueStrategy<Toolchain, Integer>();
+            toolchainToIndex.setConverter(new Converter<Toolchain, Integer>(Toolchain.class, Integer.class) {
+                @Override
+                public Integer convert(Toolchain fromObject) {
+                    if (fromObject == null) {
+                        return Integer.valueOf(-1);
+                    }
+                    return Integer.valueOf(viewModel.getToolchains().indexOf(fromObject));
                 }
-                final var vers = viewModel.getToolchains().get(idx).getVersions();
-                return Integer.valueOf(vers == null ? -1 : vers.indexOf(fromObject));
-            }
-        });
-        final UpdateValueStrategy<Integer, String> indexToToolchainVersion = new UpdateValueStrategy<>();
-        indexToToolchainVersion.setConverter(new Converter<Integer, String>(Integer.class, String.class) {
-            @Override
-            public String convert(Integer fromObject) {
-                final int idx = viewModel.getSelectedToolchainIndex();
-                if (idx < 0 || idx >= viewModel.getToolchains().size()) {
+            });
+            final var indexToToolchain = new UpdateValueStrategy<Integer, Toolchain>();
+            indexToToolchain.setConverter(new Converter<Integer, Toolchain>(Integer.class, Toolchain.class) {
+                @Override
+                public Toolchain convert(Integer fromObject) {
+                    final var idx = ((Integer) fromObject).intValue();
+                    if (idx >= 0 && idx < viewModel.getToolchains().size()) {
+                        return viewModel.getToolchains().get(idx);
+                    }
                     return null;
                 }
-                final var vers = viewModel.getToolchains().get(idx).getVersions();
-                final int vi = ((Integer) fromObject).intValue();
-                return vers != null && vi >= 0 && vi < vers.size() ? vers.get(vi) : null;
-            }
-        });
-        dbc.bindValue(toolchainVersionSelection,
-                        BeanProperties.value(VenvWizardViewModel.class, "selectedToolchainVersionIndex", Integer.class)
-                                        .observe(viewModel),
-                        toolchainVersionToIndex, indexToToolchainVersion);
+            });
+            dbc.bindValue(toolchainSelection, toolchainIndexObservable, toolchainToIndex, indexToToolchain);
 
-        final var emulatorSelection = ViewerProperties.singleSelection(Emulator.class).observe(emulatorNamesViewer);
-        final UpdateValueStrategy<Emulator, Integer> emulatorToIndex = new UpdateValueStrategy<>();
-        emulatorToIndex.setConverter(new Converter<Emulator, Integer>(Emulator.class, Integer.class) {
-            @Override
-            public Integer convert(Emulator fromObject) {
-                if (fromObject == null) {
-                    return Integer.valueOf(-1);
+            toolchainIndexObservable.addValueChangeListener(e -> {
+                final var idx = viewModel.getSelectedToolchainIndex();
+                if (idx >= 0 && idx < viewModel.getToolchains().size()) {
+                    toolchainVersionsViewer.setInput(viewModel.getToolchains().get(idx).getVersions());
+                } else {
+                    toolchainVersionsViewer.setInput(List.of());
                 }
-                return Integer.valueOf(viewModel.getEmulators().indexOf(fromObject));
-            }
-        });
-        final UpdateValueStrategy<Integer, Emulator> indexToEmulator = new UpdateValueStrategy<>();
-        indexToEmulator.setConverter(new Converter<Integer, Emulator>(Integer.class, Emulator.class) {
-            @Override
-            public Emulator convert(Integer fromObject) {
-                int idx = ((Integer) fromObject).intValue();
-                return idx >= 0 && idx < viewModel.getEmulators().size() ? viewModel.getEmulators().get(idx) : null;
-            }
-        });
-        dbc.bindValue(emulatorSelection, BeanProperties
-                        .value(VenvWizardViewModel.class, "selectedEmulatorIndex", Integer.class).observe(viewModel),
-                        emulatorToIndex, indexToEmulator);
-
-        final var emulatorIndexObservable = BeanProperties
-                        .value(VenvWizardViewModel.class, "selectedEmulatorIndex", Integer.class).observe(viewModel);
-        emulatorIndexObservable.addValueChangeListener(e -> {
-            final int idx = viewModel.getSelectedEmulatorIndex();
-            if (idx >= 0 && idx < viewModel.getEmulators().size()) {
-                emulatorVersionsViewer.setInput(viewModel.getEmulators().get(idx).getVersions());
-            } else {
-                emulatorVersionsViewer.setInput(java.util.List.of());
-            }
-        });
-        if (viewModel.getSelectedEmulatorIndex() >= 0
-                        && viewModel.getSelectedEmulatorIndex() < viewModel.getEmulators().size()) {
-            emulatorVersionsViewer
-                            .setInput(viewModel.getEmulators().get(viewModel.getSelectedEmulatorIndex()).getVersions());
-        } else {
-            emulatorVersionsViewer.setInput(java.util.List.of());
+            });
         }
 
-        final var emulatorVersionSelection =
-                        ViewerProperties.singleSelection(String.class).observe(emulatorVersionsViewer);
-        final UpdateValueStrategy<String, Integer> emulatorVersionToIndex = new UpdateValueStrategy<>();
-        emulatorVersionToIndex.setConverter(new Converter<String, Integer>(String.class, Integer.class) {
-            @Override
-            public Integer convert(String fromObject) {
-                final int idx = viewModel.getSelectedEmulatorIndex();
-                if (idx < 0 || idx >= viewModel.getEmulators().size()) {
-                    return Integer.valueOf(-1);
+        // toolchain versions
+        {
+            final var toolchainVersionSelection =
+                            ViewerProperties.singleSelection(String.class).observe(toolchainVersionsViewer);
+            final var toolchainVersionIndexObservable = BeanProperties
+                            .value(VenvWizardViewModel.class, "selectedToolchainVersionIndex", Integer.class)
+                            .observe(viewModel);
+            final var toolchainVersionToIndex = new UpdateValueStrategy<String, Integer>();
+            toolchainVersionToIndex.setConverter(new Converter<String, Integer>(String.class, Integer.class) {
+                @Override
+                public Integer convert(String fromObject) {
+                    final var idx = viewModel.getSelectedToolchainIndex();
+                    if (idx < 0 || idx >= viewModel.getToolchains().size()) {
+                        return Integer.valueOf(-1);
+                    }
+                    final var vers = viewModel.getToolchains().get(idx).getVersions();
+                    return Integer.valueOf(vers == null ? -1 : vers.indexOf(fromObject));
                 }
-                final var vers = viewModel.getEmulators().get(idx).getVersions();
-                return Integer.valueOf(vers == null ? -1 : vers.indexOf(fromObject));
-            }
-        });
-        final UpdateValueStrategy<Integer, String> indexToEmulatorVersion = new UpdateValueStrategy<>();
-        indexToEmulatorVersion.setConverter(new Converter<Integer, String>(Integer.class, String.class) {
-            @Override
-            public String convert(Integer fromObject) {
-                final int idx = viewModel.getSelectedEmulatorIndex();
-                if (idx < 0 || idx >= viewModel.getEmulators().size()) {
+            });
+            final var indexToToolchainVersion = new UpdateValueStrategy<Integer, String>();
+            indexToToolchainVersion.setConverter(new Converter<Integer, String>(Integer.class, String.class) {
+                @Override
+                public String convert(Integer fromObject) {
+                    final var idx = viewModel.getSelectedToolchainIndex();
+                    if (idx < 0 || idx >= viewModel.getToolchains().size()) {
+                        return null;
+                    }
+                    final var vers = viewModel.getToolchains().get(idx).getVersions();
+                    final var verIdx = ((Integer) fromObject).intValue();
+                    return vers != null && verIdx >= 0 && verIdx < vers.size() ? vers.get(verIdx) : null;
+                }
+            });
+            dbc.bindValue(toolchainVersionSelection, toolchainVersionIndexObservable, toolchainVersionToIndex,
+                            indexToToolchainVersion);
+        }
+
+        // emulator enablement
+        {
+            final var emulatorEnabledObservable = BeanProperties
+                            .value(VenvWizardViewModel.class, "emulatorEnabled", Boolean.class).observe(viewModel);
+            dbc.bindValue(WidgetProperties.buttonSelection().observe(emulatorCheckBox), emulatorEnabledObservable);
+            dbc.bindValue(WidgetProperties.enabled().observe(emulatorNames), emulatorEnabledObservable);
+            dbc.bindValue(WidgetProperties.enabled().observe(emulatorVersions), emulatorEnabledObservable);
+        }
+
+        // emulator names
+        {
+            final var emulatorSelection = ViewerProperties.singleSelection(Emulator.class).observe(emulatorNamesViewer);
+            final var emulatorIndexObservable =
+                            BeanProperties.value(VenvWizardViewModel.class, "selectedEmulatorIndex", Integer.class)
+                                            .observe(viewModel);
+            final var emulatorToIndex = new UpdateValueStrategy<Emulator, Integer>();
+            emulatorToIndex.setConverter(new Converter<Emulator, Integer>(Emulator.class, Integer.class) {
+                @Override
+                public Integer convert(Emulator fromObject) {
+                    if (fromObject == null) {
+                        return Integer.valueOf(-1);
+                    }
+                    return Integer.valueOf(viewModel.getEmulators().indexOf(fromObject));
+                }
+            });
+            final var indexToEmulator = new UpdateValueStrategy<Integer, Emulator>();
+            indexToEmulator.setConverter(new Converter<Integer, Emulator>(Integer.class, Emulator.class) {
+                @Override
+                public Emulator convert(Integer fromObject) {
+                    final var idx = ((Integer) fromObject).intValue();
+                    if (idx >= 0 && idx < viewModel.getEmulators().size()) {
+                        return viewModel.getEmulators().get(idx);
+                    }
                     return null;
                 }
-                final var vers = viewModel.getEmulators().get(idx).getVersions();
-                final int vi = ((Integer) fromObject).intValue();
-                return vers != null && vi >= 0 && vi < vers.size() ? vers.get(vi) : null;
-            }
-        });
-        dbc.bindValue(emulatorVersionSelection,
-                        BeanProperties.value(VenvWizardViewModel.class, "selectedEmulatorVersionIndex", Integer.class)
-                                        .observe(viewModel),
-                        emulatorVersionToIndex, indexToEmulatorVersion);
+            });
+            dbc.bindValue(emulatorSelection, emulatorIndexObservable, emulatorToIndex, indexToEmulator);
+
+            emulatorIndexObservable.addValueChangeListener(e -> {
+                final var idx = viewModel.getSelectedEmulatorIndex();
+                if (idx >= 0 && idx < viewModel.getEmulators().size()) {
+                    emulatorVersionsViewer.setInput(viewModel.getEmulators().get(idx).getVersions());
+                } else {
+                    emulatorVersionsViewer.setInput(List.of());
+                }
+            });
+        }
+
+        // emulator versions
+        {
+            final var emulatorVersionSelection =
+                            ViewerProperties.singleSelection(String.class).observe(emulatorVersionsViewer);
+            final var emulatorVersionIndexObservable = BeanProperties
+                            .value(VenvWizardViewModel.class, "selectedEmulatorVersionIndex", Integer.class)
+                            .observe(viewModel);
+            final var emulatorVersionToIndex = new UpdateValueStrategy<String, Integer>();
+            emulatorVersionToIndex.setConverter(new Converter<String, Integer>(String.class, Integer.class) {
+                @Override
+                public Integer convert(String fromObject) {
+                    final var idx = viewModel.getSelectedEmulatorIndex();
+                    if (idx < 0 || idx >= viewModel.getEmulators().size()) {
+                        return Integer.valueOf(-1);
+                    }
+                    final var vers = viewModel.getEmulators().get(idx).getVersions();
+                    return Integer.valueOf(vers == null ? -1 : vers.indexOf(fromObject));
+                }
+            });
+            final var indexToEmulatorVersion = new UpdateValueStrategy<Integer, String>();
+            indexToEmulatorVersion.setConverter(new Converter<Integer, String>(Integer.class, String.class) {
+                @Override
+                public String convert(Integer fromObject) {
+                    final var idx = viewModel.getSelectedEmulatorIndex();
+                    if (idx < 0 || idx >= viewModel.getEmulators().size()) {
+                        return null;
+                    }
+                    final var vers = viewModel.getEmulators().get(idx).getVersions();
+                    final var verIdx = ((Integer) fromObject).intValue();
+                    return vers != null && verIdx >= 0 && verIdx < vers.size() ? vers.get(verIdx) : null;
+                }
+            });
+            dbc.bindValue(emulatorVersionSelection, emulatorVersionIndexObservable, emulatorVersionToIndex,
+                            indexToEmulatorVersion);
+        }
+
+        // sysroot
+        {
+            final var sysrootSelection = new SelectObservableValue<VenvWizardViewModel.SysrootOption>();
+            sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.DEFAULT_SYSROOT,
+                            WidgetProperties.buttonSelection().observe(sysrootDefaultRadio));
+            sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.NONE_SYSROOT,
+                            WidgetProperties.buttonSelection().observe(sysrootNoneRadio));
+            sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.FOREIGN_TOOLCHAIN,
+                            WidgetProperties.buttonSelection().observe(sysrootForeignRadio));
+
+            dbc.bindValue(sysrootSelection, BeanProperties
+                            .value(VenvWizardViewModel.class, "sysrootOption", VenvWizardViewModel.SysrootOption.class)
+                            .observe(viewModel));
+        }
 
         final var completeObservable =
                         BeanProperties.value(VenvWizardViewModel.class, "configurationPageComplete", Boolean.class)
                                         .observe(viewModel);
         completeObservable.addValueChangeListener(e -> updatePageComplete());
-
-        setControl(container);
-        updatePageComplete();
     }
 
     private void updatePageComplete() {


### PR DESCRIPTION
- feat(news): auto load news after opening news view
- refactor: fix code style consistency and improve readability

## Summary by Sourcery

Refactor venv and news UI/view models for clearer structure and async operations, and improve news loading behavior.

New Features:
- Automatically load news when the news view is opened.
- Allow selecting a custom venv path via a directory browser in the venv location wizard.

Bug Fixes:
- Fix sysroot option enum and bindings to use consistent values across the wizard.
- Ensure venv and news refresh methods are safe to call repeatedly by guarding concurrent fetches.

Enhancements:
- Restructure venv wizard, venv list, and news views into smaller helper methods for layout, control creation, and event wiring to improve readability and maintainability.
- Streamline Ruyi CLI wrapper code and related view models with clearer variable naming, use of local type inference, and safer null/empty handling.
- Improve virtual env deletion flow, including clearer confirmation dialogs and error reporting.
- Simplify NewsManager to use direct PropertyChangeSupport without unused listener types and clean up observable list initializations.
- Rename and clarify news data fetch service types used by the news view models.