### PR TITLE
Cleanup

### DIFF
--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/basedir/XdgDirs.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/basedir/XdgDirs.java
@@ -62,7 +62,6 @@ public class XdgDirs {
      * @param defaultRelativePath the default path relative to user home (e.g. ".config")
      * @param appName the application name for final subdirectory
      * @return fully resolved directory path
-     * @throws NullPointerException if appName is null
      */
     private static Path getXdgDir(String xdgEnvVar, String defaultRelativePath, String appName) {
         // 1. Check environment variable (e.g. $XDG_CONFIG_HOME)

--- a/plugins/org.ruyisdk.devices/src/org/ruyisdk/devices/services/DeviceService.java
+++ b/plugins/org.ruyisdk.devices/src/org/ruyisdk/devices/services/DeviceService.java
@@ -3,7 +3,6 @@ package org.ruyisdk.devices.services;
 import java.util.ArrayList;
 import java.util.List;
 import org.ruyisdk.devices.model.Device;
-import org.ruyisdk.devices.services.PropertiesService;
 
 /**
  * Service for managing device configurations.

--- a/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/Activator.java
+++ b/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/Activator.java
@@ -26,6 +26,7 @@ public class Activator extends AbstractUIPlugin {
      * @param context bundle context
      * @throws Exception if start fails
      */
+    @Override
     public void start(BundleContext context) throws Exception {
         super.start(context);
         plugin = this;
@@ -71,6 +72,7 @@ public class Activator extends AbstractUIPlugin {
      * @param context bundle context
      * @throws Exception if stop fails
      */
+    @Override
     public void stop(BundleContext context) throws Exception {
         if (buildListener != null) {
             ResourcesPlugin.getWorkspace().removeResourceChangeListener(buildListener);

--- a/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
+++ b/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.ruyisdk.ruyi,
+ org.ruyisdk.core,
  org.ruyisdk.packages,
  wrapped.junit.junit,
  wrapped.org.hamcrest.hamcrest-core

--- a/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/core/basedir/XdgDirsTest.java
+++ b/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/core/basedir/XdgDirsTest.java
@@ -1,6 +1,9 @@
 package org.ruyisdk.core.basedir;
 
 import java.nio.file.Path;
+
+import org.junit.Ignore;
+import org.junit.Test;
 import org.ruyisdk.core.config.Constants;
 
 /**
@@ -10,14 +13,11 @@ import org.ruyisdk.core.config.Constants;
  * This class shows how to retrieve and use the standard XDG directories (config, cache, data, and
  * state) for application storage following the XDG Base Directory Specification.
  */
-public class TextXdgDir {
+public class XdgDirsTest {
 
-    /**
-     * Main entry point that demonstrates XDG directory usage.
-     *
-     * @param args command-line arguments (not used)
-     */
-    public static void main(String[] args) {
+    @Ignore("Demo test: depends on local environment")
+    @Test
+    public void testXdgDirs() {
         // Get application name from constants
         String appName = Constants.AppInfo.AppDir;
 
@@ -39,5 +39,4 @@ public class TextXdgDir {
         // dataDir.toFile().mkdirs();
         // stateDir.toFile().mkdir();
     }
-
 }

--- a/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/services/RuyiCliSmokeTest.java
+++ b/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/services/RuyiCliSmokeTest.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.ruyisdk.ruyi.services.RuyiCli;
 
 public class RuyiCliSmokeTest {
 


### PR DESCRIPTION
Commits:

- 52e73f6 refactor: mark overridden methods with the proper annotation
- 5de7914 refactor: remove unused imports
- d69df40 test(core): mv TextXdgDir to XdgDirsTest and treat it as a skipped test
- bead1b8 refactor(core): clean undeclared exception in Javadoc

No squashing.

## Summary by Sourcery

Clean up core and test modules by converting an XDG directory demo into a skipped test, tightening annotations, and removing obsolete declarations and imports.

Enhancements:
- Mark plugin lifecycle methods in Activator with the @Override annotation for better correctness and tooling support.
- Remove an inaccurate exception declaration from XdgDirs Javadoc to align documentation with behavior.

Tests:
- Move the XDG directory demo into the test suite as XdgDirsTest and mark it as an ignored environment-dependent test.
- Remove an unused import from RuyiCliSmokeTest to keep tests minimal and maintainable.