### PR TITLE
chore: add missing 3rd-party library dependencies to feature.xml

### DIFF
--- a/features/org.ruyisdk.feature/feature.xml
+++ b/features/org.ruyisdk.feature/feature.xml
@@ -383,4 +383,18 @@ You may add additional accurate notices of copyright ownership.
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.commonmark"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.commonmark.ext-gfm-tables"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
Amend https://github.com/ruyisdk/ruyisdk-eclipse-plugins/pull/95 .

## Summary by Sourcery

Declare additional third-party CommonMark plugins in the Eclipse feature definition to ensure they are packaged with the feature.

New Features:
- Include the org.commonmark plugin in the feature so it is installed with the product.
- Include the org.commonmark.ext-gfm-tables plugin in the feature so it is installed with the product.