### PR TITLE
ci: update dependent actions; only run publish_releases if a release is to be made

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
 
   publish_releases:
     name: Publish Releases
+    if: ${{ needs.config.outputs.make_continuous_release == 'true' || needs.config.outputs.make_versioning_release == 'true' }}
     needs:
       - config
       - build_and_upload


### PR DESCRIPTION
- ci: update dependent actions
- ci: only run publish_releases if a release is to be made

## Summary by Sourcery

Update CI workflow dependencies and guard release publishing so it only runs when a release is required.

Build:
- Bump GitHub Actions versions for checkout, setup-java, upload-artifact, and download-artifact in the CI workflow.

CI:
- Add a conditional to the publish_releases job so it only executes when a continuous or versioned release is configured.