### PR TITLE
feat: news list is descending; clean code about primitives and wrappers

### DIFF
--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsFetchService.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsFetchService.java
@@ -63,11 +63,21 @@ public class NewsFetchService {
                 try {
                     int unreadCount = 0;
                     for (var item : RuyiCli.listNewsItems(false)) {
-                        boolean unread = !item.isRead();
+                        if (item == null) {
+                            continue;
+                        }
+
+                        final Boolean isRead = item.isRead();
+                        boolean unread = isRead == null || !isRead.booleanValue();
                         if (unread) {
                             unreadCount++;
                         }
-                        newsList.add(new NewsItem(item.getTitle(), item.getId(), unread));
+
+                        final Integer ordObj = item.getOrd();
+                        final int ord = ordObj == null ? -1 : ordObj.intValue();
+                        final String title = item.getTitle() == null ? "" : item.getTitle();
+                        final String id = item.getId() == null ? "" : item.getId();
+                        newsList.add(new NewsItem(ord, title, id, unread));
                     }
                     LOGGER.logInfo("Fetched news list: count=" + newsList.size() + ", unread=" + unreadCount);
                 } catch (Exception e) {

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsItem.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsItem.java
@@ -4,28 +4,49 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 
 /**
- * A news item with title, id, unread status, and optional details.
+ * A news item with ordinal/index, title, id, unread status, and details.
  */
 public class NewsItem {
     private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
 
+    private int ord;
     private String title;
     private String id;
-    private Boolean unread;
+    private boolean unread;
     private String details = "";
-    private Boolean detailsFetched = false;
+    private boolean detailsFetched = false;
 
     /**
      * Creates a news item.
      *
+     * @param ord the ordinal/index
      * @param title the title
      * @param id the id
      * @param unread whether the item is unread
      */
-    public NewsItem(String title, String id, Boolean unread) {
+    public NewsItem(int ord, String title, String id, boolean unread) {
         this.title = title;
         this.id = id;
         this.unread = unread;
+        this.ord = ord;
+    }
+
+    /**
+     * Returns the ordinal/index.
+     *
+     * @return the ordinal/index
+     */
+    public int getOrd() {
+        return ord;
+    }
+
+    /**
+     * Sets the ordinal/index.
+     *
+     * @param ord the ordinal/index
+     */
+    public void setOrd(int ord) {
+        pcs.firePropertyChange("ord", this.ord, this.ord = ord);
     }
 
     /**
@@ -33,7 +54,7 @@ public class NewsItem {
      *
      * @return whether the item is unread
      */
-    public Boolean getUnread() {
+    public boolean getUnread() {
         return unread;
     }
 
@@ -42,7 +63,7 @@ public class NewsItem {
      *
      * @param unread whether the item is unread
      */
-    public void setUnread(Boolean unread) {
+    public void setUnread(boolean unread) {
         pcs.firePropertyChange("unread", this.unread, this.unread = unread);
     }
 
@@ -105,7 +126,7 @@ public class NewsItem {
      *
      * @return whether details have been fetched
      */
-    public Boolean getDetailsFetched() {
+    public boolean getDetailsFetched() {
         return detailsFetched;
     }
 
@@ -114,8 +135,8 @@ public class NewsItem {
      *
      * @param detailsFetched whether details have been fetched
      */
-    public void setDetailsFetched(Boolean detailsFetched) {
-        this.detailsFetched = detailsFetched;
+    public void setDetailsFetched(boolean detailsFetched) {
+        pcs.firePropertyChange("detailsFetched", this.detailsFetched, this.detailsFetched = detailsFetched);
     }
 
     /**

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/viewmodel/NewsListViewModel.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/viewmodel/NewsListViewModel.java
@@ -5,6 +5,7 @@ import java.beans.PropertyChangeSupport;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import org.eclipse.core.databinding.observable.list.IObservableList;
 import org.eclipse.core.databinding.observable.list.WritableList;
 import org.ruyisdk.news.model.NewsFetchService;
@@ -113,9 +114,11 @@ public class NewsListViewModel {
         setInfoText(UpdatingState.updating);
 
         service.fetchNewsListAsync(result -> {
+            final var sorted = new ArrayList<NewsItem>(result);
+            sorted.sort(Comparator.comparingInt(NewsItem::getOrd).reversed());
             observableNewsList.getRealm().asyncExec(() -> {
                 observableNewsList.clear();
-                observableNewsList.addAll(result);
+                observableNewsList.addAll(sorted);
             });
             setInfoText(String.format(UpdatingState.updatedTemplate,
                             LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))));

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/views/NewsView.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/views/NewsView.java
@@ -118,18 +118,21 @@ public class NewsView extends ViewPart {
             // TODO: use Tuple and loop to eliminate duplicates
             {
                 final var column = new TableViewerColumn(tableViewer, SWT.CENTER);
-                column.getColumn().setText("Unread");
-                tableColumnLayout.setColumnData(column.getColumn(), new ColumnWeightData(5, 60));
+                final var tableColumn = column.getColumn();
+                tableColumn.setText("Unread");
+                tableColumnLayout.setColumnData(tableColumn, new ColumnWeightData(5, 60));
             }
             {
                 final var column = new TableViewerColumn(tableViewer, SWT.NONE);
-                column.getColumn().setText("Title");
-                tableColumnLayout.setColumnData(column.getColumn(), new ColumnWeightData(100, 20));
+                final var tableColumn = column.getColumn();
+                tableColumn.setText("Title");
+                tableColumnLayout.setColumnData(tableColumn, new ColumnWeightData(100, 20));
             }
             {
                 final var column = new TableViewerColumn(tableViewer, SWT.NONE);
-                column.getColumn().setText("ID");
-                tableColumnLayout.setColumnData(column.getColumn(), new ColumnWeightData(50, 20));
+                final var tableColumn = column.getColumn();
+                tableColumn.setText("ID");
+                tableColumnLayout.setColumnData(tableColumn, new ColumnWeightData(50, 20));
             }
             tableComposite.setLayout(tableColumnLayout);
 

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
@@ -115,12 +115,12 @@ public class RuyiCli {
     /** Summary information for a news item returned by the ruyi CLI. */
     public static class NewsListItemInfo {
         private final String id;
-        private final int ord;
-        private final boolean read;
+        private final Integer ord;
+        private final Boolean read;
         private final String title;
 
         /** Creates an instance. */
-        public NewsListItemInfo(String id, int ord, boolean read, String title) {
+        public NewsListItemInfo(String id, Integer ord, Boolean read, String title) {
             this.id = id;
             this.ord = ord;
             this.read = read;
@@ -131,11 +131,11 @@ public class RuyiCli {
             return id;
         }
 
-        public int getOrd() {
+        public Integer getOrd() {
             return ord;
         }
 
-        public boolean isRead() {
+        public Boolean isRead() {
             return read;
         }
 
@@ -147,13 +147,13 @@ public class RuyiCli {
     /** Full content and metadata for a news item returned by the ruyi CLI. */
     public static class NewsReadResult {
         private final String id;
-        private final int ord;
-        private final boolean read;
+        private final Integer ord;
+        private final Boolean read;
         private final String title;
         private final String content;
 
         /** Creates an instance. */
-        public NewsReadResult(String id, int ord, boolean read, String title, String content) {
+        public NewsReadResult(String id, Integer ord, Boolean read, String title, String content) {
             this.id = id;
             this.ord = ord;
             this.read = read;
@@ -165,11 +165,11 @@ public class RuyiCli {
             return id;
         }
 
-        public int getOrd() {
+        public Integer getOrd() {
             return ord;
         }
 
-        public boolean isRead() {
+        public Boolean isRead() {
             return read;
         }
 
@@ -298,25 +298,16 @@ public class RuyiCli {
                 if (o == null) {
                     continue;
                 }
-                final var ty = o.optString("ty", "");
+                final var ty = o.optString("ty", null);
                 if (!"newsitem-v1".equalsIgnoreCase(ty)) {
                     continue;
                 }
-                var id = o.optString("id", "").trim();
-                final var ord = o.optInt("ord", -1);
-                final var isRead = o.optBoolean("is_read", false);
+                final var id = o.optString("id", null);
+                final var ord = o.optIntegerObject("ord", null);
+                final var isRead = o.optBooleanObject("is_read", null);
                 final var langs = o.optJSONArray("langs");
-                String title = chooseNewsDisplayTitle(langs);
-                if (title == null || title.trim().isEmpty()) {
-                    title = id;
-                }
-                if (id == null || id.isEmpty()) {
-                    // Defensive: fall back to ord as string if id is absent.
-                    id = ord >= 0 ? String.valueOf(ord) : "";
-                }
-                if (id != null && !id.isEmpty()) {
-                    out.add(new NewsListItemInfo(id, ord, isRead, title));
-                }
+                final var title = chooseNewsDisplayTitle(langs);
+                out.add(new NewsListItemInfo(id, ord, isRead, title));
             }
         } catch (Exception e) {
             // ignore
@@ -338,9 +329,9 @@ public class RuyiCli {
             if (o == null) {
                 return null;
             }
-            final var id = o.optString("id", "").trim();
-            final var ord = o.optInt("ord", -1);
-            final var isRead = o.optBoolean("is_read", false);
+            final var id = o.optString("id", null);
+            final var ord = o.optIntegerObject("ord", null);
+            final var isRead = o.optBooleanObject("is_read", null);
             final var langs = o.optJSONArray("langs");
             final var title = chooseNewsDisplayTitle(langs);
             final var content = chooseNewsContent(langs);
@@ -387,17 +378,17 @@ public class RuyiCli {
     private static String chooseNewsDisplayTitle(JSONArray langs) {
         final var best = chooseBestNewsLang(langs);
         if (best == null) {
-            return "";
+            return null;
         }
-        return best.optString("display_title", "");
+        return best.optString("display_title", null);
     }
 
     private static String chooseNewsContent(JSONArray langs) {
         final var best = chooseBestNewsLang(langs);
         if (best == null) {
-            return "";
+            return null;
         }
-        return best.optString("content", "");
+        return best.optString("content", null);
     }
 
     private static JSONObject chooseBestNewsLang(JSONArray langs) {

--- a/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/services/RuyiCliParsingTest.java
+++ b/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/services/RuyiCliParsingTest.java
@@ -109,12 +109,12 @@ public class RuyiCliParsingTest {
             assertEquals(2, items.size());
 
             assertEquals("2024-01-14-ruyi-news", items.get(0).getId());
-            assertEquals(1, items.get(0).getOrd());
-            assertFalse(items.get(0).isRead());
+            assertEquals(Integer.valueOf(1), items.get(0).getOrd());
+            assertEquals(Boolean.FALSE, items.get(0).isRead());
             assertEquals("Ruyi News", items.get(0).getTitle());
 
             assertEquals("2024-01-21-ruyi-news", items.get(1).getId());
-            assertTrue(items.get(1).isRead());
+            assertEquals(Boolean.TRUE, items.get(1).isRead());
             assertEquals("Second", items.get(1).getTitle());
         } finally {
             Locale.setDefault(old);
@@ -122,10 +122,10 @@ public class RuyiCliParsingTest {
     }
 
     /**
-     * Falls back to ordinal as ID when the porcelain object is missing an id.
+     * Leaves the ID as null when the porcelain object is missing an id.
      */
     @Test
-    public void parseNewsListFallsBackToOrdWhenIdMissing() {
+    public void parseNewsListKeepsNullIdWhenIdMissing() {
         String sample = """
                         {"ty":"newsitem-v1","ord":7,"is_read":false,"langs":[{"lang":"en_US","display_title":"T","content":"C"}]}
                         """;
@@ -133,8 +133,8 @@ public class RuyiCliParsingTest {
         List<RuyiCli.NewsListItemInfo> items = RuyiCli.parseNewsListFromString(sample);
         assertNotNull(items);
         assertEquals(1, items.size());
-        assertEquals("7", items.get(0).getId());
-        assertEquals(7, items.get(0).getOrd());
+        assertEquals(null, items.get(0).getId());
+        assertEquals(Integer.valueOf(7), items.get(0).getOrd());
     }
 
     /**
@@ -153,8 +153,8 @@ public class RuyiCliParsingTest {
             RuyiCli.NewsReadResult r = RuyiCli.parseNewsReadFromString(sample);
             assertNotNull(r);
             assertEquals("2024-01-14-ruyi-news", r.getId());
-            assertEquals(1, r.getOrd());
-            assertTrue(r.isRead());
+            assertEquals(Integer.valueOf(1), r.getOrd());
+            assertEquals(Boolean.TRUE, r.isRead());
             assertEquals("English Title", r.getTitle());
             assertEquals("English Content", r.getContent());
         } finally {


### PR DESCRIPTION
## Summary by Sourcery

Sort fetched news items in descending order by ordinal and align news parsing and model types to handle nullable fields consistently.

New Features:
- Display the news list with items ordered by descending ordinal/index.

Enhancements:
- Change CLI news parsing to use nullable wrapper types for ordinal and read flags and propagate these through the model.
- Simplify news title and id fallback handling by allowing nulls and normalizing values when creating UI models.
- Add ordinal/index field to the NewsItem model and expose change notifications for it and the detailsFetched flag.
- Refine table column setup for the news view for cleaner SWT layout handling.

Tests:
- Update CLI parsing tests to reflect nullable IDs, wrapper-based ord/read fields, and the new null-handling behavior.