### PR TITLE
feat: add menu entries for venv and news

### DIFF
--- a/plugins/org.ruyisdk.news/plugin.xml
+++ b/plugins/org.ruyisdk.news/plugin.xml
@@ -12,4 +12,18 @@
             class="org.ruyisdk.news.views.NewsView"
             category="org.ruyisdk.news.category"/>
     </extension>
+
+    <extension point="org.eclipse.ui.menus">
+        <menuContribution
+            locationURI="menu:org.ruyisdk.ruyi.menus.main?after=additions">
+            <command
+                commandId="org.eclipse.ui.views.showView"
+                label="News"
+                tooltip="Open Ruyi News view">
+                <parameter
+                    name="org.eclipse.ui.views.showView.viewId"
+                    value="org.ruyisdk.news.view" />
+            </command>
+        </menuContribution>
+    </extension>
 </plugin>

--- a/plugins/org.ruyisdk.venv/plugin.xml
+++ b/plugins/org.ruyisdk.venv/plugin.xml
@@ -12,4 +12,18 @@
             class="org.ruyisdk.venv.views.VenvView"
             category="org.ruyisdk.venv.category"/>
     </extension>
+
+    <extension point="org.eclipse.ui.menus">
+        <menuContribution
+            locationURI="menu:org.ruyisdk.ruyi.menus.main?after=additions">
+            <command
+                commandId="org.eclipse.ui.views.showView"
+                label="Venv (Virtual Environments)"
+                tooltip="Open Ruyi Venv view">
+                <parameter
+                    name="org.eclipse.ui.views.showView.viewId"
+                    value="org.ruyisdk.venv.view" />
+            </command>
+        </menuContribution>
+    </extension>
 </plugin>


### PR DESCRIPTION
## Summary by Sourcery

Add main menu entries to open the Ruyi News and Venv views from the primary application menu.

New Features:
- Expose the News view via a dedicated item in the main Ruyi application menu.
- Expose the Venv (Virtual Environments) view via a dedicated item in the main Ruyi application menu.