### PR TITLE
fix: properly display all exceptions from "IRunnableWithProgress"

### DIFF
--- a/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/wizards/NewProjectWizard.java
+++ b/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/wizards/NewProjectWizard.java
@@ -108,12 +108,19 @@ public class NewProjectWizard extends Wizard implements INewWizard {
         try {
             getContainer().run(true, false, op);
             ToolchainLocator.saveLastUsedToolchainPath(toolchainPath);
-        } catch (Exception e) {
+            return true;
+        } catch (InvocationTargetException e) {
             e.printStackTrace();
-            MessageDialog.openError(getShell(), "create project failed", e.getMessage());
+            final var cause = e.getCause();
+            final var detail = cause != null ? cause.getMessage() : e.getMessage();
+            MessageDialog.openError(getShell(), "Failed to create project", detail == null ? "" : detail);
+            return false;
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            final var detail = e.getMessage();
+            MessageDialog.openError(getShell(), "Project creation aborted", detail == null ? "" : detail);
             return false;
         }
-        return true;
     }
 
     /**

--- a/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/wizards/NewProjectWizard.java
+++ b/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/wizards/NewProjectWizard.java
@@ -29,6 +29,7 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.statushandlers.StatusManager;
 import org.osgi.framework.Bundle;
 import org.ruyisdk.projectcreator.Activator;
 import org.ruyisdk.projectcreator.natures.MyProjectNature;
@@ -110,15 +111,15 @@ public class NewProjectWizard extends Wizard implements INewWizard {
             ToolchainLocator.saveLastUsedToolchainPath(toolchainPath);
             return true;
         } catch (InvocationTargetException e) {
-            e.printStackTrace();
-            final var cause = e.getCause();
-            final var detail = cause != null ? cause.getMessage() : e.getMessage();
-            MessageDialog.openError(getShell(), "Failed to create project", detail == null ? "" : detail);
+            StatusManager.getManager().handle(
+                            new Status(IStatus.ERROR, Activator.PLUGIN_ID, "Failed to create project", e.getCause()),
+                            StatusManager.BLOCK);
             return false;
         } catch (InterruptedException e) {
-            e.printStackTrace();
-            final var detail = e.getMessage();
-            MessageDialog.openError(getShell(), "Project creation aborted", detail == null ? "" : detail);
+            Thread.currentThread().interrupt();
+            StatusManager.getManager().handle(
+                            new Status(IStatus.CANCEL, Activator.PLUGIN_ID, "Project creation aborted", e),
+                            StatusManager.BLOCK);
             return false;
         }
     }

--- a/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/wizards/NewProjectWizard.java
+++ b/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/wizards/NewProjectWizard.java
@@ -113,13 +113,13 @@ public class NewProjectWizard extends Wizard implements INewWizard {
         } catch (InvocationTargetException e) {
             StatusManager.getManager().handle(
                             new Status(IStatus.ERROR, Activator.PLUGIN_ID, "Failed to create project", e.getCause()),
-                            StatusManager.BLOCK);
+                            StatusManager.LOG | StatusManager.BLOCK);
             return false;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             StatusManager.getManager().handle(
                             new Status(IStatus.CANCEL, Activator.PLUGIN_ID, "Project creation aborted", e),
-                            StatusManager.BLOCK);
+                            StatusManager.LOG | StatusManager.BLOCK);
             return false;
         }
     }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
@@ -50,14 +50,14 @@ public class VenvWizard extends Wizard {
             StatusManager.getManager()
                             .handle(new Status(IStatus.ERROR, "org.ruyisdk.venv",
                                             "Failed to update package index; wizard will abort.", e.getCause()),
-                                            StatusManager.BLOCK);
+                                            StatusManager.LOG | StatusManager.BLOCK);
             return;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             StatusManager.getManager()
                             .handle(new Status(IStatus.CANCEL, "org.ruyisdk.venv",
                                             "Package index update was cancelled; wizard will abort.", e),
-                                            StatusManager.BLOCK);
+                                            StatusManager.LOG | StatusManager.BLOCK);
             return;
         }
 
@@ -98,13 +98,13 @@ public class VenvWizard extends Wizard {
             StatusManager.getManager()
                             .handle(new Status(IStatus.ERROR, "org.ruyisdk.venv",
                                             "Unable to complete virtual environment setup.", e.getCause()),
-                                            StatusManager.BLOCK);
+                                            StatusManager.LOG | StatusManager.BLOCK);
             return false;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             StatusManager.getManager().handle(
                             new Status(IStatus.CANCEL, "org.ruyisdk.venv", "Operation was cancelled.", e),
-                            StatusManager.BLOCK);
+                            StatusManager.LOG | StatusManager.BLOCK);
             return false;
         }
     }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
@@ -1,20 +1,12 @@
 package org.ruyisdk.venv.views;
 
 import java.lang.reflect.InvocationTargetException;
-import org.eclipse.jface.dialogs.Dialog;
-import org.eclipse.jface.dialogs.IDialogConstants;
-import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.wizard.Wizard;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Shell;
-import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.statushandlers.StatusManager;
 import org.ruyisdk.venv.viewmodel.VenvWizardViewModel;
 
 /**
@@ -55,13 +47,17 @@ public class VenvWizard extends Wizard {
                 monitor.worked(100);
             });
         } catch (InvocationTargetException e) {
-            final var cause = e.getCause();
-            final var detail = cause != null ? cause.getMessage() : e.getMessage();
-            displaySelectableError("Package Index Update Failed", "Failed to update package index; wizard will abort.",
-                            detail == null ? "" : detail);
+            StatusManager.getManager()
+                            .handle(new Status(IStatus.ERROR, "org.ruyisdk.venv",
+                                            "Failed to update package index; wizard will abort.", e.getCause()),
+                                            StatusManager.BLOCK);
             return;
         } catch (InterruptedException e) {
-            displaySelectableError("Package Index Update Cancelled", "Update was cancelled; wizard will abort.", "");
+            Thread.currentThread().interrupt();
+            StatusManager.getManager()
+                            .handle(new Status(IStatus.CANCEL, "org.ruyisdk.venv",
+                                            "Package index update was cancelled; wizard will abort.", e),
+                                            StatusManager.BLOCK);
             return;
         }
 
@@ -99,59 +95,15 @@ public class VenvWizard extends Wizard {
             getContainer().run(true, true, operation);
             return true;
         } catch (InvocationTargetException e) {
-            final var cause = e.getCause();
-            final var detail = cause != null ? cause.getMessage() : e.getMessage();
-            final var msg = "Unable to complete virtual environment setup — see details below.";
-            displaySelectableError("Virtual Environment Setup Failed", msg, detail == null ? "" : detail);
+            StatusManager.getManager().handle(new Status(IStatus.ERROR, "org.ruyisdk.venv",
+                            "Unable to complete virtual environment setup.", e.getCause()), StatusManager.BLOCK);
             return false;
         } catch (InterruptedException e) {
-            MessageDialog.openError(getShell(), "Cancelled", "Operation was cancelled");
+            Thread.currentThread().interrupt();
+            StatusManager.getManager().handle(
+                            new Status(IStatus.CANCEL, "org.ruyisdk.venv", "Operation was cancelled.", e),
+                            StatusManager.BLOCK);
             return false;
         }
-    }
-
-    private void displaySelectableError(String title, String message, String details) {
-        final var dialog = new Dialog(getShell()) {
-            @Override
-            protected Control createDialogArea(Composite parent) {
-                final var composite = (Composite) super.createDialogArea(parent);
-                composite.setLayout(new GridLayout(1, false));
-
-                final var msgText = new Text(composite, SWT.BORDER | SWT.READ_ONLY | SWT.WRAP | SWT.V_SCROLL);
-                {
-                    var gridData = new GridData(GridData.FILL_HORIZONTAL);
-                    gridData.heightHint = 80;
-                    msgText.setLayoutData(gridData);
-                }
-                msgText.setText(message == null ? "" : message);
-
-                final var detailsLabel = new Label(composite, SWT.NONE);
-                detailsLabel.setText("Details:");
-
-                final var detailsText = new Text(composite,
-                                SWT.BORDER | SWT.READ_ONLY | SWT.MULTI | SWT.V_SCROLL | SWT.H_SCROLL);
-                detailsText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL | GridData.FILL_VERTICAL));
-                detailsText.setText(details == null ? "" : details);
-
-                return composite;
-            }
-
-            @Override
-            protected void configureShell(Shell newShell) {
-                super.configureShell(newShell);
-                newShell.setText(title == null ? "Error" : title);
-            }
-
-            @Override
-            protected boolean isResizable() {
-                return true;
-            }
-
-            @Override
-            protected void createButtonsForButtonBar(Composite parent) {
-                createButton(parent, IDialogConstants.OK_ID, IDialogConstants.OK_LABEL, true);
-            }
-        };
-        dialog.open();
     }
 }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
@@ -95,8 +95,10 @@ public class VenvWizard extends Wizard {
             getContainer().run(true, true, operation);
             return true;
         } catch (InvocationTargetException e) {
-            StatusManager.getManager().handle(new Status(IStatus.ERROR, "org.ruyisdk.venv",
-                            "Unable to complete virtual environment setup.", e.getCause()), StatusManager.BLOCK);
+            StatusManager.getManager()
+                            .handle(new Status(IStatus.ERROR, "org.ruyisdk.venv",
+                                            "Unable to complete virtual environment setup.", e.getCause()),
+                                            StatusManager.BLOCK);
             return false;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();


### PR DESCRIPTION
Be consistent with other places where we catch these two exceptions:

- InvocationTargetException
- InterruptedException

.

## Summary by Sourcery

Standardize error and cancellation handling in wizards that run IRunnableWithProgress operations.

Bug Fixes:
- Ensure InvocationTargetException and InterruptedException from long-running wizard operations are reported via Eclipse StatusManager so all exception details are visible.
- Properly restore interrupted status and treat cancelled IRunnableWithProgress operations as user cancellations rather than generic failures.

Enhancements:
- Replace custom error dialogs and generic exception handling in wizard flows with consistent StatusManager-based status reporting for failures and cancellations.