### PR TITLE
release: bump to v0.1.2

### DIFF
--- a/features/org.ruyisdk.feature/feature.xml
+++ b/features/org.ruyisdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.ruyisdk.feature"
       label="RuyiSDK IDE Feature"
-      version="0.1.1.qualifier"
+      version="0.1.2.qualifier"
       provider-name="RuyiSDK">
 
    <description url="https://github.com/ruyisdk">

--- a/plugins/org.ruyisdk.core/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Core
 Bundle-SymbolicName: org.ruyisdk.core;singleton:=true
-Bundle-Version: 0.1.1.qualifier
+Bundle-Version: 0.1.2.qualifier
 Automatic-Module-Name: org.ruyisdk.core
 Bundle-Activator: org.ruyisdk.core.Activator
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.ruyisdk.devices/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.devices/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Devices
 Bundle-SymbolicName: org.ruyisdk.devices;singleton:=true
-Bundle-Version: 0.1.1.qualifier
+Bundle-Version: 0.1.2.qualifier
 Bundle-Activator: org.ruyisdk.devices.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.ruyisdk.intro/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.intro/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Intro
 Bundle-SymbolicName: org.ruyisdk.intro;singleton:=true
-Bundle-Version: 0.1.1.qualifier
+Bundle-Version: 0.1.2.qualifier
 Export-Package: org.ruyisdk.intro
 Bundle-Activator: org.ruyisdk.intro.Activator
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.ruyisdk.news/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.news/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: News
 Bundle-SymbolicName: org.ruyisdk.news;singleton:=true
-Bundle-Version: 0.1.1.qualifier
+Bundle-Version: 0.1.2.qualifier
 Automatic-Module-Name: org.ruyisdk.news
 Bundle-Activator: org.ruyisdk.news.Activator
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.ruyisdk.packages/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.packages/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Ruyi SDK Packages
 Bundle-SymbolicName: org.ruyisdk.packages;singleton:=true
-Bundle-Version: 0.1.1.qualifier
+Bundle-Version: 0.1.2.qualifier
 Require-Bundle: 
  org.eclipse.ui,
  org.eclipse.ui.workbench,

--- a/plugins/org.ruyisdk.projectcreator/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.projectcreator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Project Creator
 Bundle-SymbolicName: org.ruyisdk.projectcreator;singleton:=true
-Bundle-Version: 0.1.1.qualifier
+Bundle-Version: 0.1.2.qualifier
 Bundle-Activator: org.ruyisdk.projectcreator.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.ruyisdk.ruyi/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.ruyi/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Ruyi
 Bundle-SymbolicName: org.ruyisdk.ruyi;singleton:=true
-Bundle-Version: 0.1.1.qualifier
+Bundle-Version: 0.1.2.qualifier
 Bundle-Activator: org.ruyisdk.ruyi.Activator
 Bundle-ClassPath: .
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.31.100",

--- a/plugins/org.ruyisdk.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.ui/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Ui
 Bundle-SymbolicName: org.ruyisdk.ui
-Bundle-Version: 0.1.1.qualifier
+Bundle-Version: 0.1.2.qualifier
 Automatic-Module-Name: org.ruyisdk.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/plugins/org.ruyisdk.venv/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.venv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Venv
 Bundle-SymbolicName: org.ruyisdk.venv;singleton:=true
-Bundle-Version: 0.1.1.qualifier
+Bundle-Version: 0.1.2.qualifier
 Automatic-Module-Name: org.ruyisdk.venv
 Bundle-Activator: org.ruyisdk.venv.Activator
 Bundle-ActivationPolicy: lazy

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>org.ruyisdk</groupId>
   <artifactId>ruyisdk-eclipse-plugins-parent</artifactId>
-  <version>0.1.1-SNAPSHOT</version>
+  <version>0.1.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>RuyiSDK Eclipse Plugins</name>

--- a/sites/repository/category.xml
+++ b/sites/repository/category.xml
@@ -4,9 +4,9 @@
       Update site for RuyiSDK Eclipse IDE plugins
    </description>
 
-   <feature url="features/org.ruyisdk.feature_0.1.1.qualifier.jar"
+   <feature url="features/org.ruyisdk.feature_0.1.2.qualifier.jar"
             id="org.ruyisdk.feature"
-            version="0.1.1.qualifier">
+            version="0.1.2.qualifier">
       <category name="ruyisdk"/>
    </feature>
 

--- a/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
+++ b/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Ruyi Tests
 Bundle-SymbolicName: org.ruyisdk.ruyi.tests
-Bundle-Version: 0.1.1.qualifier
+Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.ruyisdk.ruyi,


### PR DESCRIPTION
ok.

## Summary by Sourcery

Bump the RuyiSDK Eclipse plugins project to version 0.1.2 across feature descriptors and build metadata.

Build:
- Update the parent Maven POM version from 0.1.1-SNAPSHOT to 0.1.2-SNAPSHOT.

Deployment:
- Update Eclipse update site category and feature descriptors to reference the 0.1.2 feature JAR and version.