### PR TITLE
refactor(ruyicli): remove redundant "execute" method from RuyiCliRequest

### DIFF
--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
@@ -260,8 +260,9 @@ public class RuyiCli {
     /** Lists available news items using the ruyi CLI. */
     public static List<NewsListItemInfo> listNewsItems(boolean onlyUnread) {
         try {
-            final var result = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(true)
-                            .news().list(onlyUnread).execute();
+            final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(true)
+                            .news().list(onlyUnread).end().build();
+            final var result = request.execute();
             return parseNewsListFromString(result.getOutput());
         } catch (Exception e) {
             // ignore

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliRequest.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliRequest.java
@@ -371,16 +371,6 @@ public class RuyiCliRequest {
             }
             return parent;
         }
-
-        /**
-         * Executes the command.
-         *
-         * @return execution result
-         * @throws RuyiCliException if the command fails
-         */
-        public RuyiExecResult execute() throws RuyiCliException {
-            return end().build().execute();
-        }
     }
 
     /**
@@ -470,16 +460,6 @@ public class RuyiCliRequest {
             parent.args(subArgs);
             return parent;
         }
-
-        /**
-         * Executes the command.
-         *
-         * @return execution result
-         * @throws RuyiCliException if the command fails
-         */
-        public RuyiExecResult execute() throws RuyiCliException {
-            return end().build().execute();
-        }
     }
 
     /**
@@ -560,16 +540,6 @@ public class RuyiCliRequest {
             parent.args(atoms);
             return parent;
         }
-
-        /**
-         * Executes the command.
-         *
-         * @return execution result
-         * @throws RuyiCliException if the command fails
-         */
-        public RuyiExecResult execute() throws RuyiCliException {
-            return end().build().execute();
-        }
     }
 
     /**
@@ -619,16 +589,6 @@ public class RuyiCliRequest {
                 parent.args("-y");
             }
             return parent;
-        }
-
-        /**
-         * Executes the command.
-         *
-         * @return execution result
-         * @throws RuyiCliException if the command fails
-         */
-        public RuyiExecResult execute() throws RuyiCliException {
-            return end().build().execute();
         }
     }
 
@@ -734,16 +694,6 @@ public class RuyiCliRequest {
             }
             return parent;
         }
-
-        /**
-         * Executes the command.
-         *
-         * @return execution result
-         * @throws RuyiCliException if the command fails
-         */
-        public RuyiExecResult execute() throws RuyiCliException {
-            return end().build().execute();
-        }
     }
 
     /**
@@ -829,16 +779,6 @@ public class RuyiCliRequest {
             }
             return parent;
         }
-
-        /**
-         * Executes the command.
-         *
-         * @return execution result
-         * @throws RuyiCliException if the command fails
-         */
-        public RuyiExecResult execute() throws RuyiCliException {
-            return end().build().execute();
-        }
     }
 
     /**
@@ -915,16 +855,6 @@ public class RuyiCliRequest {
             }
             return parent;
         }
-
-        /**
-         * Executes the command.
-         *
-         * @return execution result
-         * @throws RuyiCliException if the command fails
-         */
-        public RuyiExecResult execute() throws RuyiCliException {
-            return end().build().execute();
-        }
     }
 
     /**
@@ -946,16 +876,6 @@ public class RuyiCliRequest {
          */
         public Builder end() {
             return parent;
-        }
-
-        /**
-         * Executes the command.
-         *
-         * @return execution result
-         * @throws RuyiCliException if the command fails
-         */
-        public RuyiExecResult execute() throws RuyiCliException {
-            return end().build().execute();
         }
     }
 
@@ -997,16 +917,6 @@ public class RuyiCliRequest {
                 parent.args(subArgs);
             }
             return parent;
-        }
-
-        /**
-         * Executes the command.
-         *
-         * @return execution result
-         * @throws RuyiCliException if the command fails
-         */
-        public RuyiExecResult execute() throws RuyiCliException {
-            return end().build().execute();
         }
     }
 }


### PR DESCRIPTION
Follows #118.

## Summary by Sourcery

Refine Ruyi CLI request handling by removing redundant execute helpers from nested builder classes and updating news listing to build and execute the request explicitly.

Enhancements:
- Remove duplicate execute convenience methods from RuyiCliRequest nested builders to simplify the builder API.
- Adjust RuyiCli news listing to construct a request via the builder and invoke execute on the built request object.