### PR TITLE
fix: wrong instruction in install wizard; decrease text block indents

### DIFF
--- a/docs/developer/coding-guidelines/ruyisdk-eclipse-java-google-style.xml
+++ b/docs/developer/coding-guidelines/ruyisdk-eclipse-java-google-style.xml
@@ -90,7 +90,7 @@
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_enum_constant" value="0"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.text_block_indentation" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.text_block_indentation" value="2"/>
         <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="16"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>

--- a/docs/developer/coding-guidelines/ruyisdk_ide_google_checks.xml
+++ b/docs/developer/coding-guidelines/ruyisdk_ide_google_checks.xml
@@ -289,6 +289,10 @@
       <property name="influenceFormat" value="1"/>
     </module>
   </module>
+  <module name="SuppressionSingleFilter">
+    <property name="checks" value="Indentation"/>
+    <property name="message" value="'&quot;&quot;&quot;' has incorrect indentation"/>
+  </module>
   <module name="BeforeExecutionExclusionFileFilter">
     <property name="fileNamePattern" value="module\-info\.java$"/>
   </module>

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/util/MarkdownRenderer.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/util/MarkdownRenderer.java
@@ -18,63 +18,63 @@ public final class MarkdownRenderer {
     private static final HtmlRenderer HTML_RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
 
     private static final String HTML_TEMPLATE = """
-                    <!DOCTYPE html>
-                    <html>
-                    <head>
-                    <meta charset="UTF-8">
-                    <style>
-                    body {
-                        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-                        font-size: 14px;
-                        line-height: 1.6;
-                        padding: 10px;
-                        margin: 0;
-                    }
-                    table {
-                        border-collapse: collapse;
-                        width: 100%%;
-                        margin: 10px 0;
-                    }
-                    th, td {
-                        border: 1px solid #ddd;
-                        padding: 8px;
-                        text-align: left;
-                    }
-                    th {
-                        background-color: #f4f4f4;
-                    }
-                    a {
-                        color: #0066cc;
-                    }
-                    code {
-                        background-color: #f4f4f4;
-                        padding: 2px 4px;
-                        border-radius: 3px;
-                        font-family: monospace;
-                    }
-                    pre {
-                        background-color: #f4f4f4;
-                        padding: 10px;
-                        border-radius: 5px;
-                        overflow-x: auto;
-                    }
-                    pre code {
-                        padding: 0;
-                        background-color: transparent;
-                    }
-                    blockquote {
-                        border-left: 4px solid #ddd;
-                        margin: 0;
-                        padding-left: 16px;
-                        color: #666;
-                    }
-                    </style>
-                    </head>
-                    <body>
-                    %s
-                    </body>
-                    </html>
-                    """;
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="UTF-8">
+        <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            font-size: 14px;
+            line-height: 1.6;
+            padding: 10px;
+            margin: 0;
+        }
+        table {
+            border-collapse: collapse;
+            width: 100%%;
+            margin: 10px 0;
+        }
+        th, td {
+            border: 1px solid #ddd;
+            padding: 8px;
+            text-align: left;
+        }
+        th {
+            background-color: #f4f4f4;
+        }
+        a {
+            color: #0066cc;
+        }
+        code {
+            background-color: #f4f4f4;
+            padding: 2px 4px;
+            border-radius: 3px;
+            font-family: monospace;
+        }
+        pre {
+            background-color: #f4f4f4;
+            padding: 10px;
+            border-radius: 5px;
+            overflow-x: auto;
+        }
+        pre code {
+            padding: 0;
+            background-color: transparent;
+        }
+        blockquote {
+            border-left: 4px solid #ddd;
+            margin: 0;
+            padding-left: 16px;
+            color: #666;
+        }
+        </style>
+        </head>
+        <body>
+        %s
+        </body>
+        </html>
+        """;
 
     /**
      * Renders Markdown text to a complete HTML document.

--- a/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/views/WebsiteView.java
+++ b/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/views/WebsiteView.java
@@ -160,31 +160,31 @@ public class WebsiteView extends ViewPart {
      */
     private void injectNavigationHook() {
         browser.execute("""
-                        if (!window._ruyiSdkNavHooked) {
-                          window._ruyiSdkNavHooked = true;
-                          if (window.navigation && typeof window.navigation.addEventListener === 'function') {
-                            window.navigation.addEventListener('currententrychange', function() {
-                              window._onRuyiSdkUrlChanged();
-                            });
-                          } else {
-                            var origPush = history.pushState;
-                            var origReplace = history.replaceState;
-                            history.pushState = function() {
-                              var r = origPush.apply(this, arguments);
-                              window._onRuyiSdkUrlChanged();
-                              return r;
-                            };
-                            history.replaceState = function() {
-                              var r = origReplace.apply(this, arguments);
-                              window._onRuyiSdkUrlChanged();
-                              return r;
-                            };
-                            window.addEventListener('popstate', function() {
-                              window._onRuyiSdkUrlChanged();
-                            });
-                          }
-                        }
-                        """);
+            if (!window._ruyiSdkNavHooked) {
+              window._ruyiSdkNavHooked = true;
+              if (window.navigation && typeof window.navigation.addEventListener === 'function') {
+                window.navigation.addEventListener('currententrychange', function() {
+                  window._onRuyiSdkUrlChanged();
+                });
+              } else {
+                var origPush = history.pushState;
+                var origReplace = history.replaceState;
+                history.pushState = function() {
+                  var r = origPush.apply(this, arguments);
+                  window._onRuyiSdkUrlChanged();
+                  return r;
+                };
+                history.replaceState = function() {
+                  var r = origReplace.apply(this, arguments);
+                  window._onRuyiSdkUrlChanged();
+                  return r;
+                };
+                window.addEventListener('popstate', function() {
+                  window._onRuyiSdkUrlChanged();
+                });
+              }
+            }
+            """);
     }
 
     private void updateNavigationButtons() {

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/ConfigPreferencePage.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/ConfigPreferencePage.java
@@ -72,10 +72,10 @@ public class ConfigPreferencePage extends PreferencePage implements IWorkbenchPr
 
         final var localHint = new Label(localGroup, SWT.WRAP);
         localHint.setText("""
-                        Use an existing git clone of the packages-index repository \
-                        instead of the default cache location. Must be a valid git repository \
-                        or a non-existing path (ruyi will clone into it).
-                        Leave empty to use the location managed by ruyi.""");
+            Use an existing git clone of the packages-index repository \
+            instead of the default cache location. Must be a valid git repository \
+            or a non-existing path (ruyi will clone into it).
+            Leave empty to use the location managed by ruyi.""");
         {
             final var gridData = new GridData(SWT.FILL, SWT.TOP, true, false);
             gridData.horizontalSpan = 3;

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/ui/RuyiInstallWizard.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/ui/RuyiInstallWizard.java
@@ -146,10 +146,12 @@ public class RuyiInstallWizard extends Wizard {
             // 提示文本
             Label hintLabel = new Label(container, SWT.WRAP);
             hintLabel.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
-            hintLabel.setText("Please note:\n" + "• Click [Next] to start installation wizard.\n"
-                            + "• Select [Cancel] to manually trigger from menu: " + "RuyiSDK > Ruyi Installation.\n"
-                            + "• If you already have ruyi, configure path in: "
-                            + "Windows > Preferences > RuyiSDK > Ruyi Config > " + "Ruyi Installation Directory.\n\n");
+            hintLabel.setText("""
+                Please note:
+                • Click [Next] to start installation wizard.
+                • Select [Cancel] to manually trigger from menu: RuyiSDK > Ruyi Installation.
+                • If you already have ruyi, configure path in:
+                  Windows > Preferences > RuyiSDK > Ruyi Installation Directory.""");
             Color tipColor = new Color(hintLabel.getDisplay(), 0, 0, 255);
             hintLabel.setForeground(tipColor); // 设置标签的字体颜色
             // 颜色对象使用后需要释放资源
@@ -201,15 +203,20 @@ public class RuyiInstallWizard extends Wizard {
             Label label = new Label(container, SWT.WRAP);
             label.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
-            String text = mode == Mode.INSTALL
-                            ? "The Ruyi SDK provides all necessary tools for Ruyi development. \n\n"
-                                            + "Before proceeding, please ensure: \n" + "• 500MB+ free disk space \n"
-                                            + "• Active internet connection \n" + "• Administrator privileges if needed"
-                            : "Your Ruyi installation will be upgraded to the latest version. \n\n" + "Please note: \n"
-                                            + "• The old version will be replaced \n"
-                                            + "• Existing configurations will be preserved \n"
-                                            + "• Active internet connection \n"
-                                            + "• Administrator privileges if needed";
+            String text = mode == Mode.INSTALL ? """
+                The Ruyi SDK provides all necessary tools for Ruyi development.
+
+                Before proceeding, please ensure:
+                • 500MB+ free disk space
+                • Active internet connection
+                • Administrator privileges if needed""" : """
+                Your Ruyi installation will be upgraded to the latest version.
+
+                Please note:
+                • The old version will be replaced
+                • Existing configurations will be preserved
+                • Active internet connection
+                • Administrator privileges if needed""";
 
             label.setText(text);
             setControl(container);
@@ -390,11 +397,19 @@ public class RuyiInstallWizard extends Wizard {
             Label label = new Label(container, SWT.WRAP);
             label.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
-            String text = mode == Mode.INSTALL ? "Ruyi has been successfully installed!\n\n" + "Next steps:\n"
-                            + "• Restart your IDE to apply changes\n" + "• Configure project SDK settings\n"
-                            + "• Visit documentation for tutorials"
-                            : "Ruyi has been upgraded to the latest version.\n\n" + "What's new:\n"
-                                            + "• Improved performance\n" + "• New API features\n" + "• Bug fixes";
+            String text = mode == Mode.INSTALL ? """
+                Ruyi has been successfully installed!
+
+                Next steps:
+                • Restart your IDE to apply changes
+                • Configure project SDK settings
+                • Visit documentation for tutorials""" : """
+                Ruyi has been upgraded to the latest version.
+
+                What's new:
+                • Improved performance
+                • New API features
+                • Bug fixes""";
 
             label.setText(text);
             setControl(container);


### PR DESCRIPTION
Indentations are not my intention.

---

> https://github.com/ruyisdk/ruyisdk-eclipse-plugins/pull/126#pullrequestreview-4065414045

Thanks to @Glavo.

## Summary by Sourcery

Adjust text block formatting and installation wizard copy for Ruyi SDK plugins.

Bug Fixes:
- Correct the user instructions shown in the Ruyi installation wizard.

Enhancements:
- Normalize indentation of Java text blocks used for HTML, JavaScript, and UI copy across plugins for improved readability and consistency.

Documentation:
- Update Java and Checkstyle formatting configurations to relax indentation checks for text blocks and set a non-zero text block indentation level in Eclipse formatter profiles.