### PR TITLE
Cleanup

### DIFF
--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvView.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvView.java
@@ -240,7 +240,7 @@ public class VenvView extends ViewPart {
                 venvListViewModel.onDeleteSelectedVenvDirectories(err -> {
                     if (err != null) {
                         MessageDialog.openError(container.getShell(), "Delete virtual environment failed",
-                                        "Failed to delete:\n\n" + err.getMessage());
+                                        err.getMessage());
                     }
                 });
             }


### PR DESCRIPTION
Commit(s):

- 7f96512 fix(venv): correct error message when deleting venv

No squashing.

## Summary by Sourcery

Bug Fixes:
- Correct the delete-venv failure dialog to display only the underlying error message without an extra prefixed line.