### PR TITLE
Cleanup

### DIFF
--- a/plugins/org.ruyisdk.core/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.core/META-INF/MANIFEST.MF
@@ -4,19 +4,21 @@ Bundle-Name: Core
 Bundle-SymbolicName: org.ruyisdk.core;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.core
 Bundle-Activator: org.ruyisdk.core.Activator
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-21
-Export-Package: org.ruyisdk.core.basedir,
+Bundle-ClassPath: 
+ .,
+ icons/
+Require-Bundle: 
+ org.eclipse.core.runtime,
+ org.eclipse.jface,
+ org.eclipse.ui.console,
+ org.eclipse.ui.workbench
+Export-Package: 
+ org.ruyisdk.core.basedir,
  org.ruyisdk.core.config,
  org.ruyisdk.core.console,
  org.ruyisdk.core.ruyi.model,
  org.ruyisdk.core.util
-Require-Bundle: org.eclipse.ui,
- org.eclipse.jface,
- org.eclipse.ui.console,
- org.eclipse.core.runtime,
- org.eclipse.ui.workbench
-Bundle-ClassPath: .,
- icons/

--- a/plugins/org.ruyisdk.devices/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.devices/META-INF/MANIFEST.MF
@@ -4,13 +4,15 @@ Bundle-Name: Devices
 Bundle-SymbolicName: org.ruyisdk.devices;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS
-Bundle-Activator: org.ruyisdk.devices.Activator
-Bundle-ClassPath: .
-Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime,
- org.eclipse.jface,
- org.ruyisdk.core,
- com.google.gson
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.devices
+Bundle-Activator: org.ruyisdk.devices.Activator
 Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: 
+ .
+Require-Bundle: 
+ org.eclipse.core.runtime,
+ org.eclipse.jface,
+ org.eclipse.ui,
+ org.ruyisdk.core,
+ com.google.gson

--- a/plugins/org.ruyisdk.intro/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.intro/META-INF/MANIFEST.MF
@@ -4,16 +4,20 @@ Bundle-Name: RuyiSDK Intro
 Bundle-SymbolicName: org.ruyisdk.intro;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS
-Export-Package: org.ruyisdk.intro
-Bundle-Activator: org.ruyisdk.intro.Activator
-Require-Bundle: org.eclipse.ui,
- org.ruyisdk.core,
- org.eclipse.core.runtime,
- org.eclipse.swt,
- org.eclipse.ui.intro
-Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.intro
-Bundle-ClassPath: .,
+Bundle-Activator: org.ruyisdk.intro.Activator
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: 
+ .,
  html/,
  icons/
+Require-Bundle: 
+ org.eclipse.core.commands,
+ org.eclipse.core.runtime,
+ org.eclipse.swt,
+ org.eclipse.ui,
+ org.eclipse.ui.intro,
+ org.ruyisdk.core
+Export-Package: 
+ org.ruyisdk.intro

--- a/plugins/org.ruyisdk.news/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.news/META-INF/MANIFEST.MF
@@ -4,21 +4,24 @@ Bundle-Name: News
 Bundle-SymbolicName: org.ruyisdk.news;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.news
 Bundle-Activator: org.ruyisdk.news.Activator
-Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.eclipse.core.runtime,
+Bundle-ClassPath: 
+ .
+Require-Bundle: 
  org.eclipse.core.databinding,
- org.eclipse.ui,
- org.eclipse.swt,
- org.eclipse.jface.databinding,
  org.eclipse.core.databinding.beans,
  org.eclipse.core.databinding.property,
- org.ruyisdk.ruyi,
- org.ruyisdk.core
-Import-Package: org.commonmark,
+ org.eclipse.core.runtime,
+ org.eclipse.jface.databinding,
+ org.eclipse.swt,
+ org.eclipse.ui,
+ org.ruyisdk.core,
+ org.ruyisdk.ruyi
+Import-Package: 
+ org.commonmark,
  org.commonmark.ext.gfm.tables,
  org.commonmark.node,
  org.commonmark.parser,

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsFetchService.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsFetchService.java
@@ -17,69 +17,58 @@ public class NewsFetchService {
     public void fetchNewsDetailsAsync(String id, Consumer<String> callback, Consumer<String> errorCallback) {
         final var fetchJob = Job.create("Fetching News Details", monitor -> {
             LOGGER.logInfo("Fetching news details: id=" + id);
-            String result = "";
             try {
-                RuyiCli.NewsReadResult read = RuyiCli.readNewsItem(id);
-                if (read == null) {
+                final var result = RuyiCli.readNewsItem(id);
+                if (result == null) {
                     throw new Exception("timed out");
                 }
-                result = read.getContent() == null ? "" : read.getContent();
-                LOGGER.logInfo("Fetched news details: id=" + id + ", length=" + result.length());
+                final var content = result.getContent() == null ? "" : result.getContent();
+                LOGGER.logInfo("Fetched news details: id=" + id + ", length=" + content.length());
+                callback.accept(content);
+                return Status.OK_STATUS;
             } catch (Exception e) {
                 LOGGER.logError("Failed to fetch news details: id=" + id, e);
                 final var msg = e.getMessage() == null ? "Failed to read news details" : e.getMessage();
                 if (errorCallback != null) {
                     errorCallback.accept(msg);
                 }
-                return Status.CANCEL_STATUS;
+                return Status.CANCEL_STATUS; // avoid Eclipse error dialog
             }
-            callback.accept(result);
-            return Status.OK_STATUS;
         });
         fetchJob.schedule();
     }
 
     /** Fetches the news list asynchronously. */
     public void fetchNewsListAsync(Consumer<List<NewsItem>> callback) {
-        fetchNewsListAsync(callback, null);
-    }
-
-    /** Fetches the news list asynchronously with an optional error callback. */
-    public void fetchNewsListAsync(Consumer<List<NewsItem>> callback, Consumer<String> errorCallback) {
         final var fetchJob = Job.create("Fetching News List", monitor -> {
             LOGGER.logInfo("Fetching news list");
-            var newsList = new ArrayList<NewsItem>();
             try {
+                final var newsList = new ArrayList<NewsItem>();
                 int unreadCount = 0;
-                for (var item : RuyiCli.listNewsItems(false)) {
+                for (final var item : RuyiCli.listNewsItems(false)) {
                     if (item == null) {
                         continue;
                     }
 
-                    final Boolean isRead = item.isRead();
-                    boolean unread = isRead == null || !isRead.booleanValue();
+                    final var isRead = item.isRead();
+                    final var unread = isRead == null || !isRead.booleanValue();
                     if (unread) {
                         unreadCount++;
                     }
 
-                    final Integer ordObj = item.getOrd();
-                    final int ord = ordObj == null ? -1 : ordObj.intValue();
-                    final String title = item.getTitle() == null ? "" : item.getTitle();
-                    final String id = item.getId() == null ? "" : item.getId();
+                    final var ordObj = item.getOrd();
+                    final var ord = ordObj == null ? -1 : ordObj.intValue();
+                    final var title = item.getTitle() == null ? "" : item.getTitle();
+                    final var id = item.getId() == null ? "" : item.getId();
                     newsList.add(new NewsItem(ord, title, id, unread));
                 }
                 LOGGER.logInfo("Fetched news list: count=" + newsList.size() + ", unread=" + unreadCount);
+                callback.accept(newsList);
+                return Status.OK_STATUS;
             } catch (Exception e) {
-                String msg = e.getMessage() == null ? "Failed to list news" : e.getMessage();
-                LOGGER.logError("Failed to fetch news list", e);
-                if (errorCallback != null) {
-                    errorCallback.accept(msg);
-                }
+                callback.accept(null);
+                return Status.error("Failed to fetch news list", e);
             }
-
-            callback.accept(newsList);
-
-            return Status.OK_STATUS;
         });
         fetchJob.schedule();
     }

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsFetchService.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsFetchService.java
@@ -1,6 +1,7 @@
 package org.ruyisdk.news.model;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import org.eclipse.core.runtime.Status;
@@ -63,6 +64,7 @@ public class NewsFetchService {
                     newsList.add(new NewsItem(ord, title, id, unread));
                 }
                 LOGGER.logInfo("Fetched news list: count=" + newsList.size() + ", unread=" + unreadCount);
+                newsList.sort(Comparator.comparingInt(NewsItem::getOrd).reversed());
                 callback.accept(newsList);
                 return Status.OK_STATUS;
             } catch (Exception e) {

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/viewmodel/NewsListViewModel.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/viewmodel/NewsListViewModel.java
@@ -27,6 +27,7 @@ public class NewsListViewModel {
         private static final String notUpdated = "Not Updated, yet";
         private static final String updating = "Updating...";
         private static final String updatedTemplate = "Last Updated on %s";
+        private static final String updateFailed = "Failed to update news list";
     }
 
     /**
@@ -114,14 +115,20 @@ public class NewsListViewModel {
         setInfoText(UpdatingState.updating);
 
         service.fetchNewsListAsync(result -> {
-            final var sorted = new ArrayList<NewsItem>(result);
-            sorted.sort(Comparator.comparingInt(NewsItem::getOrd).reversed());
             observableNewsList.getRealm().asyncExec(() -> {
                 observableNewsList.clear();
-                observableNewsList.addAll(sorted);
             });
-            setInfoText(String.format(UpdatingState.updatedTemplate,
-                            LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))));
+            if (result != null) {
+                final var sorted = new ArrayList<NewsItem>(result);
+                sorted.sort(Comparator.comparingInt(NewsItem::getOrd).reversed());
+                observableNewsList.getRealm().asyncExec(() -> {
+                    observableNewsList.addAll(sorted);
+                });
+                setInfoText(String.format(UpdatingState.updatedTemplate,
+                                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))));
+            } else {
+                setInfoText(UpdatingState.updateFailed);
+            }
             setFetching(false);
         });
     }

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/viewmodel/NewsListViewModel.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/viewmodel/NewsListViewModel.java
@@ -5,7 +5,6 @@ import java.beans.PropertyChangeSupport;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Comparator;
 import org.eclipse.core.databinding.observable.list.IObservableList;
 import org.eclipse.core.databinding.observable.list.WritableList;
 import org.ruyisdk.news.model.NewsFetchService;
@@ -117,18 +116,14 @@ public class NewsListViewModel {
         service.fetchNewsListAsync(result -> {
             observableNewsList.getRealm().asyncExec(() -> {
                 observableNewsList.clear();
+                if (result != null) {
+                    observableNewsList.addAll(result);
+                    setInfoText(String.format(UpdatingState.updatedTemplate,
+                                    LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))));
+                } else {
+                    setInfoText(UpdatingState.updateFailed);
+                }
             });
-            if (result != null) {
-                final var sorted = new ArrayList<NewsItem>(result);
-                sorted.sort(Comparator.comparingInt(NewsItem::getOrd).reversed());
-                observableNewsList.getRealm().asyncExec(() -> {
-                    observableNewsList.addAll(sorted);
-                });
-                setInfoText(String.format(UpdatingState.updatedTemplate,
-                                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))));
-            } else {
-                setInfoText(UpdatingState.updateFailed);
-            }
             setFetching(false);
         });
     }

--- a/plugins/org.ruyisdk.packages/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.packages/META-INF/MANIFEST.MF
@@ -2,26 +2,27 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Ruyi SDK Packages
 Bundle-SymbolicName: org.ruyisdk.packages;singleton:=true
-Automatic-Module-Name: org.ruyisdk.packages
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS
+Bundle-RequiredExecutionEnvironment: JavaSE-21
+Automatic-Module-Name: org.ruyisdk.packages
 Bundle-Activator: org.ruyisdk.packages.Activator
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: 
+ .
 Require-Bundle: 
- org.eclipse.ui,
- org.eclipse.ui.workbench,
+ org.eclipse.core.runtime,
+ org.eclipse.jdt.annotation,
  org.eclipse.jface,
  org.eclipse.swt,
- org.eclipse.core.runtime,
+ org.eclipse.ui,
  org.eclipse.ui.console,
- org.eclipse.jdt.annotation,
+ org.eclipse.ui.workbench,
  org.ruyisdk.core,
  org.ruyisdk.ruyi,
  org.glassfish.javax.json
-Bundle-ClassPath: .
-Bundle-RequiredExecutionEnvironment: JavaSE-21
-Export-Package: org.ruyisdk.packages,
+Export-Package: 
+ org.ruyisdk.packages,
  org.ruyisdk.packages.model,
  org.ruyisdk.packages.service,
  org.ruyisdk.packages.viewmodel
-
-

--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/PackageExplorerViewModel.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/PackageExplorerViewModel.java
@@ -4,6 +4,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.annotation.Nullable;
 import org.ruyisdk.packages.model.DeviceList;
@@ -199,7 +200,7 @@ public class PackageExplorerViewModel extends BaseViewModel {
                         onFinished.run();
                     }
                 });
-                return;
+                return Status.CANCEL_STATUS;
             }
 
             try {
@@ -212,7 +213,7 @@ public class PackageExplorerViewModel extends BaseViewModel {
                             onFinished.run();
                         }
                     });
-                    return;
+                    return Status.CANCEL_STATUS;
                 }
 
                 uiExecutor.accept(() -> {
@@ -225,6 +226,8 @@ public class PackageExplorerViewModel extends BaseViewModel {
                         }
                     }
                 });
+
+                return Status.OK_STATUS;
             } catch (Exception e) {
                 final var msg = e.getMessage();
                 uiExecutor.accept(() -> {
@@ -234,10 +237,9 @@ public class PackageExplorerViewModel extends BaseViewModel {
                         onFinished.run();
                     }
                 });
+                return Status.CANCEL_STATUS; // avoid Eclipse error dialog
             }
         });
-        job.setUser(true);
-        job.setPriority(Job.LONG);
         job.schedule();
     }
 
@@ -249,12 +251,13 @@ public class PackageExplorerViewModel extends BaseViewModel {
                     setDevices(fetched);
                     setDeviceListErrorMessage(null);
                 });
+                return Status.OK_STATUS;
             } catch (Exception e) {
                 final var msg = e.getMessage();
                 uiExecutor.accept(() -> setDeviceListErrorMessage(msg));
+                return Status.CANCEL_STATUS; // avoid Eclipse error dialog
             }
         });
-        job.setSystem(true);
         job.schedule();
     }
 

--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/PackageOperationViewModel.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/PackageOperationViewModel.java
@@ -96,7 +96,6 @@ public class PackageOperationViewModel extends BaseViewModel {
                 }
             }, () -> cancelled);
         });
-        job.setSystem(true);
         job.schedule();
     }
 

--- a/plugins/org.ruyisdk.projectcreator/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.projectcreator/META-INF/MANIFEST.MF
@@ -2,21 +2,24 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Project Creator
 Bundle-SymbolicName: org.ruyisdk.projectcreator;singleton:=true
-Automatic-Module-Name: org.ruyisdk.projectcreator
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS
+Bundle-RequiredExecutionEnvironment: JavaSE-21
+Automatic-Module-Name: org.ruyisdk.projectcreator
 Bundle-Activator: org.ruyisdk.projectcreator.Activator
-Bundle-ClassPath: .
-Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime,
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: 
+ .
+Require-Bundle: 
  org.eclipse.core.resources,
- org.eclipse.ui.ide,
- org.eclipse.jface,
+ org.eclipse.core.runtime,
  org.eclipse.debug.ui,
+ org.eclipse.jface,
+ org.eclipse.ui,
+ org.eclipse.ui.ide,
+ org.ruyisdk.core,
  org.ruyisdk.packages,
  org.ruyisdk.ruyi,
- org.ruyisdk.core,
  org.glassfish.javax.json
-Export-Package: org.ruyisdk.projectcreator.builder
-Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-21
+Export-Package: 
+ org.ruyisdk.projectcreator.builder

--- a/plugins/org.ruyisdk.promotion/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.promotion/META-INF/MANIFEST.MF
@@ -4,11 +4,13 @@ Bundle-Name: Promotion
 Bundle-SymbolicName: org.ruyisdk.promotion;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.promotion
 Bundle-Activator: org.ruyisdk.promotion.Activator
-Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.eclipse.core.runtime,
+Bundle-ClassPath: 
+ .
+Require-Bundle: 
+ org.eclipse.core.runtime,
  org.eclipse.swt,
  org.eclipse.ui

--- a/plugins/org.ruyisdk.ruyi/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.ruyi/META-INF/MANIFEST.MF
@@ -4,21 +4,24 @@ Bundle-Name: Ruyi
 Bundle-SymbolicName: org.ruyisdk.ruyi;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS
+Bundle-RequiredExecutionEnvironment: JavaSE-21
+Automatic-Module-Name: org.ruyisdk.ruyi
 Bundle-Activator: org.ruyisdk.ruyi.Activator
-Bundle-ClassPath: .
-Require-Bundle: org.eclipse.core.runtime,
- org.ruyisdk.core,
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: 
+ .
+Require-Bundle: 
  org.eclipse.core.resources,
- org.eclipse.ui,
+ org.eclipse.core.runtime,
+ org.eclipse.equinox.app,
  org.eclipse.jface,
  org.eclipse.tm.terminal.view.core,
- org.eclipse.equinox.app,
- json,
- com.google.gson
-Automatic-Module-Name: org.ruyisdk.ruyi
-Bundle-RequiredExecutionEnvironment: JavaSE-21
-Bundle-ActivationPolicy: lazy
-Export-Package: org.ruyisdk.ruyi.util,
- org.ruyisdk.ruyi.services,
+ org.eclipse.ui,
+ org.ruyisdk.core,
+ com.google.gson,
+ json
+Export-Package: 
  org.ruyisdk.ruyi.core.workspace,
- org.ruyisdk.ruyi.model
+ org.ruyisdk.ruyi.services,
+ org.ruyisdk.ruyi.model,
+ org.ruyisdk.ruyi.util

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/Activator.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/Activator.java
@@ -52,9 +52,6 @@ public class Activator extends AbstractUIPlugin {
      */
     @Override
     public void stop(BundleContext context) throws Exception {
-        // ruyiCore.shutdown();
-        // plugin = null;
-        // super.stop(context);
         try {
             // 1. 停止核心服务
             if (ruyiCore != null) {
@@ -64,8 +61,6 @@ public class Activator extends AbstractUIPlugin {
             cleanupResources();
 
             LOGGER.logInfo("Ruyi plugin deactivated");
-        } catch (Exception e) {
-            LOGGER.logError("Error during plugin deactivation", e);
         } finally {
             WorkspaceProjectsMonitor.getInstance().dispose();
             plugin = null;

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/workspace/WorkspaceProjectsMonitor.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/workspace/WorkspaceProjectsMonitor.java
@@ -101,10 +101,6 @@ public final class WorkspaceProjectsMonitor {
 
     private volatile boolean installed = false;
 
-    private WorkspaceProjectsMonitor() {
-        debounceJob.setSystem(true);
-    }
-
     /**
      * Adds a listener for workspace projects events.
      *

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/handlers/FlashDeviceProvisionHandler.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/handlers/FlashDeviceProvisionHandler.java
@@ -22,13 +22,14 @@ public class FlashDeviceProvisionHandler extends AbstractHandler {
             LOGGER.logInfo("Flash device (device provision) command launched in built-in terminal");
             return null;
         } catch (Exception e) {
-            LOGGER.logError("Failed to launch flash device (device provision) command", e);
+            final var msg = "Failed to launch flash device (device provision) command";
+            LOGGER.logError(msg, e);
             final var shell = HandlerUtil.getActiveShell(event);
             if (shell != null) {
-                MessageDialog.openError(shell, "Failed to launch flash device (device provision)",
+                MessageDialog.openError(shell, msg,
                                 "Unable to start built-in terminal for 'ruyi device provision'.\n\n" + e.getMessage());
             }
-            throw new ExecutionException("Failed to launch flash device (device provision)", e);
+            throw new ExecutionException(msg, e);
         }
     }
 }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
@@ -436,14 +436,6 @@ public class RuyiCli {
         }
     }
 
-    private static String requireInstallPath() throws IOException {
-        final var install = requireInstallPathResult();
-        if (install == null || install.isBlank()) {
-            throw new IOException("ruyi executable not found in configured or default install path");
-        }
-        return install;
-    }
-
     /**
      * Runs a command with experimental environment and optional working directory.
      *
@@ -467,7 +459,11 @@ public class RuyiCli {
      * @throws IOException if no executable can be resolved
      */
     public static String getResolvedExecutablePath() throws IOException {
-        return requireInstallPath() + File.separator + "ruyi";
+        final var install = requireInstallPathResult();
+        if (install == null || install.isBlank()) {
+            throw new IOException("ruyi executable not found in configured or default install path");
+        }
+        return install + File.separator + "ruyi";
     }
 
     /**

--- a/plugins/org.ruyisdk.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.ui/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: Ui
 Bundle-SymbolicName: org.ruyisdk.ui
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS
-Automatic-Module-Name: org.ruyisdk.ui
-Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-21
+Automatic-Module-Name: org.ruyisdk.ui
+Bundle-ClassPath: 
+ .

--- a/plugins/org.ruyisdk.venv/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.venv/META-INF/MANIFEST.MF
@@ -4,20 +4,22 @@ Bundle-Name: Venv
 Bundle-SymbolicName: org.ruyisdk.venv;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.venv
 Bundle-Activator: org.ruyisdk.venv.Activator
-Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.eclipse.core.runtime,
-  org.eclipse.core.resources,
-  org.eclipse.core.databinding,
-  org.eclipse.ui,
-  org.eclipse.swt,
-  org.eclipse.jface.databinding,
-  org.eclipse.core.databinding.beans,
-  org.eclipse.core.databinding.property,
-  org.ruyisdk.ruyi,
-  org.ruyisdk.core,
-  org.eclipse.cdt.core,
-  org.eclipse.cdt.managedbuilder.core
+Bundle-ClassPath: 
+ .
+Require-Bundle: 
+ org.eclipse.cdt.core,
+ org.eclipse.cdt.managedbuilder.core,
+ org.eclipse.core.resources,
+ org.eclipse.core.runtime,
+ org.eclipse.core.databinding,
+ org.eclipse.core.databinding.beans,
+ org.eclipse.core.databinding.property,
+ org.eclipse.jface.databinding,
+ org.eclipse.swt,
+ org.eclipse.ui,
+ org.ruyisdk.core,
+ org.ruyisdk.ruyi

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvDetectionService.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvDetectionService.java
@@ -201,27 +201,24 @@ public class VenvDetectionService {
      * callback.
      */
     public void detectProjectVenvsAsync(List<String> projectRootPaths, Consumer<List<Venv>> callback) {
-        final var detectJob = new Job("Detecting virtual environments") {
-            @Override
-            protected IStatus run(IProgressMonitor monitor) {
-                LOGGER.logInfo("Detecting project venvs (async)");
+        final var detectJob = Job.create("Detecting virtual environments", monitor -> {
+            LOGGER.logInfo("Detecting project venvs (async)");
 
-                List<Venv> result;
-                try {
-                    final var projectPaths = toPathList(projectRootPaths);
-                    result = detectProjectVenvs(projectPaths);
-                } catch (Exception e) {
-                    LOGGER.logError("Failed to detect project venvs", e);
-                    result = List.of();
-                }
-                LOGGER.logInfo("Project venv detection finished: count=" + result.size());
-
-                if (callback != null) {
-                    callback.accept(result);
-                }
-                return Status.OK_STATUS;
+            List<Venv> result;
+            try {
+                final var projectPaths = toPathList(projectRootPaths);
+                result = detectProjectVenvs(projectPaths);
+            } catch (Exception e) {
+                LOGGER.logError("Failed to detect project venvs", e);
+                result = List.of();
             }
-        };
+            LOGGER.logInfo("Project venv detection finished: count=" + result.size());
+
+            if (callback != null) {
+                callback.accept(result);
+            }
+            return Status.OK_STATUS;
+        });
         detectJob.schedule();
     }
 

--- a/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
+++ b/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
@@ -2,12 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Ruyi Tests
 Bundle-SymbolicName: org.ruyisdk.ruyi.tests
-Automatic-Module-Name: org.ruyisdk.ruyi.tests
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.ruyisdk.ruyi,
+Automatic-Module-Name: org.ruyisdk.ruyi.tests
+Require-Bundle: 
+ wrapped.junit.junit,
  org.ruyisdk.core,
  org.ruyisdk.packages,
- wrapped.junit.junit,
+ org.ruyisdk.ruyi,
  wrapped.org.hamcrest.hamcrest-core


### PR DESCRIPTION
Commits:

- 863bbcd refactor: simpler usage of Jobs; news: remove unused overload method
- c6a3786 fix(ruyi): do not catch any exceptions in "Activator.stop()"
- 1c6a8a1 feat(ruyi): do not repeat error message
- c59cb1b refactor: remove one-time use extracted method and inline its logic back
- 184e6fb refactor: use "Job.create" to create new job
- 5e90ac5 chore: sort and format item lists in all MANIFEST.MF files

No squashing.

## Summary by Sourcery

Refine background job usage and error handling across news, packages, venv detection, and ruyi services while cleaning up unused helpers and normalizing manifest metadata.

Bug Fixes:
- Ensure Ruyi plugin deactivation errors in Activator.stop are no longer swallowed so failures surface properly.
- Return appropriate status and results from asynchronous news and package loading jobs to avoid Eclipse error dialogs and better signal failures to callers.

Enhancements:
- Simplify creation and configuration of background Jobs using Job.create across news fetching, venv detection, and package operations.
- Improve news list UI feedback by handling failed fetches explicitly and showing a dedicated failure status message instead of silently updating.
- Unify flash device provision error reporting by reusing a single error message string for both logging and user dialogs.
- Inline the ruyi executable resolution helper into getResolvedExecutablePath for a more direct and readable implementation.
- Remove unnecessary job configuration (system/user flags and constructors) and unused overloads to streamline background processing APIs.

Build:
- Sort and normalize item lists across all MANIFEST.MF files for consistent bundle metadata ordering.