### PR TITLE
feat(venv): support manual refresh of virtual environment list

### DIFF
--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
@@ -26,6 +26,7 @@ public class VenvListViewModel {
     private boolean isFetching = false;
     private boolean canDelete = false;
     private boolean canApply = false;
+    private boolean canRefresh = true;
 
     private final VenvDetectionService detectionService;
     private final VenvConfigurationService configService;
@@ -98,6 +99,22 @@ public class VenvListViewModel {
     }
 
     /**
+     * Returns whether refresh is currently allowed.
+     *
+     * @return whether refresh is currently allowed
+     */
+    public boolean isCanRefresh() {
+        return canRefresh;
+    }
+
+    private void setCanRefresh(boolean canRefresh) {
+        if (this.canRefresh == canRefresh) {
+            return;
+        }
+        pcs.firePropertyChange("canRefresh", this.canRefresh, this.canRefresh = canRefresh);
+    }
+
+    /**
      * Adds a property change listener.
      *
      * @param listener the listener
@@ -119,6 +136,7 @@ public class VenvListViewModel {
         this.isFetching = isFetching;
         updateCanDelete();
         updateCanApply();
+        updateCanRefresh();
     }
 
     private void updateCanDelete() {
@@ -134,6 +152,10 @@ public class VenvListViewModel {
         final var selected = selectedVenvs.get(0);
         final var projectPath = selected.getProjectPath();
         setCanApply(projectPath != null && !projectPath.isEmpty());
+    }
+
+    private void updateCanRefresh() {
+        setCanRefresh(!isFetching);
     }
 
     /**

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvView.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvView.java
@@ -48,6 +48,7 @@ public class VenvView extends ViewPart {
 
     private Button absPathCheckBox;
     private TableViewer tableViewer;
+    private Button refreshButton;
     private Button applyButton;
     private Button deleteButton;
     private Button newButton;
@@ -79,7 +80,7 @@ public class VenvView extends ViewPart {
         buttonBar = new Composite(container, SWT.NONE);
         buttonBar.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
         {
-            var gridLayout = new GridLayout(3, false);
+            var gridLayout = new GridLayout(4, false);
             gridLayout.marginWidth = 0;
             buttonBar.setLayout(gridLayout);
         }
@@ -133,6 +134,10 @@ public class VenvView extends ViewPart {
             tableViewer.setInput(venvListViewModel.getVenvList());
         }
 
+        refreshButton = new Button(buttonBar, SWT.PUSH);
+        refreshButton.setText("Refresh List");
+        refreshButton.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
+
         applyButton = new Button(buttonBar, SWT.PUSH);
         applyButton.setText("Apply to Project");
         applyButton.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
@@ -150,10 +155,19 @@ public class VenvView extends ViewPart {
         dbc = new DataBindingContext();
 
         dbc.bindList(ViewerProperties.multipleSelection().observe(tableViewer), venvListViewModel.getSelectedVenvs());
+        dbc.bindValue(WidgetProperties.enabled().observe(refreshButton), BeanProperties
+                        .value(VenvListViewModel.class, "canRefresh", Boolean.class).observe(venvListViewModel));
         dbc.bindValue(WidgetProperties.enabled().observe(deleteButton), BeanProperties
                         .value(VenvListViewModel.class, "canDelete", Boolean.class).observe(venvListViewModel));
         dbc.bindValue(WidgetProperties.enabled().observe(applyButton), BeanProperties
                         .value(VenvListViewModel.class, "canApply", Boolean.class).observe(venvListViewModel));
+
+        refreshButton.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                venvListViewModel.onRefreshVenvListAsync();
+            }
+        });
 
         applyButton.addSelectionListener(new SelectionAdapter() {
             @Override


### PR DESCRIPTION
## Summary by Sourcery

Add UI and view model support for manually refreshing the detected virtual environment list and disable refresh while a fetch is in progress.

New Features:
- Introduce a refresh button in the virtual environment view to manually reload the venv list.

Enhancements:
- Expose a canRefresh state in the virtual environment list view model and bind it to the refresh button's enabled state based on the current fetching status.