### PR TITLE
fix: no "next" or "finish" in Ruyi install wizard before completion

### DIFF
--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/ui/RuyiInstallWizard.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/ui/RuyiInstallWizard.java
@@ -368,9 +368,6 @@ public class RuyiInstallWizard extends Wizard {
                 }
             });
             installationJob.schedule();
-            if (installationJob.getResult() == Status.OK_STATUS) {
-                setPageComplete(true);
-            }
         }
 
         private void updateProgress(int percent, String message) {


### PR DESCRIPTION
Part of #82.

## Summary by Sourcery

Bug Fixes:
- Prevent the install wizard from showing completion actions (Next/Finish) before the installation process has actually completed.