### PR TITLE
fix: redesign exception handling across plugins

### DIFF
--- a/plugins/org.ruyisdk.core/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.core/META-INF/MANIFEST.MF
@@ -20,5 +20,6 @@ Export-Package:
  org.ruyisdk.core.basedir,
  org.ruyisdk.core.config,
  org.ruyisdk.core.console,
+ org.ruyisdk.core.exception,
  org.ruyisdk.core.ruyi.model,
  org.ruyisdk.core.util

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/exception/PluginException.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/exception/PluginException.java
@@ -1,0 +1,52 @@
+package org.ruyisdk.core.exception;
+
+/**
+ * Base exception for all Ruyi SDK domain exceptions.
+ *
+ * <p>
+ * Subclasses represent specific failure categories (CLI errors, API errors, etc.). UI code can
+ * catch this base type to handle all domain errors uniformly, or catch a specific subclass when
+ * different handling is required.
+ * </p>
+ *
+ * <p>
+ * Subclasses should declare private constructors and expose public static factory methods rather
+ * than being instantiated with new directly.
+ * </p>
+ */
+public class PluginException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new SDK exception with the specified message.
+     *
+     * @param message the detail message
+     */
+    protected PluginException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new SDK exception with the specified message and cause.
+     *
+     * @param message the detail message
+     * @param cause the underlying cause
+     */
+    protected PluginException(String message, Throwable cause) {
+        super(makeMessage(message, cause), cause);
+    }
+
+    private static String makeMessage(String message, Throwable cause) {
+        if (cause == null) {
+            return message;
+        }
+        final var exType = cause.getClass().getSimpleName();
+        final var msg = message + "\n" + exType;
+
+        final var exMsg = cause.getMessage();
+        if (exMsg != null) {
+            return msg + ": " + exMsg;
+        }
+        return msg;
+    }
+}

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/exception/RuyiConfigException.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/exception/RuyiConfigException.java
@@ -1,0 +1,24 @@
+package org.ruyisdk.core.exception;
+
+import java.io.IOException;
+
+/**
+ * Exception thrown when reading or writing configuration or properties files fails.
+ */
+public class RuyiConfigException extends PluginException {
+    private static final long serialVersionUID = 1L;
+
+    private RuyiConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /** Failed to save a configuration or properties file. */
+    public static RuyiConfigException saveFailed(String target, IOException cause) {
+        return new RuyiConfigException("Failed to save " + target, cause);
+    }
+
+    /** Failed to delete a file or directory. */
+    public static RuyiConfigException deleteFailed(String path, IOException cause) {
+        return new RuyiConfigException("Failed to delete: " + path, cause);
+    }
+}

--- a/plugins/org.ruyisdk.devices/src/org/ruyisdk/devices/services/PropertiesService.java
+++ b/plugins/org.ruyisdk.devices/src/org/ruyisdk/devices/services/PropertiesService.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Properties;
 import org.ruyisdk.core.basedir.XdgDirs;
 import org.ruyisdk.core.config.Constants;
+import org.ruyisdk.core.exception.RuyiConfigException;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.devices.Activator;
 import org.ruyisdk.devices.model.Device;
@@ -104,7 +105,7 @@ public class PropertiesService {
 
             LOGGER.logInfo("Devices is successfully stored to file :" + FILE_PATH.toString());
         } catch (IOException e) {
-            LOGGER.logError("Failed to store devices to properties file: " + FILE_PATH.toString(), e);
+            throw RuyiConfigException.saveFailed("devices properties: " + FILE_PATH, e);
         }
     }
 }

--- a/plugins/org.ruyisdk.devices/src/org/ruyisdk/devices/views/DevicePreferencePage.java
+++ b/plugins/org.ruyisdk.devices/src/org/ruyisdk/devices/views/DevicePreferencePage.java
@@ -17,6 +17,7 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.devices.Activator;
 import org.ruyisdk.devices.model.Device;
@@ -211,7 +212,7 @@ public class DevicePreferencePage extends PreferencePage implements IWorkbenchPr
         try {
             deviceService.saveDevices();
             return true;
-        } catch (Exception e) {
+        } catch (PluginException e) {
             LOGGER.logError("Failed to save devices to properties file", e);
             setErrorMessage("保存失败: " + e.getMessage());
             return false;

--- a/plugins/org.ruyisdk.intro/src/org/ruyisdk/intro/CustomIntroPart.java
+++ b/plugins/org.ruyisdk.intro/src/org/ruyisdk/intro/CustomIntroPart.java
@@ -8,6 +8,10 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.commands.NotEnabledException;
+import org.eclipse.core.commands.NotHandledException;
+import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.swt.SWT;
@@ -58,66 +62,57 @@ public class CustomIntroPart implements IIntroPart {
         parent.setLayout(new FillLayout());
         browser = new Browser(parent, SWT.NONE);
 
-        try {
-            Bundle bundle = Activator.getDefault() != null ? Activator.getDefault().getBundle()
-                            : FrameworkUtil.getBundle(getClass());
-            if (bundle == null) {
-                browser.setText("<html><body><h1>Error: Plugin bundle could not be determined.</h1></body></html>");
-                return;
-            }
+        Bundle bundle = Activator.getDefault() != null ? Activator.getDefault().getBundle()
+                        : FrameworkUtil.getBundle(getClass());
+        if (bundle == null) {
+            browser.setText("<html><body><h1>Error: Plugin bundle could not be determined.</h1></body></html>");
+            return;
+        }
 
-            List<String> resourcePaths = Arrays.asList("html/welcome.html", "html/style.css", "icons/ruyi_logo.png",
-                            "icons/icon_new.png", "icons/icon_open.png", "icons/icon_settings.png",
-                            "icons/icon_matrix.png", "icons/icon_docs.png", "icons/icon_discussions.png"
-            // Add all other images referenced in welcome.html here
-            );
+        List<String> resourcePaths = Arrays.asList("html/welcome.html", "html/style.css", "icons/ruyi_logo.png",
+                        "icons/icon_new.png", "icons/icon_open.png", "icons/icon_settings.png", "icons/icon_matrix.png",
+                        "icons/icon_docs.png", "icons/icon_discussions.png"
+        // Add all other images referenced in welcome.html here
+        );
 
-            URL resolvedWelcomePageUrl = null;
+        URL resolvedWelcomePageUrl = null;
 
-            for (String resourcePath : resourcePaths) {
-                URL bundleUrl = FileLocator.find(bundle, new Path(resourcePath), null);
-                if (bundleUrl != null) {
-                    try {
-                        URL fileUrl = FileLocator.toFileURL(bundleUrl);
-                        if (resourcePath.equals("html/welcome.html")) {
-                            resolvedWelcomePageUrl = fileUrl;
-                        }
-                    } catch (IOException ioException) {
-                        if (resourcePath.equals("html/welcome.html")) {
-                            String errorMessage = ioException.getMessage();
-                            String safeErrorMessage = (errorMessage == null) ? "An unknown error occurred."
-                                            : escapeHtml(errorMessage);
-                            String errorHtml = "<html><body>"
-                                            + "<h1>Error: Could not resolve welcome.html to a file URL.</h1>" + "<p>"
-                                            + safeErrorMessage + "</p></body></html>";
-                            browser.setText(errorHtml);
-                            return;
-                        }
-                        // For other resources, we might log this error but not necessarily stop loading the intro
-                    }
-                } else {
+        for (String resourcePath : resourcePaths) {
+            URL bundleUrl = FileLocator.find(bundle, new Path(resourcePath), null);
+            if (bundleUrl != null) {
+                try {
+                    URL fileUrl = FileLocator.toFileURL(bundleUrl);
                     if (resourcePath.equals("html/welcome.html")) {
-                        browser.setText("<html><body><h1>Error: welcome.html not found in bundle.</h1></body></html>");
+                        resolvedWelcomePageUrl = fileUrl;
+                    }
+                } catch (IOException ioException) {
+                    if (resourcePath.equals("html/welcome.html")) {
+                        String errorMessage = ioException.getMessage();
+                        String safeErrorMessage = (errorMessage == null) ? "An unknown error occurred."
+                                        : escapeHtml(errorMessage);
+                        String errorHtml =
+                                        "<html><body>" + "<h1>Error: Could not resolve welcome.html to a file URL.</h1>"
+                                                        + "<p>" + safeErrorMessage + "</p></body></html>";
+                        browser.setText(errorHtml);
                         return;
                     }
-                    // For other resources, we might log this error
+                    // For other resources, we might log this error but not necessarily stop loading the intro
                 }
-            }
-
-            if (resolvedWelcomePageUrl != null) {
-                browser.setUrl(resolvedWelcomePageUrl.toExternalForm());
             } else {
-                String errorMsg = "<html><body>" + "<h1>Error: Welcome page URL could not be determined "
-                                + "after resource processing.</h1></body></html>";
-                browser.setText(errorMsg);
+                if (resourcePath.equals("html/welcome.html")) {
+                    browser.setText("<html><body><h1>Error: welcome.html not found in bundle.</h1></body></html>");
+                    return;
+                }
+                // For other resources, we might log this error
             }
+        }
 
-        } catch (Exception e) {
-            String errorMessage = e.getMessage();
-            String safeErrorMessage = (errorMessage == null) ? "An unknown error occurred." : escapeHtml(errorMessage);
-            browser.setText("<html><body><h1>Error loading welcome page.</h1><p>" + safeErrorMessage
-                            + "</p></body></html>");
-            // Consider proper logging for 'e' here using Activator or ILog
+        if (resolvedWelcomePageUrl != null) {
+            browser.setUrl(resolvedWelcomePageUrl.toExternalForm());
+        } else {
+            String errorMsg = "<html><body>" + "<h1>Error: Welcome page URL could not be determined "
+                            + "after resource processing.</h1></body></html>";
+            browser.setText(errorMsg);
         }
 
         browser.addLocationListener(new LocationListener() {
@@ -153,7 +148,7 @@ public class CustomIntroPart implements IIntroPart {
                                 handlerService.executeCommand(commandId, null);
                             }
                         }
-                    } catch (Exception e) {
+                    } catch (ExecutionException | NotDefinedException | NotEnabledException | NotHandledException e) {
                         LOGGER.logError("Failed to execute command: " + commandId, e);
                     }
                     event.doit = false;

--- a/plugins/org.ruyisdk.intro/src/org/ruyisdk/intro/OpenBrowserHandler.java
+++ b/plugins/org.ruyisdk.intro/src/org/ruyisdk/intro/OpenBrowserHandler.java
@@ -2,6 +2,7 @@ package org.ruyisdk.intro;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Locale;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
@@ -50,7 +51,7 @@ public class OpenBrowserHandler extends AbstractHandler {
             // First level: Java standard API (most concise)
             java.awt.Desktop.getDesktop().browse(new URI(url));
             return;
-        } catch (Exception e) {
+        } catch (IOException | URISyntaxException e) {
             LOGGER.logWarning("Java Desktop open failed", e);
         }
 

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsFetchService.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsFetchService.java
@@ -21,18 +21,19 @@ public class NewsFetchService {
             try {
                 final var result = RuyiCli.readNewsItem(id);
                 if (result == null) {
-                    throw new Exception("timed out");
+                    final var msg = "News item not found: id=" + id;
+                    LOGGER.logError(msg);
+                    errorCallback.accept(msg);
+                    return Status.CANCEL_STATUS; // avoid Eclipse error dialog
                 }
                 final var content = result.getContent() == null ? "" : result.getContent();
                 LOGGER.logInfo("Fetched news details: id=" + id + ", length=" + content.length());
                 callback.accept(content);
                 return Status.OK_STATUS;
             } catch (Exception e) {
-                LOGGER.logError("Failed to fetch news details: id=" + id, e);
-                final var msg = e.getMessage() == null ? "Failed to read news details" : e.getMessage();
-                if (errorCallback != null) {
-                    errorCallback.accept(msg);
-                }
+                final var msg = "Failed to read news details: id=" + id;
+                LOGGER.logError(msg, e);
+                errorCallback.accept(msg);
                 return Status.CANCEL_STATUS; // avoid Eclipse error dialog
             }
         });

--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/JsonParser.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/JsonParser.java
@@ -6,7 +6,6 @@ import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 import javax.json.JsonValue;
-import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.packages.model.TreeNode;
 import org.ruyisdk.ruyi.services.RuyiCli;
 
@@ -14,7 +13,6 @@ import org.ruyisdk.ruyi.services.RuyiCli;
  * JSON parser for package tree data.
  */
 public class JsonParser {
-    private static final PluginLogger LOGGER = Activator.getLogger();
 
     /**
      * Parses raw porcelain CLI output into a tree structure. Each non-empty line that starts with '{'
@@ -24,7 +22,7 @@ public class JsonParser {
      * @param rootLabel label for root node
      * @return parsed tree node
      */
-    public static TreeNode parseRawOutput(String rawOutput, String rootLabel) throws Exception {
+    public static TreeNode parseRawOutput(String rawOutput, String rootLabel) {
         final var root = new TreeNode(rootLabel, null);
         if (rawOutput == null || rawOutput.isEmpty()) {
             return root;
@@ -104,56 +102,50 @@ public class JsonParser {
 
         String entity = boardName.startsWith("device:") ? boardName : "device:" + boardName;
 
-        try {
-            final var rawJson = RuyiCli.listRelatedToEntity(entity).replace("\n", "").replace("\r", "");
-            if (rawJson.trim().isEmpty()) {
-                return null; // No output from ruyi
-            }
-            // The output is a stream of JSON objects, wrap it to be a valid JSON array.
-            String jsonData = "[" + rawJson.replace("}{", "},{") + "]";
+        final var rawJson = RuyiCli.listRelatedToEntity(entity).replace("\n", "").replace("\r", "");
+        if (rawJson.trim().isEmpty()) {
+            return null; // No output from ruyi
+        }
+        // The output is a stream of JSON objects, wrap it to be a valid JSON array.
+        String jsonData = "[" + rawJson.replace("}{", "},{") + "]";
 
-            // Parse the JSON to find the toolchain
-            try (JsonReader reader = Json.createReader(new StringReader(jsonData))) {
-                JsonArray jsonArray = reader.readArray();
-                for (JsonValue value : jsonArray) {
-                    if (value.getValueType() != JsonValue.ValueType.OBJECT) {
+        // Parse the JSON to find the toolchain
+        try (JsonReader reader = Json.createReader(new StringReader(jsonData))) {
+            JsonArray jsonArray = reader.readArray();
+            for (JsonValue value : jsonArray) {
+                if (value.getValueType() != JsonValue.ValueType.OBJECT) {
+                    continue;
+                }
+
+                JsonObject pkgObject = (JsonObject) value;
+                String category = pkgObject.getString("category", "");
+
+                if ("toolchain".equals(category)) {
+                    JsonArray versions = pkgObject.getJsonArray("vers");
+                    if (versions == null) {
                         continue;
                     }
 
-                    JsonObject pkgObject = (JsonObject) value;
-                    String category = pkgObject.getString("category", "");
-
-                    if ("toolchain".equals(category)) {
-                        JsonArray versions = pkgObject.getJsonArray("vers");
-                        if (versions == null) {
-                            continue;
-                        }
-
-                        for (JsonValue verValue : versions) {
-                            JsonObject verObject = (JsonObject) verValue;
-                            if (verObject.getBoolean("is_installed", false)) {
-                                // Extract the full package name from the install command
-                                // to match the expected format.
-                                if (verObject.containsKey("install_command")) {
-                                    String installCommand = verObject.getString("install_command");
-                                    int lastSpace = installCommand.lastIndexOf(' ');
-                                    if (lastSpace != -1) {
-                                        return installCommand.substring(lastSpace + 1);
-                                    }
+                    for (JsonValue verValue : versions) {
+                        JsonObject verObject = (JsonObject) verValue;
+                        if (verObject.getBoolean("is_installed", false)) {
+                            // Extract the full package name from the install command
+                            // to match the expected format.
+                            if (verObject.containsKey("install_command")) {
+                                String installCommand = verObject.getString("install_command");
+                                int lastSpace = installCommand.lastIndexOf(' ');
+                                if (lastSpace != -1) {
+                                    return installCommand.substring(lastSpace + 1);
                                 }
-                                // Fallback if install_command is missing
-                                String pkgName = pkgObject.getString("name");
-                                String pkgVersion = verObject.getString("semver");
-                                return pkgName + "-" + pkgVersion;
                             }
+                            // Fallback if install_command is missing
+                            String pkgName = pkgObject.getString("name");
+                            String pkgVersion = verObject.getString("semver");
+                            return pkgName + "-" + pkgVersion;
                         }
                     }
                 }
             }
-
-        } catch (Exception e) {
-            LOGGER.logError("Failed to find installed toolchain for board: " + boardName, e);
-            return null;
         }
 
         return null; // No installed toolchain found

--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/model/DeviceList.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/model/DeviceList.java
@@ -16,9 +16,8 @@ public class DeviceList {
      * Loads all device entities from the Ruyi CLI, sorted case-insensitively by label.
      *
      * @return sorted list of device entities
-     * @throws Exception if the CLI call or parsing fails
      */
-    public static List<DeviceEntityInfo> loadDevices() throws Exception {
+    public static List<DeviceEntityInfo> loadDevices() {
         final var output = RuyiCli.listEntitiesByType("device");
         final var devices = EntityInfoParser.parseDeviceEntities(output);
         devices.sort(Comparator.comparing(DeviceEntityInfo::getLabel, String.CASE_INSENSITIVE_ORDER));

--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/model/PackageTree.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/model/PackageTree.java
@@ -14,9 +14,8 @@ public class PackageTree {
      *
      * @param entityId device entity ID to filter by, or {@code null} for all packages
      * @return the root {@link TreeNode} of the parsed tree
-     * @throws Exception if the CLI call or JSON parsing fails
      */
-    public static TreeNode loadPackages(String entityId) throws Exception {
+    public static TreeNode loadPackages(String entityId) {
         final String output;
         if (entityId != null) {
             output = RuyiCli.listRelatedToEntity("device:" + entityId);

--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/service/PackageOperationRunner.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/service/PackageOperationRunner.java
@@ -23,9 +23,8 @@ public class PackageOperationRunner {
          *
          * @param op the operation to execute
          * @param lineCallback called for each line of process output
-         * @throws Exception if the operation fails
          */
-        void execute(PackageOperation op, Consumer<String> lineCallback) throws Exception;
+        void execute(PackageOperation op, Consumer<String> lineCallback);
     }
 
     /** Default installer that delegates to {@link RuyiCli}. */
@@ -94,7 +93,7 @@ public class PackageOperationRunner {
                 installer.execute(op, callback::onOutputLine);
                 callback.onStepDone(i);
             } catch (Exception e) {
-                callback.onStepFailed(i, e.getMessage());
+                callback.onStepFailed(i, e.toString());
             }
         }
         callback.onAllFinished(cancelFlag.getAsBoolean());

--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/PackageExplorerViewModel.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/PackageExplorerViewModel.java
@@ -92,13 +92,15 @@ public class PackageExplorerViewModel extends BaseViewModel {
 
     /** Kick off initial data loading (packages + device list). */
     public void initialize() {
-        loadPackagesAsync(null);
+        loadPackagesAsync(() -> {
+        });
         loadDevicesAsync();
     }
 
     /** Reload the package list for the currently chosen device. */
     public void refreshPackages() {
-        loadPackagesAsync(null);
+        loadPackagesAsync(() -> {
+        });
     }
 
     /**
@@ -196,9 +198,7 @@ public class PackageExplorerViewModel extends BaseViewModel {
             if (monitor.isCanceled()) {
                 uiExecutor.accept(() -> {
                     setPackagesLoading(false);
-                    if (onFinished != null) {
-                        onFinished.run();
-                    }
+                    onFinished.run();
                 });
                 return Status.CANCEL_STATUS;
             }
@@ -209,9 +209,7 @@ public class PackageExplorerViewModel extends BaseViewModel {
                 if (monitor.isCanceled()) {
                     uiExecutor.accept(() -> {
                         setPackagesLoading(false);
-                        if (onFinished != null) {
-                            onFinished.run();
-                        }
+                        onFinished.run();
                     });
                     return Status.CANCEL_STATUS;
                 }
@@ -221,9 +219,7 @@ public class PackageExplorerViewModel extends BaseViewModel {
                         setPackageRoot(root);
                     } finally {
                         setPackagesLoading(false);
-                        if (onFinished != null) {
-                            onFinished.run();
-                        }
+                        onFinished.run();
                     }
                 });
 
@@ -233,9 +229,7 @@ public class PackageExplorerViewModel extends BaseViewModel {
                 uiExecutor.accept(() -> {
                     setPackagesLoading(false);
                     firePropertyChange(PROP_ERROR, null, "Failed to load packages: " + msg);
-                    if (onFinished != null) {
-                        onFinished.run();
-                    }
+                    onFinished.run();
                 });
                 return Status.CANCEL_STATUS; // avoid Eclipse error dialog
             }
@@ -255,7 +249,7 @@ public class PackageExplorerViewModel extends BaseViewModel {
             } catch (Exception e) {
                 final var msg = e.getMessage();
                 uiExecutor.accept(() -> setDeviceListErrorMessage(msg));
-                return Status.CANCEL_STATUS; // avoid Eclipse error dialog
+                return Status.error("Failed to load device data: " + msg, e);
             }
         });
         job.schedule();

--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/PackageOperationViewModel.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/PackageOperationViewModel.java
@@ -60,6 +60,7 @@ public class PackageOperationViewModel extends BaseViewModel {
         appendOutput("Starting operations...\n\n");
 
         job = Job.create("Package Operations", monitor -> {
+            // All exceptions are caught and reported via "onStepFailed"
             runner.run(operations, new PackageOperationRunner.OperationCallback() {
                 @Override
                 public void onStepStart(int index, int total, PackageOperation op) {

--- a/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/Activator.java
+++ b/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/Activator.java
@@ -35,38 +35,34 @@ public class Activator extends AbstractUIPlugin {
     public void start(BundleContext context) throws Exception {
         super.start(context);
         plugin = this;
-        try {
-            getBundle().loadClass("org.ruyisdk.projectcreator.builder.MakefileBuilder");
-            IWorkspace workspace = ResourcesPlugin.getWorkspace();
-            buildListener = event -> {
-                switch (event.getType()) {
-                    case IResourceChangeEvent.PRE_BUILD:
-                        if (event.getSource() instanceof IProject) {
-                            IProject project = (IProject) event.getSource();
-                            LOGGER.logInfo("Building project: " + project.getName());
-                            try {
-                                IProjectDescription desc = project.getDescription();
-                                ICommand[] commands = desc.getBuildSpec();
-                                LOGGER.logInfo("Project builders:");
-                                for (ICommand cmd : commands) {
-                                    LOGGER.logInfo("  - " + cmd.getBuilderName());
-                                }
-                            } catch (CoreException e) {
-                                LOGGER.logError("Failed to add Makefile builder: " + e.getMessage(), e);
+        getBundle().loadClass("org.ruyisdk.projectcreator.builder.MakefileBuilder");
+        IWorkspace workspace = ResourcesPlugin.getWorkspace();
+        buildListener = event -> {
+            switch (event.getType()) {
+                case IResourceChangeEvent.PRE_BUILD:
+                    if (event.getSource() instanceof IProject) {
+                        IProject project = (IProject) event.getSource();
+                        LOGGER.logInfo("Building project: " + project.getName());
+                        try {
+                            IProjectDescription desc = project.getDescription();
+                            ICommand[] commands = desc.getBuildSpec();
+                            LOGGER.logInfo("Project builders:");
+                            for (ICommand cmd : commands) {
+                                LOGGER.logInfo("  - " + cmd.getBuilderName());
                             }
+                        } catch (CoreException e) {
+                            LOGGER.logError("Failed to add Makefile builder: " + e.getMessage(), e);
                         }
-                        break;
-                    default:
-                        break;
-                }
-            };
-            workspace.addResourceChangeListener(buildListener, IResourceChangeEvent.PRE_BUILD
-                            | IResourceChangeEvent.POST_BUILD | IResourceChangeEvent.PRE_DELETE);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        };
+        workspace.addResourceChangeListener(buildListener, IResourceChangeEvent.PRE_BUILD
+                        | IResourceChangeEvent.POST_BUILD | IResourceChangeEvent.PRE_DELETE);
 
-            LOGGER.logInfo("Build listener registered successfully");
-        } catch (Exception e) {
-            LOGGER.logError("Error during plugin initialization", e);
-        }
+        LOGGER.logInfo("Build listener registered successfully");
     }
 
     /**

--- a/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/RuyiProjectException.java
+++ b/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/RuyiProjectException.java
@@ -1,0 +1,58 @@
+package org.ruyisdk.projectcreator;
+
+import org.ruyisdk.core.exception.PluginException;
+
+/**
+ * Exception thrown when project creation or build operations fail.
+ */
+public class RuyiProjectException extends PluginException {
+    private static final long serialVersionUID = 1L;
+
+    private RuyiProjectException(String message) {
+        super(message);
+    }
+
+    private RuyiProjectException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /** Eclipse project creation failed. */
+    public static RuyiProjectException creationFailed(String projectName, Throwable cause) {
+        return new RuyiProjectException("Failed to create project: " + projectName, cause);
+    }
+
+    /** Project template not found in bundle. */
+    public static RuyiProjectException templateNotFound(String templatePath) {
+        return new RuyiProjectException("Template not found: " + templatePath);
+    }
+
+    /** Failed to create a folder inside the project. */
+    public static RuyiProjectException folderCreationFailed(String path, Throwable cause) {
+        return new RuyiProjectException("Failed to create folder: " + path, cause);
+    }
+
+    /** Failed to read a template file. */
+    public static RuyiProjectException fileReadFailed(String file, Throwable cause) {
+        return new RuyiProjectException("Failed to read template: " + file, cause);
+    }
+
+    /** Failed to write a file into the project. */
+    public static RuyiProjectException fileWriteFailed(String file, Throwable cause) {
+        return new RuyiProjectException("Failed to write file: " + file, cause);
+    }
+
+    /** Failed to copy a file into the project. */
+    public static RuyiProjectException fileCopyFailed(String file, Throwable cause) {
+        return new RuyiProjectException("Failed to copy file: " + file, cause);
+    }
+
+    /** Failed to read a persistent project property. */
+    public static RuyiProjectException propertyAccessFailed(String property, Throwable cause) {
+        return new RuyiProjectException("Failed to retrieve " + property + " from project properties", cause);
+    }
+
+    /** A required persistent project property is not set. */
+    public static RuyiProjectException propertyMissing(String property) {
+        return new RuyiProjectException(property + " not set for project");
+    }
+}

--- a/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/builder/MakefileBuilder.java
+++ b/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/builder/MakefileBuilder.java
@@ -23,11 +23,12 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.DebugPlugin;
+import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.packages.JsonParser;
 import org.ruyisdk.projectcreator.Activator;
+import org.ruyisdk.projectcreator.RuyiProjectException;
 import org.ruyisdk.ruyi.services.RuyiCli;
-import org.ruyisdk.ruyi.services.RuyiCliException;
 
 /**
  * Builder for Makefile projects.
@@ -119,10 +120,13 @@ public class MakefileBuilder extends IncrementalProjectBuilder {
             String resultMessage = "Build finished with exit code: " + exitCode;
             logToFile(project, resultMessage);
 
-        } catch (Exception e) {
+        } catch (IOException | InterruptedException e) {
             final var errorMessage = "Build failed with exception";
             LOGGER.logError("MakefileBuilder: " + errorMessage, e);
             logToFile(project, errorMessage + ": " + e.getMessage());
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
         } finally {
             logToFile(project, "=== Build finished at " + new Date() + " ===");
             project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
@@ -138,14 +142,18 @@ public class MakefileBuilder extends IncrementalProjectBuilder {
      * @param gccPath The path to the gcc compiler
      * @param project The project
      * @return The appropriate CFLAGS for the toolchain
-     * @throws CoreException if board model is not set
      */
-    private String determineCorrectCflags(String gccPath, IProject project) throws CoreException {
+    private String determineCorrectCflags(String gccPath, IProject project) {
         // Base CFLAGS that are always included
         String cflags = "-Wall -O2";
 
         // Get the board model to provide more specific flags
-        String boardModel = project.getPersistentProperty(new QualifiedName(Activator.PLUGIN_ID, BOARD_MODEL_PROPERTY));
+        String boardModel;
+        try {
+            boardModel = project.getPersistentProperty(new QualifiedName(Activator.PLUGIN_ID, BOARD_MODEL_PROPERTY));
+        } catch (CoreException e) {
+            throw RuyiProjectException.propertyAccessFailed(BOARD_MODEL_PROPERTY, e);
+        }
         if (boardModel == null || boardModel.trim().isEmpty()) {
             return cflags; // Return default flags if board model is not available
         }
@@ -197,7 +205,7 @@ public class MakefileBuilder extends IncrementalProjectBuilder {
         return null;
     }
 
-    private void ensureRuyiVenv(IProject project) throws CoreException {
+    private void ensureRuyiVenv(IProject project) {
         File projectLocation = project.getLocation().toFile();
         File venvDir = new File(projectLocation, RUYI_VENV_DIR);
 
@@ -208,8 +216,12 @@ public class MakefileBuilder extends IncrementalProjectBuilder {
 
         logToFile(project, "Ruyi virtual environment not found. Creating...");
 
-        String venvCommand =
-                        project.getPersistentProperty(new QualifiedName(Activator.PLUGIN_ID, RUYI_VENV_CMD_PROPERTY));
+        String venvCommand;
+        try {
+            venvCommand = project.getPersistentProperty(new QualifiedName(Activator.PLUGIN_ID, RUYI_VENV_CMD_PROPERTY));
+        } catch (CoreException e) {
+            throw RuyiProjectException.propertyAccessFailed(RUYI_VENV_CMD_PROPERTY, e);
+        }
         final var useCustomCommand = !(venvCommand == null || venvCommand.trim().isEmpty());
         String boardModel = null;
         String toolchain = null;
@@ -217,12 +229,21 @@ public class MakefileBuilder extends IncrementalProjectBuilder {
 
         if (!useCustomCommand) {
             logToFile(project, "No custom venv command found, generating default command...");
-            boardModel = project.getPersistentProperty(new QualifiedName(Activator.PLUGIN_ID, BOARD_MODEL_PROPERTY));
-            if (boardModel == null) {
-                throw new CoreException(
-                                new Status(IStatus.ERROR, Activator.PLUGIN_ID, "Board model not set for project."));
+            try {
+                boardModel = project
+                                .getPersistentProperty(new QualifiedName(Activator.PLUGIN_ID, BOARD_MODEL_PROPERTY));
+            } catch (CoreException e) {
+                throw RuyiProjectException.propertyAccessFailed(BOARD_MODEL_PROPERTY, e);
             }
-            toolchain = JsonParser.findInstalledToolchainForBoard(boardModel);
+            if (boardModel == null) {
+                throw RuyiProjectException.propertyMissing(BOARD_MODEL_PROPERTY);
+            }
+            try {
+                toolchain = JsonParser.findInstalledToolchainForBoard(boardModel);
+            } catch (PluginException e) {
+                logToFile(project, "Failed to find installed toolchain for board: " + e.getMessage());
+                toolchain = null;
+            }
             if (toolchain == null || toolchain.trim().isEmpty()) {
                 if ("milkv-duo".equals(boardModel)) {
                     toolchain = "gnu-milkv-milkv-duo-elf-bin";
@@ -247,15 +268,10 @@ public class MakefileBuilder extends IncrementalProjectBuilder {
 
         logToFile(project, "Executing: ruyi " + String.join(" ", ruyiArgs));
 
-        try {
-            final var output = RuyiCli.runRuyiExperimental(ruyiArgs, projectLocation);
+        final var output = RuyiCli.runRuyiExperimental(ruyiArgs, projectLocation);
 
-            if (output != null && !output.isBlank()) {
-                logToFile(project, "[ruyi venv] " + output);
-            }
-        } catch (RuyiCliException e) {
-            throw new CoreException(new Status(IStatus.ERROR, Activator.PLUGIN_ID,
-                            "Failed to create Ruyi virtual environment: " + e.getMessage(), e));
+        if (output != null && !output.isBlank()) {
+            logToFile(project, "[ruyi venv] " + output);
         }
     }
 

--- a/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/properties/BuildPropertyPage.java
+++ b/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/properties/BuildPropertyPage.java
@@ -12,7 +12,9 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbenchPropertyPage;
 import org.eclipse.ui.dialogs.PropertyPage;
+import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.core.util.PluginLogger;
+import org.ruyisdk.packages.JsonParser;
 import org.ruyisdk.projectcreator.Activator;
 
 /**
@@ -111,7 +113,11 @@ public class BuildPropertyPage extends PropertyPage implements IWorkbenchPropert
             } else {
 
                 profile = boardModel;
-                toolchain = org.ruyisdk.packages.JsonParser.findInstalledToolchainForBoard(boardModel);
+                try {
+                    toolchain = JsonParser.findInstalledToolchainForBoard(boardModel);
+                } catch (PluginException e) {
+                    toolchain = null;
+                }
                 if (toolchain == null || toolchain.trim().isEmpty()) {
                     if ("milkv-duo".equals(boardModel)) {
                         toolchain = "gnu-milkv-milkv-duo-elf-bin";

--- a/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/utils/ToolchainLocator.java
+++ b/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/utils/ToolchainLocator.java
@@ -5,6 +5,7 @@ import java.nio.file.Paths;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
+import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.packages.JsonParser;
 import org.ruyisdk.projectcreator.Activator;
@@ -37,11 +38,8 @@ public class ToolchainLocator {
             LOGGER.logInfo("Preparing to call JsonParser.findInstalledToolchainForBoard...");
             toolchainName = JsonParser.findInstalledToolchainForBoard(boardModel);
             LOGGER.logInfo("Successfully called JsonParser. Returned toolchainName: " + toolchainName);
-        } catch (NoClassDefFoundError e) {
-            LOGGER.logError("Failed to find or load class", e);
-            return null;
-        } catch (Throwable t) {
-            LOGGER.logError("An unexpected error or exception occurred", t);
+        } catch (PluginException e) {
+            LOGGER.logError("Failed to find installed toolchain for board: " + boardModel, e);
             return null;
         }
 

--- a/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/wizards/NewProjectWizard.java
+++ b/plugins/org.ruyisdk.projectcreator/src/org/ruyisdk/projectcreator/wizards/NewProjectWizard.java
@@ -30,8 +30,10 @@ import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.statushandlers.StatusManager;
 import org.osgi.framework.Bundle;
+import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.projectcreator.Activator;
+import org.ruyisdk.projectcreator.RuyiProjectException;
 import org.ruyisdk.projectcreator.natures.MyProjectNature;
 import org.ruyisdk.projectcreator.utils.ToolchainLocator;
 
@@ -101,7 +103,7 @@ public class NewProjectWizard extends Wizard implements INewWizard {
                 try {
                     // 2. Pass CFLAGS to the createProject method
                     createProject(projectName, boardModel, toolchainPath, cflags, finalTemplateName, monitor);
-                } catch (CoreException | IOException e) {
+                } catch (PluginException e) {
                     throw new InvocationTargetException(e);
                 } finally {
                     monitor.done();
@@ -137,47 +139,50 @@ public class NewProjectWizard extends Wizard implements INewWizard {
 
     // 3. Update method signature to accept CFLAGS
     private void createProject(String projectName, String boardModel, String toolchainPath, String cflags,
-                    String templateName, IProgressMonitor monitor) throws CoreException, IOException {
-        monitor.beginTask("Creating project " + projectName, 4);
+                    String templateName, IProgressMonitor monitor) {
+        try {
+            monitor.beginTask("Creating project " + projectName, 4);
 
-        IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+            IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
 
-        project.create(monitor);
-        project.open(monitor);
-        monitor.worked(1);
+            project.create(monitor);
+            project.open(monitor);
+            monitor.worked(1);
 
-        IProjectDescription description = project.getDescription();
+            IProjectDescription description = project.getDescription();
 
-        description.setBuildSpec(new ICommand[0]);
+            description.setBuildSpec(new ICommand[0]);
 
-        description.setNatureIds(new String[] {MyProjectNature.NATURE_ID});
+            description.setNatureIds(new String[] {MyProjectNature.NATURE_ID});
 
-        project.setDescription(description, monitor);
-        monitor.worked(1);
-        // 4. Pass CFLAGS to the copyTemplateFiles method
-        copyTemplateFiles(project, templateName, toolchainPath, cflags, monitor);
-        monitor.worked(1);
+            project.setDescription(description, monitor);
+            monitor.worked(1);
+            // 4. Pass CFLAGS to the copyTemplateFiles method
+            copyTemplateFiles(project, templateName, toolchainPath, cflags, monitor);
+            monitor.worked(1);
 
-        project.setPersistentProperty(new QualifiedName(Activator.PLUGIN_ID, "boardModel"), boardModel);
-        project.setPersistentProperty(new QualifiedName(Activator.PLUGIN_ID, "toolchainPath"), toolchainPath);
-        project.setPersistentProperty(new QualifiedName(Activator.PLUGIN_ID, "buildCmd"), "make");
-        // 5. Save CFLAGS as a persistent property
-        project.setPersistentProperty(new QualifiedName(Activator.PLUGIN_ID, "cflags"), cflags);
-        // refresh the project to ensure all changes are applied
-        project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
-        monitor.worked(1);
+            project.setPersistentProperty(new QualifiedName(Activator.PLUGIN_ID, "boardModel"), boardModel);
+            project.setPersistentProperty(new QualifiedName(Activator.PLUGIN_ID, "toolchainPath"), toolchainPath);
+            project.setPersistentProperty(new QualifiedName(Activator.PLUGIN_ID, "buildCmd"), "make");
+            // 5. Save CFLAGS as a persistent property
+            project.setPersistentProperty(new QualifiedName(Activator.PLUGIN_ID, "cflags"), cflags);
+            // refresh the project to ensure all changes are applied
+            project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+            monitor.worked(1);
+        } catch (CoreException e) {
+            throw RuyiProjectException.creationFailed(projectName, e);
+        }
     }
 
     // 6. Update method signature to accept CFLAGS
     private void copyTemplateFiles(IProject project, String templateName, String toolchainRootPath, String cflags,
-                    IProgressMonitor monitor) throws CoreException, IOException {
+                    IProgressMonitor monitor) {
         Bundle bundle = Activator.getDefault().getBundle();
         String templatePath = "/templates/" + templateName;
         Enumeration<URL> entries = bundle.findEntries(templatePath, "*", true);
 
         if (entries == null) {
-            throw new CoreException(
-                            new Status(IStatus.ERROR, Activator.PLUGIN_ID, "Template not found: " + templatePath));
+            throw RuyiProjectException.templateNotFound(templatePath);
         }
 
         while (entries.hasMoreElements()) {
@@ -192,7 +197,11 @@ public class NewProjectWizard extends Wizard implements INewWizard {
             if (entryPath.endsWith("/")) {
                 IFolder folder = project.getFolder(targetPath);
                 if (!folder.exists()) {
-                    folder.create(true, true, monitor);
+                    try {
+                        folder.create(true, true, monitor);
+                    } catch (CoreException e) {
+                        throw RuyiProjectException.folderCreationFailed(targetPath, e);
+                    }
                 }
                 continue;
             }
@@ -219,6 +228,8 @@ public class NewProjectWizard extends Wizard implements INewWizard {
                         line = line.replace("__CFLAGS_OPTIONS__", cflags); // 7. Replace CFLAGS placeholder
                         sb.append(line).append(System.lineSeparator());
                     }
+                } catch (IOException e) {
+                    throw RuyiProjectException.fileReadFailed("Makefile", e);
                 }
 
                 String finalContent = sb.toString();
@@ -229,6 +240,8 @@ public class NewProjectWizard extends Wizard implements INewWizard {
                     } else {
                         file.create(newContentStream, true, monitor);
                     }
+                } catch (IOException | CoreException e) {
+                    throw RuyiProjectException.fileWriteFailed("Makefile", e);
                 }
 
             } else {
@@ -238,6 +251,8 @@ public class NewProjectWizard extends Wizard implements INewWizard {
                     } else {
                         file.create(is, true, monitor);
                     }
+                } catch (IOException | CoreException e) {
+                    throw RuyiProjectException.fileCopyFailed(entryPath, e);
                 }
             }
         }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/RuyiCore.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/RuyiCore.java
@@ -34,6 +34,8 @@ public class RuyiCore {
                 CheckResult result = new CheckRuyiJob().runCheck(monitor);
                 handleCheckResult(result);
                 return Status.OK_STATUS;
+            } catch (Exception e) {
+                return Status.error("Automatic environment check failed", e);
             } finally {
                 isChecking = false;
             }
@@ -60,9 +62,13 @@ public class RuyiCore {
      */
     public void runManualCheck() {
         Job.create("Manual Ruyi Check", monitor -> {
-            CheckResult result = new CheckRuyiJob().runCheck(monitor);
-            handleCheckResult(result);
-            return Status.OK_STATUS;
+            try {
+                CheckResult result = new CheckRuyiJob().runCheck(monitor);
+                handleCheckResult(result);
+                return Status.OK_STATUS;
+            } catch (Exception e) {
+                return Status.error("Manual check failed", e);
+            }
         }).schedule();
     }
 

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/workspace/WorkspaceProjectsMonitor.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/workspace/WorkspaceProjectsMonitor.java
@@ -14,6 +14,7 @@ import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.SafeRunner;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
@@ -143,7 +144,7 @@ public final class WorkspaceProjectsMonitor {
     public void dispose() {
         try {
             ResourcesPlugin.getWorkspace().removeResourceChangeListener(resourceChangeListener);
-        } catch (Exception e) {
+        } catch (IllegalStateException e) {
             // ignore
         }
         debounceJob.cancel();
@@ -164,7 +165,7 @@ public final class WorkspaceProjectsMonitor {
                     return true;
                 }
             }
-        } catch (Exception e) {
+        } catch (IllegalStateException e) {
             LOGGER.logWarning("Failed to get workspace projects", e);
         }
         return false;
@@ -206,7 +207,7 @@ public final class WorkspaceProjectsMonitor {
                 }
                 out.add(Path.of(loc.toOSString()));
             }
-        } catch (Exception e) {
+        } catch (IllegalStateException e) {
             LOGGER.logWarning("Failed to get workspace projects", e);
         }
         out.removeIf(Objects::isNull);
@@ -258,7 +259,7 @@ public final class WorkspaceProjectsMonitor {
                 }
                 return true;
             });
-        } catch (Exception ex) {
+        } catch (CoreException ex) {
             LOGGER.logWarning("Failed to visit workspace delta for workspace projects monitor", ex);
             shouldRefresh.set(true);
         }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/handlers/CheckInstallationHandler.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/handlers/CheckInstallationHandler.java
@@ -3,6 +3,7 @@ package org.ruyisdk.ruyi.handlers;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
+import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.ruyi.Activator;
 import org.ruyisdk.ruyi.core.RuyiCore;
@@ -23,7 +24,7 @@ public class CheckInstallationHandler extends AbstractHandler {
             ruyiCore.runManualCheck();
             LOGGER.logInfo("Ruyi activated successfully");
             return null;
-        } catch (Exception e) {
+        } catch (PluginException e) {
             LOGGER.logError("Failed to execute check installation command", e);
             throw new ExecutionException("Check installation failed", e);
         }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/handlers/FlashDeviceProvisionHandler.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/handlers/FlashDeviceProvisionHandler.java
@@ -5,6 +5,7 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.ui.handlers.HandlerUtil;
+import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.ruyi.Activator;
 import org.ruyisdk.ruyi.services.DeviceProvisionService;
@@ -21,7 +22,7 @@ public class FlashDeviceProvisionHandler extends AbstractHandler {
             new DeviceProvisionService().launchProvisionWizard();
             LOGGER.logInfo("Flash device (device provision) command launched in built-in terminal");
             return null;
-        } catch (Exception e) {
+        } catch (PluginException e) {
             final var msg = "Failed to launch flash device (device provision) command";
             LOGGER.logError(msg, e);
             final var shell = HandlerUtil.getActiveShell(event);

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/jobs/CheckRuyiJob.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/jobs/CheckRuyiJob.java
@@ -1,7 +1,6 @@
 package org.ruyisdk.ruyi.jobs;
 
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.OperationCanceledException;
 import org.ruyisdk.core.ruyi.model.CheckResult;
 import org.ruyisdk.core.ruyi.model.RuyiVersion;
 import org.ruyisdk.core.util.PluginLogger;
@@ -47,12 +46,6 @@ public class CheckRuyiJob {
             }
 
             return CheckResult.ok();
-        } catch (OperationCanceledException e) {
-            LOGGER.logInfo("Version check cancelled");
-            throw e;
-        } catch (Exception e) {
-            LOGGER.logError("Version check failed", e);
-            throw new RuntimeException("Check failed: " + e.getMessage(), e);
         } finally {
             monitor.done();
         }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/model/EntityInfoParser.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/model/EntityInfoParser.java
@@ -160,28 +160,24 @@ public final class EntityInfoParser {
         if (input == null || input.isBlank()) {
             return out;
         }
-        try {
-            final var t = new JSONTokener(input);
-            while (true) {
-                final var c = t.nextClean();
-                if (c == 0) {
-                    break;
-                }
-                t.back();
-                final var v = t.nextValue();
-                if (v instanceof JSONObject) {
-                    out.add((JSONObject) v);
-                } else if (v instanceof JSONArray arr) {
-                    for (int i = 0; i < arr.length(); i++) {
-                        final var el = arr.get(i);
-                        if (el instanceof JSONObject) {
-                            out.add((JSONObject) el);
-                        }
+        final var t = new JSONTokener(input);
+        while (true) {
+            final var c = t.nextClean();
+            if (c == 0) {
+                break;
+            }
+            t.back();
+            final var v = t.nextValue();
+            if (v instanceof JSONObject) {
+                out.add((JSONObject) v);
+            } else if (v instanceof JSONArray arr) {
+                for (int i = 0; i < arr.length(); i++) {
+                    final var el = arr.get(i);
+                    if (el instanceof JSONObject) {
+                        out.add((JSONObject) el);
                     }
                 }
             }
-        } catch (Exception e) {
-            // partial parse is fine — return what we have so far
         }
         return out;
     }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/AutomaticCheckPreference.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/AutomaticCheckPreference.java
@@ -1,10 +1,10 @@
 package org.ruyisdk.ruyi.preferences;
 
-import java.io.IOException;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.ruyi.Activator;
 import org.ruyisdk.ruyi.services.RuyiProperties;
@@ -66,7 +66,7 @@ public class AutomaticCheckPreference {
     public void setAutomaticDetection() {
         try {
             RuyiProperties.setAutomaticDetection(automaticCheckCheckbox.getSelection());
-        } catch (IOException e) {
+        } catch (PluginException e) {
             LOGGER.logError("Failed to save automatic detection setting", e);
         }
     }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/ConfigPreferencePage.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/ConfigPreferencePage.java
@@ -13,10 +13,10 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.ruyi.Activator;
 import org.ruyisdk.ruyi.services.RuyiCli;
-import org.ruyisdk.ruyi.services.RuyiCliException;
 
 /**
  * Preference page for Ruyi's configuration.
@@ -54,9 +54,16 @@ public class ConfigPreferencePage extends PreferencePage implements IWorkbenchPr
         final var localLabel = new Label(localGroup, SWT.NONE);
         localLabel.setText("Checkout path:");
 
-        final var localValue = RuyiCli.getRepoLocal();
+        String localValue;
+        try {
+            localValue = RuyiCli.getRepoLocal();
+            localValue = localValue != null && !localValue.isBlank() ? localValue.trim() : "";
+        } catch (PluginException e) {
+            LOGGER.logWarning("Use default local repository location due to error", e);
+            localValue = "";
+        }
         localPathText = new Text(localGroup, SWT.BORDER);
-        localPathText.setText(localValue != null && !localValue.isBlank() ? localValue.trim() : "");
+        localPathText.setText(localValue);
         localPathText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 
         final var browseButton = new Button(localGroup, SWT.PUSH);
@@ -117,15 +124,11 @@ public class ConfigPreferencePage extends PreferencePage implements IWorkbenchPr
 
     @Override
     public boolean performOk() {
-        try {
-            RuyiCli.setRepoRemote(repoPreference.getSelectedUrl());
-            RuyiCli.setRepoBranch(repoPreference.getBranch());
-            RuyiCli.setRepoLocal(localPathText.getText().trim());
-            RuyiCli.setPackagesPrereleases(prereleasesCheckbox.getSelection());
-            RuyiCli.setTelemetry(telemetryPreference.getTelemetryMode());
-        } catch (RuyiCliException e) {
-            LOGGER.logError("Failed to apply Ruyi config", e);
-        }
+        RuyiCli.setRepoRemote(repoPreference.getSelectedUrl());
+        RuyiCli.setRepoBranch(repoPreference.getBranch());
+        RuyiCli.setRepoLocal(localPathText.getText().trim());
+        RuyiCli.setPackagesPrereleases(prereleasesCheckbox.getSelection());
+        RuyiCli.setTelemetry(telemetryPreference.getTelemetryMode());
         return true;
     }
 }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/RepoConfigPreference.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/RepoConfigPreference.java
@@ -10,12 +10,16 @@ import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.ruyisdk.core.config.Constants;
+import org.ruyisdk.core.exception.PluginException;
+import org.ruyisdk.core.util.PluginLogger;
+import org.ruyisdk.ruyi.Activator;
 import org.ruyisdk.ruyi.services.RuyiCli;
 
 /**
  * Preference component for remote repository selection.
  */
 public class RepoConfigPreference {
+    private static final PluginLogger LOGGER = Activator.getLogger();
 
     private final Composite parent;
     private Button githubRadio;
@@ -46,11 +50,15 @@ public class RepoConfigPreference {
     }
 
     private void createControls(Composite container) {
-        var currentUrl = RuyiCli.getRepoRemote();
-        if (currentUrl == null || currentUrl.isBlank()) {
+        String currentUrl;
+        try {
+            currentUrl = RuyiCli.getRepoRemote();
+            currentUrl = currentUrl != null && !currentUrl.isBlank() ? currentUrl.trim()
+                            : Constants.NetAddress.MAIN_REPO_URL;
+        } catch (PluginException e) {
+            LOGGER.logWarning("Use default repository URL due to error", e);
             currentUrl = Constants.NetAddress.MAIN_REPO_URL;
         }
-        currentUrl = currentUrl.trim();
 
         final var isGithub = currentUrl.equals(Constants.NetAddress.MAIN_REPO_URL);
         final var isIscas = currentUrl.equals(Constants.NetAddress.BACKUP_REPO_URL);
@@ -103,10 +111,17 @@ public class RepoConfigPreference {
         final var branchLabel = new Label(container, SWT.NONE);
         branchLabel.setText("Branch:");
 
-        final var branchValue = RuyiCli.getRepoBranch();
+        String branchValue;
+        try {
+            branchValue = RuyiCli.getRepoBranch();
+            branchValue = branchValue != null && !branchValue.isBlank() ? branchValue.trim()
+                            : Constants.NetAddress.DEFAULT_BRANCH;
+        } catch (PluginException e) {
+            LOGGER.logWarning("Use default branch due to error.", e);
+            branchValue = Constants.NetAddress.DEFAULT_BRANCH;
+        }
         branchText = new Text(container, SWT.BORDER);
-        branchText.setText(branchValue != null && !branchValue.isBlank() ? branchValue.trim()
-                        : Constants.NetAddress.DEFAULT_BRANCH);
+        branchText.setText(branchValue);
         branchText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
     }
 

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/RootPreferencePage.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/RootPreferencePage.java
@@ -1,6 +1,5 @@
 package org.ruyisdk.ruyi.preferences;
 
-import java.io.IOException;
 import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
@@ -12,15 +11,11 @@ import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
-import org.ruyisdk.core.util.PluginLogger;
-import org.ruyisdk.ruyi.Activator;
 
 /**
  * Root preference page for RuyiSDK.
  */
 public class RootPreferencePage extends PreferencePage implements IWorkbenchPreferencePage {
-    private static final PluginLogger LOGGER = Activator.getLogger();
-
     private AutomaticCheckPreference automaticCheckPreference;
     private RuyiInstallPathPreference installPreference;
 
@@ -72,13 +67,8 @@ public class RootPreferencePage extends PreferencePage implements IWorkbenchPref
 
     @Override
     public boolean performOk() {
-        try {
-            automaticCheckPreference.setAutomaticDetection();
-            installPreference.saveInstallPath();
-        } catch (IOException e) {
-            LOGGER.logError("Failed to save preferences", e);
-            return false;
-        }
+        automaticCheckPreference.setAutomaticDetection();
+        installPreference.saveInstallPath();
         return true;
     }
 }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/RuyiInstallPathPreference.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/RuyiInstallPathPreference.java
@@ -1,6 +1,5 @@
 package org.ruyisdk.ruyi.preferences;
 
-import java.io.IOException;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -75,10 +74,8 @@ public class RuyiInstallPathPreference {
 
     /**
      * Saves install path.
-     *
-     * @throws IOException if save fails
      */
-    public void saveInstallPath() throws IOException {
+    public void saveInstallPath() {
         String newPath = ruyiInstallPathText.getText();
         RuyiProperties.setInstallPath(newPath);
     }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/DeviceProvisionService.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/DeviceProvisionService.java
@@ -1,6 +1,5 @@
 package org.ruyisdk.ruyi.services;
 
-import java.io.IOException;
 import java.util.HashMap;
 import org.eclipse.tm.terminal.view.core.TerminalServiceFactory;
 import org.eclipse.tm.terminal.view.core.interfaces.constants.ITerminalsConnectorConstants;
@@ -11,15 +10,13 @@ import org.eclipse.tm.terminal.view.core.interfaces.constants.ITerminalsConnecto
 public class DeviceProvisionService {
     /**
      * Launches `ruyi device provision` in Eclipse built-in terminal. The terminal will be reused.
-     *
-     * @throws IOException if terminal launch fails
      */
-    public void launchProvisionWizard() throws IOException {
+    public void launchProvisionWizard() {
         final var ruyiExecutable = toSingleQuoted(RuyiCli.getResolvedExecutablePath());
 
         final var terminalService = TerminalServiceFactory.getService();
         if (terminalService == null) {
-            throw new IOException("Eclipse terminal service is unavailable");
+            throw RuyiCliException.terminalUnavailable();
         }
 
         final var cmdline = new StringBuilder();

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiApi.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiApi.java
@@ -4,8 +4,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.ruyisdk.core.ruyi.model.RuyiReleaseInfo;
 import org.ruyisdk.core.ruyi.model.RuyiVersion;
@@ -26,9 +28,8 @@ public class RuyiApi {
      *
      * @param osArch 系统架构 (x86_64/aarch64/riscv64)
      * @return 结构化版本信息
-     * @throws RuyiApiException 当API请求或数据处理失败时抛出
      */
-    public static RuyiReleaseInfo getLatestRelease(String osArch) throws RuyiApiException {
+    public static RuyiReleaseInfo getLatestRelease(String osArch) {
         try {
             JSONObject response = sendGetRequest("/releases/latest-pm");
             JSONObject stable = response.getJSONObject("channels").getJSONObject("stable");
@@ -40,7 +41,7 @@ public class RuyiApi {
 
             JSONObject downloads = stable.getJSONObject("download_urls");
             if (!downloads.has(platformKey)) {
-                throw new RuyiApiException("Unsupported architecture: " + osArch);
+                throw RuyiApiException.invalidArgument("Unsupported architecture: " + osArch);
             }
 
             // 构建版本信息对象
@@ -53,12 +54,12 @@ public class RuyiApi {
             return new RuyiReleaseInfo(RuyiVersion.parse(version), stable.getString("channel"), filename, urls[0],
                             urls[1]);
 
-        } catch (Exception e) {
-            throw new RuyiApiException("Failed to get release info: " + e.getMessage(), e);
+        } catch (JSONException e) {
+            throw RuyiApiException.jsonError(e);
         }
     }
 
-    private static JSONObject sendGetRequest(String path) throws IOException, URISyntaxException {
+    private static JSONObject sendGetRequest(String path) {
         HttpURLConnection conn = null;
         BufferedReader reader = null;
 
@@ -69,7 +70,7 @@ public class RuyiApi {
             conn.setReadTimeout(TIMEOUT);
 
             if (conn.getResponseCode() != 200) {
-                throw new IOException("HTTP " + conn.getResponseCode());
+                throw RuyiApiException.unexpectedStatusCode(conn.getResponseCode());
             }
 
             reader = new BufferedReader(new InputStreamReader(conn.getInputStream()));
@@ -80,9 +81,17 @@ public class RuyiApi {
             }
 
             return new JSONObject(response.toString());
+        } catch (URISyntaxException | MalformedURLException e) {
+            throw RuyiApiException.invalidArgument(path);
+        } catch (IOException e) {
+            throw RuyiApiException.ioError(e);
         } finally {
             if (reader != null) {
-                reader.close();
+                try {
+                    reader.close();
+                } catch (IOException e) {
+                    // ignore
+                }
             }
             if (conn != null) {
                 conn.disconnect();

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiApiException.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiApiException.java
@@ -1,9 +1,13 @@
 package org.ruyisdk.ruyi.services;
 
+import java.io.IOException;
+import org.json.JSONException;
+import org.ruyisdk.core.exception.PluginException;
+
 /**
  * RuyiApi专用异常.
  */
-public class RuyiApiException extends Exception {
+public class RuyiApiException extends PluginException {
     private static final long serialVersionUID = 1L;
 
     /**
@@ -11,7 +15,7 @@ public class RuyiApiException extends Exception {
      *
      * @param message 异常消息
      */
-    public RuyiApiException(String message) {
+    private RuyiApiException(String message) {
         super(message);
     }
 
@@ -21,7 +25,32 @@ public class RuyiApiException extends Exception {
      * @param message 异常消息
      * @param cause 原始异常
      */
-    public RuyiApiException(String message, Throwable cause) {
+    private RuyiApiException(String message, Throwable cause) {
         super(message, cause);
+    }
+
+    /** Operation was cancelled. */
+    public static RuyiApiException cancelled() {
+        return new RuyiApiException("ruyi command was cancelled");
+    }
+
+    /** Unexpected status code. */
+    public static RuyiApiException unexpectedStatusCode(int code) {
+        return new RuyiApiException("Unexpected status code: " + code);
+    }
+
+    /** Invalid argument provided to CLI. */
+    public static RuyiApiException invalidArgument(String message) {
+        return new RuyiApiException(message);
+    }
+
+    /** I/O error during API request. */
+    public static RuyiApiException ioError(IOException cause) {
+        return new RuyiApiException("I/O error during API request", cause);
+    }
+
+    /** JSON error during API request. */
+    public static RuyiApiException jsonError(JSONException cause) {
+        return new RuyiApiException("JSON error during API request", cause);
     }
 }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
@@ -251,41 +251,37 @@ public class RuyiCli {
                 }
             }
 
-        } catch (Exception e) {
-            // ignore - return empty list
+        } catch (IOException e) {
+            throw RuyiCliException.ioError(e);
         }
         return out;
     }
 
     /** Lists available news items using the ruyi CLI. */
     public static List<NewsListItemInfo> listNewsItems(boolean onlyUnread) {
-        try {
-            final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(true)
-                            .news().list(onlyUnread).end().build();
-            final var result = request.execute();
-            return parseNewsListFromString(result.getOutput());
-        } catch (Exception e) {
-            // ignore
-        }
-        return new ArrayList<>();
+        final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(true).news()
+                        .list(onlyUnread).end().build();
+        final var result = request.execute();
+        return parseNewsListFromString(result.getOutput());
     }
 
-    /** Reads a news item by ID or ordinal using the ruyi CLI. */
+    /**
+     * Reads a news item by ID or ordinal using the ruyi CLI.
+     *
+     * @param idOrOrdinal news item ID or ordinal
+     * @return the news read result
+     */
     public static NewsReadResult readNewsItem(String idOrOrdinal) {
-        try {
-            if (idOrOrdinal == null || idOrOrdinal.isBlank()) {
-                return null;
-            }
-            // TODO: the 3-second timeout help us avoid hanging if the CLI gets stuck trying to read news
-            // content.
-            // The hang is due to a unresolved bug.
-            final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(true)
-                            .timeoutSeconds(3).news().read(idOrOrdinal).end().build();
-            final var result = request.execute();
-            return parseNewsReadFromString(result.getOutput());
-        } catch (Exception e) {
-            return null;
+        if (idOrOrdinal == null || idOrOrdinal.isBlank()) {
+            throw RuyiCliException.invalidArgument("Invalid news item ID or ordinal");
         }
+        // TODO: the 3-second timeout help us avoid hanging if the CLI gets stuck trying to read news
+        // content.
+        // The hang is due to a unresolved bug.
+        final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(true)
+                        .timeoutSeconds(3).news().read(idOrOrdinal).end().build();
+        final var result = request.execute();
+        return parseNewsReadFromString(result.getOutput());
     }
 
     /** Parses the output of a news list command. */
@@ -294,24 +290,20 @@ public class RuyiCli {
         if (input == null || input.isBlank()) {
             return out;
         }
-        try {
-            for (final var o : parseConcatenatedJsonObjects(input)) {
-                if (o == null) {
-                    continue;
-                }
-                final var ty = o.optString("ty", null);
-                if (!"newsitem-v1".equalsIgnoreCase(ty)) {
-                    continue;
-                }
-                final var id = o.optString("id", null);
-                final var ord = o.optIntegerObject("ord", null);
-                final var isRead = o.optBooleanObject("is_read", null);
-                final var langs = o.optJSONArray("langs");
-                final var title = chooseNewsDisplayTitle(langs);
-                out.add(new NewsListItemInfo(id, ord, isRead, title));
+        for (final var o : parseConcatenatedJsonObjects(input)) {
+            if (o == null) {
+                continue;
             }
-        } catch (Exception e) {
-            // ignore
+            final var ty = o.optString("ty", null);
+            if (!"newsitem-v1".equalsIgnoreCase(ty)) {
+                continue;
+            }
+            final var id = o.optString("id", null);
+            final var ord = o.optIntegerObject("ord", null);
+            final var isRead = o.optBooleanObject("is_read", null);
+            final var langs = o.optJSONArray("langs");
+            final var title = chooseNewsDisplayTitle(langs);
+            out.add(new NewsListItemInfo(id, ord, isRead, title));
         }
         return out;
     }
@@ -321,25 +313,21 @@ public class RuyiCli {
         if (input == null || input.isBlank()) {
             return null;
         }
-        try {
-            final var objs = parseConcatenatedJsonObjects(input);
-            if (objs.isEmpty()) {
-                return null;
-            }
-            final var o = objs.get(0);
-            if (o == null) {
-                return null;
-            }
-            final var id = o.optString("id", null);
-            final var ord = o.optIntegerObject("ord", null);
-            final var isRead = o.optBooleanObject("is_read", null);
-            final var langs = o.optJSONArray("langs");
-            final var title = chooseNewsDisplayTitle(langs);
-            final var content = chooseNewsContent(langs);
-            return new NewsReadResult(id, ord, isRead, title, content);
-        } catch (Exception e) {
+        final var objs = parseConcatenatedJsonObjects(input);
+        if (objs.isEmpty()) {
             return null;
         }
+        final var o = objs.get(0);
+        if (o == null) {
+            return null;
+        }
+        final var id = o.optString("id", null);
+        final var ord = o.optIntegerObject("ord", null);
+        final var isRead = o.optBooleanObject("is_read", null);
+        final var langs = o.optJSONArray("langs");
+        final var title = chooseNewsDisplayTitle(langs);
+        final var content = chooseNewsContent(langs);
+        return new NewsReadResult(id, ord, isRead, title, content);
     }
 
     private static List<JSONObject> parseConcatenatedJsonObjects(String input) {
@@ -347,31 +335,27 @@ public class RuyiCli {
         if (input == null) {
             return out;
         }
-        try {
-            final var t = new JSONTokener(input);
-            while (true) {
-                final var c = t.nextClean();
-                if (c == 0) {
-                    break;
-                }
-                t.back();
-                final var v = t.nextValue();
-                if (v instanceof JSONObject) {
-                    out.add((JSONObject) v);
-                } else if (v instanceof JSONArray) {
-                    final var arr = (JSONArray) v;
-                    for (int i = 0; i < arr.length(); i++) {
-                        final var el = arr.get(i);
-                        if (el instanceof JSONObject) {
-                            out.add((JSONObject) el);
-                        }
-                    }
-                } else {
-                    // ignore other values
-                }
+        final var t = new JSONTokener(input);
+        while (true) {
+            final var c = t.nextClean();
+            if (c == 0) {
+                break;
             }
-        } catch (Exception e) {
-            // ignore
+            t.back();
+            final var v = t.nextValue();
+            if (v instanceof JSONObject) {
+                out.add((JSONObject) v);
+            } else if (v instanceof JSONArray) {
+                final var arr = (JSONArray) v;
+                for (int i = 0; i < arr.length(); i++) {
+                    final var el = arr.get(i);
+                    if (el instanceof JSONObject) {
+                        out.add((JSONObject) el);
+                    }
+                }
+            } else {
+                // ignore other values
+            }
         }
         return out;
     }
@@ -429,11 +413,7 @@ public class RuyiCli {
     }
 
     private static String requireInstallPathResult() {
-        try {
-            return RuyiFileUtils.findInstallPathWithRuyi();
-        } catch (Exception e) {
-            return "";
-        }
+        return RuyiFileUtils.findInstallPathWithRuyi();
     }
 
     /**
@@ -442,9 +422,8 @@ public class RuyiCli {
      * @param args arguments without the `ruyi` executable
      * @param workingDirectory working directory for the process (may be {@code null})
      * @return command result with exit code and captured output
-     * @throws RuyiCliException if the command fails
      */
-    public static String runRuyiExperimental(List<String> args, File workingDirectory) throws RuyiCliException {
+    public static String runRuyiExperimental(List<String> args, File workingDirectory) {
         final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false)
                         .args(args).experimental(true).workingDirectory(workingDirectory).build();
         return request.execute().getOutput();
@@ -455,13 +434,11 @@ public class RuyiCli {
      * Gets the path to the resolved {@code ruyi} executable.
      *
      * @return executable path
-     *
-     * @throws IOException if no executable can be resolved
      */
-    public static String getResolvedExecutablePath() throws IOException {
+    public static String getResolvedExecutablePath() {
         final var install = requireInstallPathResult();
         if (install == null || install.isBlank()) {
-            throw new IOException("ruyi executable not found in configured or default install path");
+            throw RuyiCliException.ruyiNotFound();
         }
         return install + File.separator + "ruyi";
     }
@@ -469,9 +446,8 @@ public class RuyiCli {
     /**
      * Updates package index.
      *
-     * @throws RuyiCliException if update fails
      */
-    public static void updatePackageIndex() throws RuyiCliException {
+    public static void updatePackageIndex() {
         final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(true).update()
                         .end().build();
         request.execute();
@@ -483,14 +459,10 @@ public class RuyiCli {
      * @return version or null if not available or command fails
      */
     public static RuyiVersion getInstalledVersion() {
-        try {
-            final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false)
-                            .args("-V").build();
-            final var result = request.execute();
-            return parseInstalledVersion(result);
-        } catch (RuyiCliException e) {
-            return null;
-        }
+        final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false)
+                        .args("-V").build();
+        final var result = request.execute();
+        return parseInstalledVersion(result);
     }
 
     private static RuyiVersion parseInstalledVersion(RuyiExecResult result) {
@@ -498,33 +470,22 @@ public class RuyiCli {
             return null;
         }
 
-        try (final var reader = new BufferedReader(new StringReader(result.getOutput()))) {
-            final var firstLine = reader.readLine();
-            if (firstLine == null) {
-                return null;
-            }
+        final var pattern = Pattern.compile("^Ruyi\\s+(\\d+\\.\\d+\\.\\d+)\\b");
+        final var matcher = pattern.matcher(result.getOutput());
 
-            final var prefix = "Ruyi ";
-            if (firstLine.startsWith(prefix)) {
-                final var versionStr = firstLine.substring(prefix.length()).trim();
-                if (versionStr.matches("^\\d+\\.\\d+\\.\\d+$")) {
-                    return RuyiVersion.parse(versionStr);
-                }
-            }
-        } catch (IOException e) {
-            // Should not happen with StringReader, but handle it gracefully
+        if (!matcher.find()) {
             return null;
         }
-        return null;
+        final var versionStr = matcher.group(1);
+        return RuyiVersion.parse(versionStr);
     }
 
     /**
      * Sets repository remote URL.
      *
      * @param remoteUrl remote repository URL
-     * @throws RuyiCliException if command fails
      */
-    public static void setRepoRemote(String remoteUrl) throws RuyiCliException {
+    public static void setRepoRemote(String remoteUrl) {
         RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false).config()
                         .set("repo.remote", remoteUrl).end().build().execute();
     }
@@ -535,23 +496,18 @@ public class RuyiCli {
      * @return repository URL or null if not available or command fails
      */
     public static String getRepoRemote() {
-        try {
-            final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false)
-                            .config().get("repo.remote").end().build();
-            final var result = request.execute();
-            return readFirstLine(result);
-        } catch (RuyiCliException e) {
-            return null;
-        }
+        final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false)
+                        .config().get("repo.remote").end().build();
+        final var result = request.execute();
+        return readFirstLine(result);
     }
 
     /**
      * Sets repository branch.
      *
      * @param branch branch name
-     * @throws RuyiCliException if command fails
      */
-    public static void setRepoBranch(String branch) throws RuyiCliException {
+    public static void setRepoBranch(String branch) {
         final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false)
                         .config().set("repo.branch", branch).end().build();
         request.execute();
@@ -563,23 +519,18 @@ public class RuyiCli {
      * @return branch name or null if not set
      */
     public static String getRepoBranch() {
-        try {
-            final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false)
-                            .config().get("repo.branch").end().build();
-            final var result = request.execute();
-            return readFirstLine(result);
-        } catch (RuyiCliException e) {
-            return null;
-        }
+        final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false)
+                        .config().get("repo.branch").end().build();
+        final var result = request.execute();
+        return readFirstLine(result);
     }
 
     /**
      * Sets repository local checkout path override.
      *
      * @param localPath local path, or null/empty to unset
-     * @throws RuyiCliException if command fails
      */
-    public static void setRepoLocal(String localPath) throws RuyiCliException {
+    public static void setRepoLocal(String localPath) {
         if (localPath == null || localPath.isBlank()) {
             RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false).config()
                             .unset("repo.local").end().build().execute();
@@ -595,23 +546,18 @@ public class RuyiCli {
      * @return local path or null if not set
      */
     public static String getRepoLocal() {
-        try {
-            final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false)
-                            .config().get("repo.local").end().build();
-            final var result = request.execute();
-            return readFirstLine(result);
-        } catch (RuyiCliException e) {
-            return null;
-        }
+        final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false)
+                        .config().get("repo.local").end().build();
+        final var result = request.execute();
+        return readFirstLine(result);
     }
 
     /**
      * Sets packages.prereleases config.
      *
      * @param enabled true to include pre-release packages
-     * @throws RuyiCliException if command fails
      */
-    public static void setPackagesPrereleases(boolean enabled) throws RuyiCliException {
+    public static void setPackagesPrereleases(boolean enabled) {
         RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false).config()
                         .set("packages.prereleases", enabled ? "true" : "false").end().build().execute();
     }
@@ -622,23 +568,18 @@ public class RuyiCli {
      * @return true if pre-releases enabled, false otherwise
      */
     public static boolean getPackagesPrereleases() {
-        try {
-            final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false)
-                            .config().get("packages.prereleases").end().build();
-            final var result = request.execute();
-            return "true".equals(readFirstLine(result));
-        } catch (RuyiCliException e) {
-            return false;
-        }
+        final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false)
+                        .config().get("packages.prereleases").end().build();
+        final var result = request.execute();
+        return "true".equals(readFirstLine(result));
     }
 
     /**
      * Sets telemetry mode.
      *
      * @param mode telemetry mode
-     * @throws RuyiCliException if command fails
      */
-    public static void setTelemetry(TelemetryMode mode) throws RuyiCliException {
+    public static void setTelemetry(TelemetryMode mode) {
         final var telemetryBuilder = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult())
                         .porcelain(false).telemetry();
         switch (mode) {
@@ -665,14 +606,10 @@ public class RuyiCli {
      * @return the first line of telemetry status output or null if not available or command fails
      */
     public static String getTelemetryMode() {
-        try {
-            final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false)
-                            .telemetry().status().end().build();
-            final var result = request.execute();
-            return readFirstLine(result);
-        } catch (RuyiCliException e) {
-            return null;
-        }
+        final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false)
+                        .telemetry().status().end().build();
+        final var result = request.execute();
+        return readFirstLine(result);
     }
 
     private static String readFirstLine(RuyiExecResult result) {
@@ -691,9 +628,8 @@ public class RuyiCli {
     /**
      * Uploads telemetry data.
      *
-     * @throws RuyiCliException if upload fails
      */
-    public static void telemetryUpload() throws RuyiCliException {
+    public static void telemetryUpload() {
         final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(false)
                         .telemetry().upload().end().build();
         request.execute();
@@ -704,9 +640,8 @@ public class RuyiCli {
      *
      * @param entity entity id such as device:milkv-duo
      * @return command result with exit code and captured output
-     * @throws RuyiCliException if the command fails
      */
-    public static String listRelatedToEntity(String entity) throws RuyiCliException {
+    public static String listRelatedToEntity(String entity) {
         if (entity == null || entity.isBlank()) {
             throw RuyiCliException.invalidArgument("Invalid entity");
         }
@@ -719,9 +654,8 @@ public class RuyiCli {
      * Lists all available packages.
      *
      * @return command result with captured output
-     * @throws RuyiCliException if the command fails
      */
-    public static String listAllPackages() throws RuyiCliException {
+    public static String listAllPackages() {
         final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(true)
                         .experimental(true).list().nameContains("").end().build();
         return request.execute().getOutput();
@@ -732,9 +666,8 @@ public class RuyiCli {
      *
      * @param type entity type such as device
      * @return command result with exit code and captured output
-     * @throws RuyiCliException if the command fails
      */
-    public static String listEntitiesByType(String type) throws RuyiCliException {
+    public static String listEntitiesByType(String type) {
         if (type == null || type.isBlank()) {
             throw RuyiCliException.invalidArgument("Invalid entity type");
         }
@@ -749,9 +682,8 @@ public class RuyiCli {
      *
      * @param name package name
      * @param version package version
-     * @throws RuyiCliException if the command fails
      */
-    public static void installPackage(String name, String version) throws RuyiCliException {
+    public static void installPackage(String name, String version) {
         if (name == null || name.isBlank() || version == null || version.isBlank()) {
             throw RuyiCliException.invalidArgument("Invalid package name or version");
         }
@@ -769,10 +701,9 @@ public class RuyiCli {
      * @param packageRef package atom, e.g. name(version)
      * @param lineCallback called for each output line (may be {@code null})
      * @param monitor progress monitor for cancellation (may be {@code null})
-     * @throws RuyiCliException if the command fails
      */
     public static void installPackageStreaming(String packageRef, Consumer<String> lineCallback,
-                    IProgressMonitor monitor) throws RuyiCliException {
+                    IProgressMonitor monitor) {
         if (packageRef == null || packageRef.isBlank()) {
             throw RuyiCliException.invalidArgument("Invalid package reference");
         }
@@ -789,10 +720,9 @@ public class RuyiCli {
      * @param assumeYes whether to pass -y
      * @param lineCallback called for each output line (may be {@code null})
      * @param monitor progress monitor for cancellation (may be {@code null})
-     * @throws RuyiCliException if the command fails
      */
     public static void uninstallPackageStreaming(String packageRef, boolean assumeYes, Consumer<String> lineCallback,
-                    IProgressMonitor monitor) throws RuyiCliException {
+                    IProgressMonitor monitor) {
         if (packageRef == null || packageRef.isBlank()) {
             throw RuyiCliException.invalidArgument("Invalid package reference");
         }
@@ -812,10 +742,9 @@ public class RuyiCli {
      * @param profile profile name (required)
      * @param emulatorName optional emulator package name (may be null)
      * @param emulatorVersion optional emulator version (may be null)
-     * @throws RuyiCliException if the command fails or arguments are invalid
      */
     public static void createVenv(String path, String toolchainName, String toolchainVersion, String profile,
-                    String emulatorName, String emulatorVersion) throws RuyiCliException {
+                    String emulatorName, String emulatorVersion) {
         if (path == null || path.isBlank()) {
             throw RuyiCliException.invalidArgument("Empty venv path");
         }
@@ -869,18 +798,14 @@ public class RuyiCli {
     /** Lists available toolchains as reported by the ruyi CLI. */
     public static List<ToolchainInfo> listToolchains() {
         final var out = new ArrayList<ToolchainInfo>();
-        try {
-            final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(true)
-                            .list().toolchains().end().build();
-            final var result = request.execute();
-            final var output = result.getOutput();
-            if (output == null || output.isEmpty()) {
-                return out;
-            }
-            out.addAll(parseToolchainsFromString(output));
-        } catch (Exception e) {
-            // ignore
+        final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(true).list()
+                        .toolchains().end().build();
+        final var result = request.execute();
+        final var output = result.getOutput();
+        if (output == null || output.isEmpty()) {
+            return out;
         }
+        out.addAll(parseToolchainsFromString(output));
         return out;
     }
 
@@ -891,55 +816,43 @@ public class RuyiCli {
      */
     public static List<ToolchainInfo> parseToolchainsFromString(String input) {
         final var out = new ArrayList<ToolchainInfo>();
-        try {
-            if (input == null || input.isEmpty()) {
-                return out;
+        if (input == null || input.isEmpty()) {
+            return out;
+        }
+        final var objs = extractJsonObjects(input);
+        for (final var jo : objs) {
+            if (jo == null || jo.isBlank()) {
+                continue;
             }
-            final var objs = extractJsonObjects(input);
-            for (final var jo : objs) {
-                if (jo == null || jo.isBlank()) {
-                    continue;
-                }
-                try {
-                    final var o = new JSONObject(jo);
-                    final var category = o.optString("category", "");
-                    if (!"toolchain".equalsIgnoreCase(category)) {
+            final var o = new JSONObject(jo);
+            final var category = o.optString("category", "");
+            if (!"toolchain".equalsIgnoreCase(category)) {
+                continue;
+            }
+            final var pkgName = o.optString("name", "").trim();
+            if (pkgName.isEmpty()) {
+                continue;
+            }
+            final var versions = new ArrayList<String>();
+            final var vers = o.optJSONArray("vers");
+            if (vers != null && vers.length() > 0) {
+                for (int vi = 0; vi < vers.length(); vi++) {
+                    final var v = vers.optJSONObject(vi);
+                    if (v == null) {
                         continue;
                     }
-                    final var pkgName = o.optString("name", "").trim();
-                    if (pkgName.isEmpty()) {
-                        continue;
+                    final var sem = v.optString("semver", v.optString("version", "")).trim();
+                    if (sem != null && !sem.isEmpty()) {
+                        versions.add(sem);
                     }
-                    final var versions = new ArrayList<String>();
-                    final var vers = o.optJSONArray("vers");
-                    if (vers != null && vers.length() > 0) {
-                        for (int vi = 0; vi < vers.length(); vi++) {
-                            try {
-                                final var v = vers.optJSONObject(vi);
-                                if (v == null) {
-                                    continue;
-                                }
-                                final var sem = v.optString("semver", v.optString("version", "")).trim();
-                                if (sem != null && !sem.isEmpty()) {
-                                    versions.add(sem);
-                                }
-                            } catch (Exception ex) {
-                                // ignore individual version parse problems
-                            }
-                        }
-                    }
-                    // Extract quirks (flavors) from the first version's metadata
-                    final var quirks = extractPackageQuirks(vers, "toolchain");
-                    // only expose packages for which we actually know at least one version
-                    if (!versions.isEmpty()) {
-                        out.add(new ToolchainInfo(pkgName, versions, quirks));
-                    }
-                } catch (Exception e) {
-                    // ignore malformed object and continue parsing others
                 }
             }
-        } catch (Exception outer) {
-            // defensive: never fail the caller due to parsing problems
+            // Extract quirks (flavors) from the first version's metadata
+            final var quirks = extractPackageQuirks(vers, "toolchain");
+            // only expose packages for which we actually know at least one version
+            if (!versions.isEmpty()) {
+                out.add(new ToolchainInfo(pkgName, versions, quirks));
+            }
         }
         return out;
     }
@@ -947,18 +860,14 @@ public class RuyiCli {
     /** Lists available emulators as reported by the ruyi CLI. */
     public static List<EmulatorInfo> listEmulators() {
         final var out = new ArrayList<EmulatorInfo>();
-        try {
-            final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(true)
-                            .list().emulators().end().build();
-            final var result = request.execute();
-            final var output = result.getOutput();
-            if (output == null || output.isEmpty()) {
-                return out;
-            }
-            out.addAll(parseEmulatorsFromString(output));
-        } catch (Exception e) {
-            // ignore
+        final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult()).porcelain(true).list()
+                        .emulators().end().build();
+        final var result = request.execute();
+        final var output = result.getOutput();
+        if (output == null || output.isEmpty()) {
+            return out;
         }
+        out.addAll(parseEmulatorsFromString(output));
         return out;
     }
 
@@ -969,54 +878,42 @@ public class RuyiCli {
      */
     public static List<EmulatorInfo> parseEmulatorsFromString(String input) {
         final var out = new ArrayList<EmulatorInfo>();
-        try {
-            if (input == null || input.isEmpty()) {
-                return out;
+        if (input == null || input.isEmpty()) {
+            return out;
+        }
+        final var objs = extractJsonObjects(input);
+        for (final var jo : objs) {
+            if (jo == null || jo.isBlank()) {
+                continue;
             }
-            final var objs = extractJsonObjects(input);
-            for (final var jo : objs) {
-                if (jo == null || jo.isBlank()) {
-                    continue;
-                }
-                try {
-                    final var o = new JSONObject(jo);
-                    final var category = o.optString("category", "");
-                    if (!"emulator".equalsIgnoreCase(category)) {
+            final var o = new JSONObject(jo);
+            final var category = o.optString("category", "");
+            if (!"emulator".equalsIgnoreCase(category)) {
+                continue;
+            }
+            final var pkgName = o.optString("name", "").trim();
+            if (pkgName.isEmpty()) {
+                continue;
+            }
+            final var versions = new ArrayList<String>();
+            final var vers = o.optJSONArray("vers");
+            if (vers != null && vers.length() > 0) {
+                for (int vi = 0; vi < vers.length(); vi++) {
+                    final var v = vers.optJSONObject(vi);
+                    if (v == null) {
                         continue;
                     }
-                    final var pkgName = o.optString("name", "").trim();
-                    if (pkgName.isEmpty()) {
-                        continue;
+                    final var sem = v.optString("semver", v.optString("version", "")).trim();
+                    if (sem != null && !sem.isEmpty()) {
+                        versions.add(sem);
                     }
-                    final var versions = new ArrayList<String>();
-                    final var vers = o.optJSONArray("vers");
-                    if (vers != null && vers.length() > 0) {
-                        for (int vi = 0; vi < vers.length(); vi++) {
-                            try {
-                                final var v = vers.optJSONObject(vi);
-                                if (v == null) {
-                                    continue;
-                                }
-                                final var sem = v.optString("semver", v.optString("version", "")).trim();
-                                if (sem != null && !sem.isEmpty()) {
-                                    versions.add(sem);
-                                }
-                            } catch (Exception ex) {
-                                // ignore individual version parse problems
-                            }
-                        }
-                    }
-                    // Extract quirks (flavors) from the first version's metadata
-                    final var quirks = extractPackageQuirks(vers, "emulator");
-                    if (!versions.isEmpty()) {
-                        out.add(new EmulatorInfo(pkgName, versions, quirks));
-                    }
-                } catch (Exception e) {
-                    // ignore malformed object and continue parsing others
                 }
             }
-        } catch (Exception outer) {
-            // defensive: never fail the caller due to parsing problems
+            // Extract quirks (flavors) from the first version's metadata
+            final var quirks = extractPackageQuirks(vers, "emulator");
+            if (!versions.isEmpty()) {
+                out.add(new EmulatorInfo(pkgName, versions, quirks));
+            }
         }
         return out;
     }
@@ -1031,25 +928,21 @@ public class RuyiCli {
         }
         final var quirksSet = new LinkedHashSet<String>();
         for (int vi = 0; vi < vers.length(); vi++) {
-            try {
-                final var v = vers.optJSONObject(vi);
-                if (v == null) {
-                    continue;
-                }
-                final var pm = v.optJSONObject("pm");
-                if (pm == null) {
-                    continue;
-                }
-                final var meta = pm.optJSONObject(metadataKey);
-                if (meta == null) {
-                    continue;
-                }
-                collectJsonArrayStrings(meta.optJSONArray("quirks"), quirksSet);
-                collectJsonArrayStrings(meta.optJSONArray("flavors"), quirksSet);
-                break; // all versions should have the same quirks, so use first version's metadata
-            } catch (Exception e) {
-                // ignore
+            final var v = vers.optJSONObject(vi);
+            if (v == null) {
+                continue;
             }
+            final var pm = v.optJSONObject("pm");
+            if (pm == null) {
+                continue;
+            }
+            final var meta = pm.optJSONObject(metadataKey);
+            if (meta == null) {
+                continue;
+            }
+            collectJsonArrayStrings(meta.optJSONArray("quirks"), quirksSet);
+            collectJsonArrayStrings(meta.optJSONArray("flavors"), quirksSet);
+            break; // all versions should have the same quirks, so use first version's metadata
         }
         return new ArrayList<>(quirksSet);
     }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliException.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliException.java
@@ -1,11 +1,13 @@
 package org.ruyisdk.ruyi.services;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import org.ruyisdk.core.exception.PluginException;
 
 /**
  * Exception thrown when a Ruyi CLI operation fails.
  */
-public class RuyiCliException extends Exception {
+public class RuyiCliException extends PluginException {
     private static final long serialVersionUID = 1L;
 
     private RuyiCliException(String message) {
@@ -22,12 +24,13 @@ public class RuyiCliException extends Exception {
     }
 
     /** CLI command returned non-zero exit code. CLI output is included in the message. */
-    public static RuyiCliException executionFailed(String output, String commandHint) {
-        final var sb = new StringBuilder("ruyi command execution failed: ").append(commandHint);
-        if (output != null && !output.isBlank()) {
-            sb.append("\n\nCLI Output:\n").append(output);
-        }
-        return new RuyiCliException(sb.toString());
+    public static RuyiCliException executionFailed(String commandHint, int exitCode, String output) {
+        final var message = String.format("""
+            ruyi command execution failed with code: %d
+            Command: %s
+            CLI Output:
+            %s""", exitCode, commandHint, output);
+        return new RuyiCliException(message);
     }
 
     /** Invalid argument provided to CLI. */
@@ -48,5 +51,15 @@ public class RuyiCliException extends Exception {
     /** I/O error during CLI execution. */
     public static RuyiCliException ioError(IOException cause) {
         return new RuyiCliException("I/O error during ruyi command execution", cause);
+    }
+
+    /** {@link ExecutionException} during CLI execution. */
+    public static RuyiCliException executionError(ExecutionException e) {
+        return new RuyiCliException("Unexpected error during ruyi command execution", e.getCause());
+    }
+
+    /** Eclipse terminal service is not available. */
+    public static RuyiCliException terminalUnavailable() {
+        return new RuyiCliException("Eclipse terminal service is unavailable");
     }
 }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliExecutor.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliExecutor.java
@@ -1,6 +1,5 @@
 package org.ruyisdk.ruyi.services;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -10,13 +9,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.OperationCanceledException;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.ruyi.Activator;
 
@@ -48,13 +45,9 @@ public final class RuyiCliExecutor {
      * @param timeoutSeconds maximum seconds to wait, 0 for unlimited
      * @param args ruyi arguments
      * @return command result with exit code and accumulated output
-     * @throws IOException if process launch fails
-     * @throws InterruptedException if interrupted while waiting
-     * @throws OperationCanceledException if the monitor is cancelled
      */
     public static RuyiExecResult execute(String ruyiInstallDir, Map<String, String> environment, File workingDirectory,
-                    Consumer<String> lineCallback, IProgressMonitor monitor, int timeoutSeconds, String... args)
-                    throws IOException, InterruptedException {
+                    Consumer<String> lineCallback, IProgressMonitor monitor, int timeoutSeconds, String... args) {
         final var command = buildCommand(ruyiInstallDir, args);
         return executeCommand(command, environment, workingDirectory, true, lineCallback, monitor, timeoutSeconds);
     }
@@ -73,7 +66,7 @@ public final class RuyiCliExecutor {
     }
 
     private static Process startProcess(List<String> command, Map<String, String> environment, File workingDirectory,
-                    boolean redirectErrorStream) throws IOException {
+                    boolean redirectErrorStream) {
         final var processBuilder = new ProcessBuilder(command);
         processBuilder.redirectErrorStream(redirectErrorStream);
         if (workingDirectory != null) {
@@ -82,138 +75,120 @@ public final class RuyiCliExecutor {
         if (environment != null && !environment.isEmpty()) {
             processBuilder.environment().putAll(environment);
         }
-        return processBuilder.start();
+        try {
+            return processBuilder.start();
+        } catch (IOException e) {
+            throw RuyiCliException.ioError(e);
+        }
     }
 
     private static RuyiExecResult executeCommand(List<String> command, Map<String, String> environment,
                     File workingDirectory, boolean redirectErrorStream, Consumer<String> lineCallback,
-                    IProgressMonitor monitor, int timeoutSeconds) throws IOException, InterruptedException {
+                    IProgressMonitor monitor, int timeoutSeconds) {
         LOGGER.logInfo("[RuyiCliExecutor] Executing ruyi command: [" + String.join("] [", command) + "]");
         final var process = startProcess(command, environment, workingDirectory, redirectErrorStream);
         final var outputFuture = CompletableFuture.supplyAsync(() -> {
-            try {
-                return readLines(process, lineCallback, monitor);
-            } catch (IOException e) {
-                throw new CompletionException(e);
-            }
+            return readLines(process, lineCallback, monitor);
         });
         final long deadlineNanos = timeoutSeconds > 0 ? System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds)
                         : Long.MAX_VALUE;
-        var cleanupStreams = true;
-        var cancelOutputFuture = false;
         try {
             waitForProcess(process, monitor, deadlineNanos, timeoutSeconds);
             final var output = awaitOutput(outputFuture, deadlineNanos, timeoutSeconds);
             final var exitCode = process.exitValue();
             LOGGER.logInfo("[RuyiCliExecutor] ruyi command exited with code: " + exitCode);
             return new RuyiExecResult(exitCode, output);
-        } catch (OperationCanceledException e) {
-            cancelOutputFuture = true;
-            LOGGER.logInfo("[RuyiCliExecutor] ruyi command cancelled");
-            throw e;
-        } catch (TimeoutException e) {
-            cancelOutputFuture = true;
-            LOGGER.logInfo("[RuyiCliExecutor] ruyi command timed out after " + timeoutSeconds + "s");
-            return new RuyiExecResult(-1, "ruyi command timed out");
-        } catch (InterruptedException e) {
-            cancelOutputFuture = true;
-            throw e;
-        } catch (ExecutionException e) {
-            cleanupStreams = false;
-
-            final var cause = e.getCause();
-            if (cause instanceof CompletionException && cause.getCause() != null) {
-                throw unwrapThrowable(cause.getCause());
-            }
-            throw unwrapThrowable(cause);
         } finally {
-            cleanupProcess(process, outputFuture, cancelOutputFuture, cleanupStreams);
+            cleanupProcess(process, outputFuture);
         }
     }
 
-    private static void cleanupProcess(Process process, CompletableFuture<String> outputFuture,
-                    boolean cancelOutputFuture, boolean closeStreams) throws InterruptedException {
-        if (cancelOutputFuture) {
+    private static void cleanupProcess(Process process, CompletableFuture<String> outputFuture) {
+        try {
             outputFuture.cancel(true);
-        }
-        if (closeStreams) {
-            closeQuietly(process.getInputStream());
-            closeQuietly(process.getErrorStream());
-            closeQuietly(process.getOutputStream());
+        } catch (CancellationException e) {
+            // why not "throws CancellationException"???
+            // ignore
         }
 
-        if (process.isAlive()) {
+        try {
+            process.getInputStream().close();
+            process.getErrorStream().close();
+            process.getOutputStream().close();
+        } catch (IOException e) {
+            // ignore
+        }
+
+        try {
             process.destroy();
             if (!process.waitFor(WAIT_SLICE_MILLIS, TimeUnit.MILLISECONDS) && process.isAlive()) {
                 process.destroyForcibly();
                 process.waitFor();
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            // ignore
         }
 
         try {
             outputFuture.get(OUTPUT_JOIN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-        } catch (CancellationException | ExecutionException | TimeoutException e) {
-            LOGGER.logInfo("[RuyiCliExecutor] Output reader finished during cleanup: " + e.getClass().getSimpleName());
-        }
-    }
-
-    private static void closeQuietly(Closeable closeable) {
-        try {
-            closeable.close();
-        } catch (IOException e) {
-            LOGGER.logInfo("[RuyiCliExecutor] Ignoring close failure during process cleanup: " + e.getMessage());
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            // ignore
         }
     }
 
     private static void waitForProcess(Process process, IProgressMonitor monitor, long deadlineNanos,
-                    int timeoutSeconds) throws InterruptedException, TimeoutException {
+                    int timeoutSeconds) {
         while (true) {
             if (monitor != null && monitor.isCanceled()) {
-                throw new OperationCanceledException();
+                throw RuyiCliException.cancelled();
             }
-            if (process.waitFor(WAIT_SLICE_MILLIS, TimeUnit.MILLISECONDS)) {
-                return;
+            try {
+                if (process.waitFor(WAIT_SLICE_MILLIS, TimeUnit.MILLISECONDS)) {
+                    return;
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw RuyiCliException.cancelled();
             }
             if (timeoutSeconds > 0 && System.nanoTime() >= deadlineNanos) {
-                throw new TimeoutException();
+                throw RuyiCliException.timeout(timeoutSeconds);
             }
         }
     }
 
-    private static String awaitOutput(CompletableFuture<String> outputFuture, long deadlineNanos, int timeoutSeconds)
-                    throws InterruptedException, ExecutionException, TimeoutException {
-        if (timeoutSeconds <= 0) {
-            return outputFuture.get();
+    private static String awaitOutput(CompletableFuture<String> outputFuture, long deadlineNanos, int timeoutSeconds) {
+        try {
+            if (timeoutSeconds <= 0) {
+                return outputFuture.get();
+            }
+            final long remainingNanos = deadlineNanos - System.nanoTime();
+            if (remainingNanos <= 0) {
+                throw RuyiCliException.timeout(timeoutSeconds);
+            }
+            return outputFuture.get(remainingNanos, TimeUnit.NANOSECONDS);
+        } catch (TimeoutException e) {
+            LOGGER.logWarning("[RuyiCliExecutor] ruyi command timed out after " + timeoutSeconds + "s");
+            throw RuyiCliException.timeout(timeoutSeconds);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw RuyiCliException.cancelled();
+        } catch (ExecutionException e) {
+            throw RuyiCliException.executionError(e);
         }
-        final long remainingNanos = deadlineNanos - System.nanoTime();
-        if (remainingNanos <= 0) {
-            throw new TimeoutException();
-        }
-        return outputFuture.get(remainingNanos, TimeUnit.NANOSECONDS);
-    }
-
-    private static IOException unwrapThrowable(Throwable throwable) throws IOException {
-        if (throwable instanceof IOException ioException) {
-            return ioException;
-        }
-        if (throwable instanceof RuntimeException runtimeException) {
-            throw runtimeException;
-        }
-        throw new IOException("Failed to read process output", throwable);
     }
 
     /**
      * Reads process output line-by-line using {@link Process#inputReader()}. Supports optional per-line
      * callback and cancellation via monitor.
      */
-    private static String readLines(Process process, Consumer<String> lineCallback, IProgressMonitor monitor)
-                    throws IOException {
+    private static String readLines(Process process, Consumer<String> lineCallback, IProgressMonitor monitor) {
         final var output = new StringBuilder();
         try (var reader = process.inputReader(StandardCharsets.UTF_8)) {
             String line;
             while ((line = reader.readLine()) != null) {
                 if (monitor != null && monitor.isCanceled()) {
-                    throw new OperationCanceledException();
+                    throw RuyiCliException.cancelled();
                 }
                 output.append(line).append(System.lineSeparator());
 
@@ -222,11 +197,13 @@ public final class RuyiCliExecutor {
                 }
             }
             if (monitor != null && monitor.isCanceled()) {
-                throw new OperationCanceledException();
+                throw RuyiCliException.cancelled();
             }
 
             LOGGER.logInfo("[RuyiCliExecutor] Finished reading output");
             return output.toString();
+        } catch (IOException e) {
+            throw RuyiCliException.ioError(e);
         }
     }
 }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliRequest.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliRequest.java
@@ -1,7 +1,6 @@
 package org.ruyisdk.ruyi.services;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -10,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.OperationCanceledException;
 
 /**
  * An immutable, executable request to the Ruyi CLI.
@@ -52,34 +50,20 @@ public class RuyiCliRequest {
      * Executes this request against the Ruyi CLI.
      *
      * @return the execution result
-     * @throws RuyiCliException if the command fails, times out, or is cancelled
      */
-    public RuyiExecResult execute() throws RuyiCliException {
+    public RuyiExecResult execute() {
         if (ruyiInstallDir == null || ruyiInstallDir.isBlank()) {
             throw RuyiCliException.ruyiNotFound();
         }
 
         final var cmdArgs = buildCommandArgs();
         final var cmdString = buildCommandString(cmdArgs);
-        try {
-            final var result = RuyiCliExecutor.execute(ruyiInstallDir, environment, workingDirectory, lineCallback,
-                            monitor, timeoutSeconds, cmdArgs.toArray(new String[0]));
-            if (result.getExitCode() != 0) {
-                // Check if the output indicates a timeout
-                if (result.getOutput() != null && result.getOutput().contains("ruyi command timed out")) {
-                    throw RuyiCliException.timeout(timeoutSeconds);
-                }
-                throw RuyiCliException.executionFailed(result.getOutput(), cmdString);
-            }
-            return result;
-        } catch (IOException e) {
-            throw RuyiCliException.ioError(e);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw RuyiCliException.cancelled();
-        } catch (OperationCanceledException e) {
-            throw RuyiCliException.cancelled();
+        final var result = RuyiCliExecutor.execute(ruyiInstallDir, environment, workingDirectory, lineCallback, monitor,
+                        timeoutSeconds, cmdArgs.toArray(new String[0]));
+        if (result.getExitCode() != 0) {
+            throw RuyiCliException.executionFailed(cmdString, result.getExitCode(), result.getOutput());
         }
+        return result;
     }
 
     private List<String> buildCommandArgs() {

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiInstallException.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiInstallException.java
@@ -1,0 +1,61 @@
+package org.ruyisdk.ruyi.services;
+
+import java.io.IOException;
+import org.ruyisdk.core.exception.PluginException;
+
+/**
+ * Exception thrown when Ruyi package manager installation fails.
+ */
+public class RuyiInstallException extends PluginException {
+    private static final long serialVersionUID = 1L;
+
+    private RuyiInstallException(String message) {
+        super(message);
+    }
+
+    private RuyiInstallException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /** Failed to create the installation directory. */
+    public static RuyiInstallException directoryCreationFailed(String path, IOException cause) {
+        return new RuyiInstallException("Failed to create installation directory: " + path, cause);
+    }
+
+    /** Filesystem I/O error during installation preparation. */
+    public static RuyiInstallException filesystemError(String message, IOException cause) {
+        return new RuyiInstallException(message, cause);
+    }
+
+    /** Available disk space is below the required threshold. */
+    public static RuyiInstallException insufficientDiskSpace(String requiredMb, String availableMb) {
+        return new RuyiInstallException(String.format("Insufficient disk space. Required: %s MB, available: %s MB",
+                        requiredMb, availableMb));
+    }
+
+    /** All download attempts for the Ruyi binary failed. */
+    public static RuyiInstallException downloadFailed(String message, Throwable cause) {
+        return new RuyiInstallException(message, cause);
+    }
+
+    /** Downloaded executable not found at expected path. */
+    public static RuyiInstallException fileNotFound(String path) {
+        return new RuyiInstallException("File not found: " + path);
+    }
+
+    /** Failed to set executable permissions on the Ruyi binary. */
+    public static RuyiInstallException permissionFailed(String path, Throwable cause) {
+        return new RuyiInstallException("Failed to set executable permissions: " + path, cause);
+    }
+
+    /** Executable permissions could not be verified after setting them. */
+    public static RuyiInstallException permissionVerifyFailed(String path) {
+        return new RuyiInstallException(
+                        "Failed to set executable permissions for: " + path + ". You may need root/sudo privileges.");
+    }
+
+    /** Post-installation validation failed. */
+    public static RuyiInstallException validationFailed(String message) {
+        return new RuyiInstallException(message);
+    }
+}

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiInstallManager.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiInstallManager.java
@@ -1,7 +1,6 @@
 package org.ruyisdk.ruyi.services;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -15,6 +14,7 @@ import java.util.Objects;
 import java.util.Set;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
+import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.core.ruyi.model.RuyiReleaseInfo;
 import org.ruyisdk.core.ruyi.model.SystemInfo;
 import org.ruyisdk.core.util.PluginLogger;
@@ -39,10 +39,9 @@ public final class RuyiInstallManager {
      * @param telemetryMode telemetry setting to apply after install
      * @param monitor progress monitor
      * @param listener installation listener
-     * @throws Exception if installation fails
      */
     public static void install(String destinationDirectory, String repoUrl, TelemetryMode telemetryMode,
-                    IProgressMonitor monitor, InstallationListener listener) throws Exception {
+                    IProgressMonitor monitor, InstallationListener listener) {
         SubMonitor subMonitor = SubMonitor.convert(monitor, "Installing Ruyi", 100);
 
         try {
@@ -57,16 +56,12 @@ public final class RuyiInstallManager {
             listener.logMessage("Installation completed successfully");
 
             configureInstalledRuyi(repoUrl, telemetryMode, listener);
-        } catch (Exception e) {
-            listener.logMessage("Installation failed: " + e.getMessage());
-            throw e;
         } finally {
             subMonitor.done();
         }
     }
 
-    private static void prepareInstallation(String destinationDirectory, InstallationListener listener)
-                    throws Exception {
+    private static void prepareInstallation(String destinationDirectory, InstallationListener listener) {
         final var destinationPath = Paths.get(destinationDirectory);
         listener.logMessage("Verifying installation directory: " + destinationPath);
         LOGGER.logInfo("Ruyi package manager install path: " + destinationPath);
@@ -77,7 +72,7 @@ public final class RuyiInstallManager {
                 Files.createDirectories(destinationPath);
                 listener.logMessage("Directory created successfully.");
             } catch (IOException e) {
-                throw new Exception("Failed to create installation directory: " + e.getMessage(), e);
+                throw RuyiInstallException.directoryCreationFailed(destinationPath.toString(), e);
             }
         } else {
             listener.logMessage("Directory already exists.");
@@ -89,10 +84,15 @@ public final class RuyiInstallManager {
         try {
             store = Files.getFileStore(destinationPath);
         } catch (IOException e) {
-            throw new Exception("Cannot access filesystem: " + e.getMessage(), e);
+            throw RuyiInstallException.filesystemError("Cannot access filesystem", e);
         }
 
-        long freeSpaceBytes = store.getUsableSpace();
+        long freeSpaceBytes;
+        try {
+            freeSpaceBytes = store.getUsableSpace();
+        } catch (IOException e) {
+            throw RuyiInstallException.filesystemError("Cannot read disk space", e);
+        }
         long requiredSpaceBytes = 500L * 1024 * 1024;
         if (freeSpaceBytes < requiredSpaceBytes) {
             BigDecimal requiredMb = BigDecimal.valueOf(requiredSpaceBytes).divide(BigDecimal.valueOf(1024L * 1024L), 1,
@@ -100,9 +100,8 @@ public final class RuyiInstallManager {
             BigDecimal freeMb = BigDecimal.valueOf(freeSpaceBytes).divide(BigDecimal.valueOf(1024L * 1024L), 1,
                             RoundingMode.HALF_UP);
 
-            throw new Exception(
-                            String.format("需要至少 %s MB 空间，当前可用 %s MB", requiredMb.stripTrailingZeros().toPlainString(),
-                                            freeMb.stripTrailingZeros().toPlainString()));
+            throw RuyiInstallException.insufficientDiskSpace(requiredMb.stripTrailingZeros().toPlainString(),
+                            freeMb.stripTrailingZeros().toPlainString());
         }
 
         BigDecimal freeMb = BigDecimal.valueOf(freeSpaceBytes).divide(BigDecimal.valueOf(1024L * 1024L), 1,
@@ -112,7 +111,7 @@ public final class RuyiInstallManager {
     }
 
     private static Path downloadRuyi(String destinationDirectory, IProgressMonitor monitor,
-                    InstallationListener listener) throws Exception {
+                    InstallationListener listener) {
         String archSuffix = SystemInfo.detectArchitecture().getSuffix();
         RuyiReleaseInfo latestRelease = RuyiApi.getLatestRelease(archSuffix);
         Path ruyiExecutablePath = Paths.get(destinationDirectory, "ruyi");
@@ -156,7 +155,7 @@ public final class RuyiInstallManager {
 
                 listener.logMessage("下载成功");
                 return ruyiExecutablePath;
-            } catch (Exception e) {
+            } catch (PluginException e) {
                 lastException = e;
                 listener.logMessage(String.format("%s下载失败: %s", sourceName, e.getMessage()));
 
@@ -171,15 +170,15 @@ public final class RuyiInstallManager {
             }
         }
 
-        throw new Exception(String.format("所有下载尝试均失败。最后错误: %s",
+        throw RuyiInstallException.downloadFailed(String.format("所有下载尝试均失败。最后错误: %s",
                         lastException != null ? lastException.getMessage() : "未知错误"), lastException);
     }
 
-    private static void setExecutablePermissions(Path executablePath, InstallationListener listener) throws Exception {
+    private static void setExecutablePermissions(Path executablePath, InstallationListener listener) {
         File file = executablePath.toFile();
 
         if (!file.exists()) {
-            throw new FileNotFoundException("File not found: " + executablePath);
+            throw RuyiInstallException.fileNotFound(executablePath.toString());
         }
 
         if (file.canExecute()) {
@@ -202,32 +201,31 @@ public final class RuyiInstallManager {
                 if (listener != null) {
                     listener.logMessage("Successfully set executable permissions using POSIX API: " + executablePath);
                 }
-            } catch (UnsupportedOperationException e) {
-                throw new Exception("Failed to set executable permissions on non-POSIX system: " + executablePath);
+            } catch (IOException | UnsupportedOperationException e) {
+                throw RuyiInstallException.permissionFailed(executablePath.toString(), e);
             }
         } else if (listener != null) {
             listener.logMessage("Successfully set executable permissions: " + executablePath);
         }
 
         if (!file.canExecute()) {
-            throw new Exception("Failed to set executable permissions for: " + executablePath
-                            + ". You may need root/sudo privileges.");
+            throw RuyiInstallException.permissionVerifyFailed(executablePath.toString());
         }
     }
 
-    private static void validateInstallation(InstallationListener listener) throws Exception {
+    private static void validateInstallation(InstallationListener listener) {
         listener.logMessage("Validating installation...");
 
         final var version = RuyiCli.getInstalledVersion();
         if (version == null) {
-            throw new Exception("There are problems in the operation ruyi -V.");
+            throw RuyiInstallException.validationFailed("There are problems in the operation ruyi -V.");
         }
 
         listener.logMessage("Ruyi " + version.toString() + " install successful.");
     }
 
     private static void configureInstalledRuyi(String repoUrl, TelemetryMode telemetryMode,
-                    InstallationListener listener) throws Exception {
+                    InstallationListener listener) {
         listener.logMessage("Ruyi Config...");
 
         Objects.requireNonNull(repoUrl, "No repository configuration selected");

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiManager.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiManager.java
@@ -2,14 +2,11 @@ package org.ruyisdk.ruyi.services;
 
 import org.ruyisdk.core.ruyi.model.RuyiVersion;
 import org.ruyisdk.core.ruyi.model.SystemInfo;
-import org.ruyisdk.core.util.PluginLogger;
-import org.ruyisdk.ruyi.Activator;
 
 /**
  * Manager for Ruyi operations.
  */
 public class RuyiManager {
-    private static final PluginLogger LOGGER = Activator.getLogger();
 
     /**
      * Checks if Ruyi is installed.
@@ -35,14 +32,8 @@ public class RuyiManager {
      * @return latest version or null
      */
     public static RuyiVersion getLatestVersion() {
-        try {
-            final var archSuffix = SystemInfo.detectArchitecture().getSuffix();
-            final var info = RuyiApi.getLatestRelease(archSuffix);
-            final var version = info.getVersion();
-            return version;
-        } catch (Exception e) {
-            LOGGER.logError("Failed to get latest Ruyi version", e);
-            return null;
-        }
+        final var archSuffix = SystemInfo.detectArchitecture().getSuffix();
+        final var info = RuyiApi.getLatestRelease(archSuffix);
+        return info.getVersion();
     }
 }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiProperties.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiProperties.java
@@ -9,6 +9,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.Properties;
 import org.ruyisdk.core.basedir.XdgDirs;
 import org.ruyisdk.core.config.Constants;
+import org.ruyisdk.core.exception.RuyiConfigException;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.ruyi.Activator;
 import org.ruyisdk.ruyi.util.RuyiFileUtils;
@@ -42,7 +43,7 @@ public class RuyiProperties {
                     saveConfig();
                 }
             }
-        } catch (IOException e) {
+        } catch (IOException | RuyiConfigException e) {
             LOGGER.logError("Failed to init config directory", e);
         }
     }
@@ -61,7 +62,7 @@ public class RuyiProperties {
     }
 
     // 初始化默认配置
-    private static void initDefaultConfig() throws IOException {
+    private static void initDefaultConfig() {
         Properties defaults = new Properties();
         defaults.setProperty("automatic.detection", "on");
         defaults.setProperty("ruyi.install.path", RuyiFileUtils.getDefaultInstallPath().toString());
@@ -71,14 +72,16 @@ public class RuyiProperties {
     }
 
     // 修改saveConfig方法使其能接受Properties参数
-    private static synchronized void saveConfig(Properties propsToSave) throws IOException {
+    private static synchronized void saveConfig(Properties propsToSave) {
         try (OutputStream os = Files.newOutputStream(FILE_PATH, StandardOpenOption.CREATE,
                         StandardOpenOption.TRUNCATE_EXISTING)) {
             propsToSave.store(os, "Ruyi Configuration");
+        } catch (IOException e) {
+            throw RuyiConfigException.saveFailed("config: " + FILE_PATH, e);
         }
     }
 
-    private static synchronized void saveConfig() throws IOException {
+    private static synchronized void saveConfig() {
         saveConfig(props); // 重用上面的方法
     }
 
@@ -98,9 +101,8 @@ public class RuyiProperties {
      * Sets automatic detection.
      *
      * @param enabled true to enable
-     * @throws IOException if save fails
      */
-    public static void setAutomaticDetection(boolean enabled) throws IOException {
+    public static void setAutomaticDetection(boolean enabled) {
         props.setProperty("automatic.detection", enabled ? "on" : "off");
         saveConfig();
     }
@@ -119,9 +121,8 @@ public class RuyiProperties {
      * Sets install path.
      *
      * @param path install path
-     * @throws IOException if save fails
      */
-    public static void setInstallPath(String path) throws IOException {
+    public static void setInstallPath(String path) {
         props.setProperty("ruyi.install.path", path != null ? path : "");
         saveConfig();
     }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/ui/RuyiInstallWizard.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/ui/RuyiInstallWizard.java
@@ -1,6 +1,5 @@
 package org.ruyisdk.ruyi.ui;
 
-import java.io.IOException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.wizard.IWizardPage;
@@ -19,6 +18,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
+import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.core.ruyi.model.RuyiVersion;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.ruyi.Activator;
@@ -179,7 +179,7 @@ public class RuyiInstallWizard extends Wizard {
         private void setAutomaticDetection() {
             try {
                 RuyiProperties.setAutomaticDetection(!dontCheckAgainCheckbox.getSelection());
-            } catch (IOException e) {
+            } catch (PluginException e) {
                 LOGGER.logError("Failed to save automatic detection setting", e);
             }
         }
@@ -272,11 +272,7 @@ public class RuyiInstallWizard extends Wizard {
         }
 
         public void saveConfig() {
-            try {
-                installPref.saveInstallPath();
-            } catch (IOException e) {
-                LOGGER.logError("Failed to save install path", e);
-            }
+            installPref.saveInstallPath();
         }
     }
 

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/util/PathUtils.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/util/PathUtils.java
@@ -1,7 +1,7 @@
 package org.ruyisdk.ruyi.util;
 
-import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -38,7 +38,7 @@ public class PathUtils {
             Path path = Paths.get(rawPath).toAbsolutePath().normalize();
             // 统一去除末尾斜杠
             return path.toString().replaceAll("/+$", "");
-        } catch (Exception e) {
+        } catch (InvalidPathException e) {
             // 如果路径无效，返回原始值（标准化后）
             return rawPath.replaceAll("/+$", "");
         }
@@ -48,9 +48,8 @@ public class PathUtils {
      * 获取用户shell配置文件路径.
      *
      * @return shell配置文件路径
-     * @throws IOException if file access fails
      */
-    public static Path detectShellConfigFile() throws IOException {
+    public static Path detectShellConfigFile() {
         String userHome = System.getProperty("user.home");
         String[] candidates = {".bashrc", ".zshrc", ".bash_profile", ".profile"};
 

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/util/RuyiNetworkUtils.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/util/RuyiNetworkUtils.java
@@ -7,7 +7,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
@@ -18,6 +17,7 @@ import java.util.function.BiConsumer;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.ruyi.Activator;
+import org.ruyisdk.ruyi.services.RuyiApiException;
 
 /**
  * Network utility methods for Ruyi.
@@ -35,11 +35,9 @@ public class RuyiNetworkUtils {
      * @param destinationPath destination path
      * @param monitor progress monitor
      * @param progressCallback progress callback
-     * @throws IOException if download fails
-     * @throws URISyntaxException if URL is invalid
      */
     public static void downloadFile(String fileUrl, String destinationPath, IProgressMonitor monitor,
-                    BiConsumer<Long, Long> progressCallback) throws IOException, URISyntaxException {
+                    BiConsumer<Long, Long> progressCallback) {
         HttpURLConnection connection = null;
         InputStream input = null;
         OutputStream output = null;
@@ -54,7 +52,7 @@ public class RuyiNetworkUtils {
 
             int responseCode = connection.getResponseCode();
             if (responseCode != HttpURLConnection.HTTP_OK) {
-                throw new IOException("Server returned HTTP " + responseCode + ": " + connection.getResponseMessage());
+                throw RuyiApiException.unexpectedStatusCode(responseCode);
             }
 
             long fileSize = connection.getContentLengthLong();
@@ -87,8 +85,12 @@ public class RuyiNetworkUtils {
 
             // if (subMonitor.isCanceled()) {
             if (monitor.isCanceled()) {
-                throw new InterruptedIOException("Download cancelled by user");
+                throw RuyiApiException.cancelled();
             }
+        } catch (URISyntaxException e) {
+            throw RuyiApiException.invalidArgument("Invalid URL: " + fileUrl);
+        } catch (IOException e) {
+            throw RuyiApiException.ioError(e);
         } finally {
             closeQuietly(input);
             closeQuietly(output);
@@ -107,11 +109,8 @@ public class RuyiNetworkUtils {
      * @param urlString URL string
      * @param monitor progress monitor
      * @return string content
-     * @throws IOException if fetch fails
-     * @throws URISyntaxException if URL is invalid
      */
-    public static String fetchStringContent(String urlString, IProgressMonitor monitor)
-                    throws IOException, URISyntaxException {
+    public static String fetchStringContent(String urlString, IProgressMonitor monitor) {
         HttpURLConnection connection = null;
         InputStream input = null;
 
@@ -126,7 +125,7 @@ public class RuyiNetworkUtils {
 
             int responseCode = connection.getResponseCode();
             if (responseCode != HttpURLConnection.HTTP_OK) {
-                throw new IOException("HTTP request failed with code: " + responseCode);
+                throw RuyiApiException.unexpectedStatusCode(responseCode);
             }
 
             input = connection.getInputStream();
@@ -143,10 +142,14 @@ public class RuyiNetworkUtils {
             }
 
             if (monitor != null && monitor.isCanceled()) {
-                throw new InterruptedIOException("Operation cancelled by user");
+                throw RuyiApiException.cancelled();
             }
 
             return content.toString();
+        } catch (URISyntaxException e) {
+            throw RuyiApiException.invalidArgument("Invalid URL: " + urlString);
+        } catch (IOException e) {
+            throw RuyiApiException.ioError(e);
         } finally {
             closeQuietly(input);
             if (connection != null) {
@@ -162,11 +165,8 @@ public class RuyiNetworkUtils {
      * @param data data to post
      * @param monitor progress monitor
      * @return response string
-     * @throws IOException if post fails
-     * @throws URISyntaxException if URL is invalid
      */
-    public static String postJson(String urlString, Map<String, Object> data, IProgressMonitor monitor)
-                    throws IOException, URISyntaxException {
+    public static String postJson(String urlString, Map<String, Object> data, IProgressMonitor monitor) {
         HttpURLConnection connection = null;
         OutputStream output = null;
         InputStream input = null;
@@ -199,7 +199,7 @@ public class RuyiNetworkUtils {
 
             int responseCode = connection.getResponseCode();
             if (responseCode != HttpURLConnection.HTTP_OK) {
-                throw new IOException("HTTP request failed with code: " + responseCode);
+                throw RuyiApiException.unexpectedStatusCode(responseCode);
             }
 
             input = connection.getInputStream();
@@ -216,10 +216,14 @@ public class RuyiNetworkUtils {
             }
 
             if (monitor != null && monitor.isCanceled()) {
-                throw new InterruptedIOException("Operation cancelled by user");
+                throw RuyiApiException.cancelled();
             }
 
             return response.toString();
+        } catch (URISyntaxException e) {
+            throw RuyiApiException.invalidArgument("Invalid URL: " + urlString);
+        } catch (IOException e) {
+            throw RuyiApiException.ioError(e);
         } finally {
             closeQuietly(output);
             closeQuietly(input);
@@ -246,7 +250,7 @@ public class RuyiNetworkUtils {
             connection.setRequestMethod("HEAD");
             int responseCode = connection.getResponseCode();
             return (200 <= responseCode && responseCode <= 399);
-        } catch (Exception e) {
+        } catch (IOException | URISyntaxException e) {
             return false;
         } finally {
             if (connection != null) {

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvConfigurationService.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvConfigurationService.java
@@ -1,18 +1,20 @@
 package org.ruyisdk.venv.model;
 
+import java.io.IOException;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Consumer;
 import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.core.envvar.IEnvironmentVariable;
 import org.eclipse.cdt.core.settings.model.ICConfigurationDescription;
+import org.eclipse.cdt.managedbuilder.core.BuildException;
 import org.eclipse.cdt.managedbuilder.core.IConfiguration;
 import org.eclipse.cdt.managedbuilder.core.IToolChain;
 import org.eclipse.cdt.managedbuilder.core.ManagedBuildManager;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.ruyisdk.core.util.PluginLogger;
@@ -127,9 +129,6 @@ public class VenvConfigurationService {
         } catch (CoreException e) {
             LOGGER.logError("Failed to apply CDT configuration: project=" + projectPath, e);
             return new ApplyResult(false, "Failed to apply CDT configuration: " + e.getMessage());
-        } catch (Exception e) {
-            LOGGER.logError("Unexpected error applying venv configuration: project=" + projectPath, e);
-            return new ApplyResult(false, "Unexpected error: " + e.getMessage());
         }
     }
 
@@ -203,7 +202,7 @@ public class VenvConfigurationService {
             if (option != null) {
                 config.setOption(toolChain, option, value);
             }
-        } catch (Exception e) {
+        } catch (BuildException e) {
             // Option doesn't exist or can't be set for this toolchain type - ignore
             LOGGER.logWarning("Could not set toolchain option: " + optionId, e);
         }
@@ -212,12 +211,16 @@ public class VenvConfigurationService {
     /** Applies the venv configuration to the project asynchronously. */
     public void applyToProjectAsync(Venv venv, Consumer<ApplyResult> callback) {
         final var applyJob = Job.create("Applying venv configuration to CDT project", monitor -> {
-            final var result = applyToProject(venv);
-            if (callback != null) {
+            try {
+                final var result = applyToProject(venv);
                 callback.accept(result);
+                return result.isSuccess() ? Status.OK_STATUS : Status.warning(result.getMessage());
+            } catch (Exception e) {
+                final var msg = "Failed to apply venv configuration";
+                LOGGER.logError(msg, e);
+                callback.accept(new ApplyResult(false, msg));
+                return Status.CANCEL_STATUS; // avoid Eclipse error dialog
             }
-            return result.isSuccess() ? Status.OK_STATUS
-                            : new Status(IStatus.WARNING, Activator.PLUGIN_ID, result.getMessage());
         });
         applyJob.schedule();
     }
@@ -257,13 +260,14 @@ public class VenvConfigurationService {
         }
         try {
             return Paths.get(pathString).toRealPath();
-        } catch (Exception e) {
-            // Fall back to normalized path if real path resolution fails (e.g., path doesn't exist)
-            try {
-                return Paths.get(pathString).normalize().toAbsolutePath();
-            } catch (Exception e2) {
-                return null;
-            }
+        } catch (IOException e) {
+            LOGGER.logWarning("Could not resolve real path for: " + pathString, e);
         }
+        try {
+            return Paths.get(pathString).normalize().toAbsolutePath();
+        } catch (InvalidPathException e) {
+            LOGGER.logWarning("Could not normalize path for: " + pathString, e);
+        }
+        return null;
     }
 }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvDetectionService.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvDetectionService.java
@@ -18,9 +18,9 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.ruyisdk.core.exception.RuyiConfigException;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.ruyi.services.RuyiCli;
 import org.ruyisdk.venv.Activator;
@@ -66,43 +66,28 @@ public class VenvDetectionService {
 
     /** Returns the list of known profiles from the Ruyi CLI. */
     public List<RuyiCli.ProfileInfo> listProfiles() {
-        try {
-            return RuyiCli.listProfiles();
-        } catch (Exception e) {
-            LOGGER.logError("Failed to list profiles", e);
-            return new ArrayList<>();
-        }
+        return RuyiCli.listProfiles();
     }
 
     /** Returns the list of known toolchains from the Ruyi CLI. */
     public List<RuyiCli.ToolchainInfo> listToolchains() {
-        try {
-            return RuyiCli.listToolchains();
-        } catch (Exception e) {
-            LOGGER.logError("Failed to list toolchains", e);
-            return new ArrayList<>();
-        }
+        return RuyiCli.listToolchains();
     }
 
     /** Returns the list of known emulators from the Ruyi CLI. */
     public List<RuyiCli.EmulatorInfo> listEmulators() {
-        try {
-            return RuyiCli.listEmulators();
-        } catch (Exception e) {
-            LOGGER.logError("Failed to list emulators", e);
-            return new ArrayList<>();
-        }
+        return RuyiCli.listEmulators();
     }
 
     /** Updates the local package index via the Ruyi CLI. */
-    public void updateIndex() throws Exception {
+    public void updateIndex() {
         LOGGER.logInfo("Updating Ruyi package index");
         RuyiCli.updatePackageIndex();
         LOGGER.logInfo("Ruyi package index update finished successfully");
     }
 
     /** Installs a package via the Ruyi CLI. */
-    public void installPackage(String name, String version) throws Exception {
+    public void installPackage(String name, String version) {
         LOGGER.logInfo("Installing package: name=" + name + ", version=" + version);
         RuyiCli.installPackage(name, version);
         LOGGER.logInfo("Package install finished: name=" + name + ", version=" + version);
@@ -110,7 +95,7 @@ public class VenvDetectionService {
 
     /** Creates a new venv via the Ruyi CLI. */
     public void createVenv(String path, String toolchainName, String toolchainVersion, String profile,
-                    String emulatorName, String emulatorVersion) throws Exception {
+                    String emulatorName, String emulatorVersion) {
         LOGGER.logInfo("Creating venv: path=" + path + ", profile=" + profile + ", toolchain=" + toolchainName + ":"
                         + toolchainVersion + ", emulator=" + emulatorName + ":" + emulatorVersion);
         RuyiCli.createVenv(path, toolchainName, toolchainVersion, profile, emulatorName, emulatorVersion);
@@ -149,7 +134,7 @@ public class VenvDetectionService {
 
                     out.add(venv);
                 });
-            } catch (Exception e) {
+            } catch (IOException e) {
                 // ignore per-project failures
                 LOGGER.logError("Failed to scan project for venv config: path=" + projectPath, e);
             }
@@ -166,25 +151,22 @@ public class VenvDetectionService {
         final var detectJob = Job.create("Detecting virtual environments", monitor -> {
             LOGGER.logInfo("Detecting project venvs (async)");
 
-            List<Venv> result;
             try {
                 final var projectPaths = toPathList(projectRootPaths);
-                result = detectProjectVenvs(projectPaths);
-            } catch (Exception e) {
-                LOGGER.logError("Failed to detect project venvs", e);
-                result = List.of();
-            }
-            LOGGER.logInfo("Project venv detection finished: count=" + result.size());
-
-            if (callback != null) {
+                final var result = detectProjectVenvs(projectPaths);
+                LOGGER.logInfo("Project venv detection finished: count=" + result.size());
                 callback.accept(result);
+                return Status.OK_STATUS;
+            } catch (Exception e) {
+                return Status.error("Failed to detect project venvs", e);
             }
-            return Status.OK_STATUS;
         });
         detectJob.schedule();
     }
 
-    /** Deletes venv directories asynchronously and reports completion through the callback. */
+    /**
+     * Deletes venv directories asynchronously and reports completion or errors through the callback.
+     */
     public void deleteVenvDirectoriesAsync(List<String> venvDirectoryPaths, Consumer<Exception> callback) {
         final var deleteJob = Job.create("Deleting virtual environments", monitor -> {
             LOGGER.logInfo("Deleting venv directories: count="
@@ -199,17 +181,12 @@ public class VenvDetectionService {
 
                     refreshWorkspaceProjects(monitor);
                 }
-                if (callback != null) {
-                    callback.accept(null);
-                }
                 LOGGER.logInfo("Venv directories deletion finished");
+                callback.accept(null);
                 return Status.OK_STATUS;
             } catch (Exception e) {
-                LOGGER.logError("Failed to delete venv directories", e);
-                if (callback != null) {
-                    callback.accept(e);
-                }
-                return new Status(IStatus.ERROR, "org.ruyisdk.venv", "Failed to delete virtual environment", e);
+                callback.accept(e);
+                return Status.CANCEL_STATUS; // avoid Eclipse error dialog
             }
         });
         deleteJob.schedule();
@@ -262,7 +239,7 @@ public class VenvDetectionService {
                     return new DerivedToolchainInfo(binDir.toString(), prefix);
                 }
             }
-        } catch (Exception e) {
+        } catch (IOException e) {
             // ignore scan failures
             LOGGER.logError("Failed to list entries in dir: path=" + binDir, e);
         }
@@ -307,7 +284,7 @@ public class VenvDetectionService {
                     sysroot = val;
                 }
             }
-        } catch (Exception e) {
+        } catch (IOException e) {
             // ignore parse failures
             LOGGER.logWarning("Failed to parse venv config: path=" + tomlPath, e);
         }
@@ -329,31 +306,35 @@ public class VenvDetectionService {
         return s;
     }
 
-    private static void deleteDirectoryRecursively(Path dir) throws IOException {
+    private static void deleteDirectoryRecursively(Path dir) {
         if (dir == null) {
             return;
         }
         if (!Files.exists(dir)) {
             return;
         }
-        Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
-            /** {@inheritDoc} */
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                Files.deleteIfExists(file);
-                return FileVisitResult.CONTINUE;
-            }
-
-            /** {@inheritDoc} */
-            @Override
-            public FileVisitResult postVisitDirectory(Path directory, IOException exc) throws IOException {
-                if (exc != null) {
-                    throw exc;
+        try {
+            Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
+                /** {@inheritDoc} */
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.deleteIfExists(file);
+                    return FileVisitResult.CONTINUE;
                 }
-                Files.deleteIfExists(directory);
-                return FileVisitResult.CONTINUE;
-            }
-        });
+
+                /** {@inheritDoc} */
+                @Override
+                public FileVisitResult postVisitDirectory(Path directory, IOException exc) throws IOException {
+                    if (exc != null) {
+                        throw exc;
+                    }
+                    Files.deleteIfExists(directory);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            throw RuyiConfigException.deleteFailed(dir.toString(), e);
+        }
     }
 
     private static void refreshWorkspaceProjects(IProgressMonitor monitor) {

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
@@ -236,8 +236,12 @@ public class VenvListViewModel {
         detectionService.detectProjectVenvsAsync(projectRootPaths, result -> {
             observableVenvList.getRealm().asyncExec(() -> {
                 observableVenvList.clear();
-                observableVenvList.addAll(result);
-                LOGGER.logInfo("Venv list refreshed; count=" + result.size());
+                if (result != null) {
+                    observableVenvList.addAll(result);
+                    LOGGER.logInfo("Venv list refreshed; count=" + result.size());
+                } else {
+                    LOGGER.logError("Venv list failed to refresh");
+                }
                 updateHasOpenProjects();
                 setFetching(false);
             });

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Set;
 import org.eclipse.core.databinding.observable.list.IObservableList;
 import org.eclipse.core.databinding.observable.list.WritableList;
+import org.ruyisdk.ruyi.services.RuyiCliException;
 import org.ruyisdk.venv.model.Emulator;
 import org.ruyisdk.venv.model.Profile;
 import org.ruyisdk.venv.model.Toolchain;
@@ -148,7 +149,7 @@ public class VenvWizardViewModel {
         return sb.toString();
     }
 
-    private void refreshLists() throws Exception {
+    private void refreshLists() {
         service.updateIndex();
 
         profiles.clear();
@@ -224,39 +225,39 @@ public class VenvWizardViewModel {
     }
 
     /** Updates the CLI index and refreshes all view model data. */
-    public void refreshAll() throws Exception {
+    public void refreshAll() {
         refreshLists();
         filterPackagesBySelectedProfile();
         recomputeDerivedState();
     }
 
-    private void installToolchain(String name, String version) throws Exception {
+    private void installToolchain(String name, String version) {
         service.installPackage(name, version);
     }
 
     /** Installs the currently-selected toolchain package. */
-    public void installToolchain() throws Exception {
+    public void installToolchain() {
         if (selectedToolchainIndex < 0 || selectedToolchainIndex >= toolchains.size()
                         || selectedToolchainVersionIndex < 0) {
-            throw new IllegalArgumentException("No toolchain selected");
+            throw RuyiCliException.invalidArgument("No toolchain selected");
         }
         final var name = toolchains.get(selectedToolchainIndex).getName();
         final var version = toolchains.get(selectedToolchainIndex).getVersions().get(selectedToolchainVersionIndex);
         installToolchain(name, version);
     }
 
-    private void installEmulator(String name, String version) throws Exception {
+    private void installEmulator(String name, String version) {
         service.installPackage(name, version);
     }
 
     /** Installs the currently-selected emulator package when enabled. */
-    public void installEmulator() throws Exception {
+    public void installEmulator() {
         if (!emulatorEnabled) {
-            throw new IllegalArgumentException("Emulator disabled");
+            throw RuyiCliException.invalidArgument("Emulator disabled");
         }
         if (selectedEmulatorIndex < 0 || selectedEmulatorIndex >= emulators.size()
                         || selectedEmulatorVersionIndex < 0) {
-            throw new IllegalArgumentException("Emulator enabled but not selected");
+            throw RuyiCliException.invalidArgument("Emulator enabled but not selected");
         }
         final var name = emulators.get(selectedEmulatorIndex).getName();
         final var version = emulators.get(selectedEmulatorIndex).getVersions().get(selectedEmulatorVersionIndex);
@@ -264,24 +265,24 @@ public class VenvWizardViewModel {
     }
 
     private void createVenv(String path, String toolchainName, String toolchainVersion, String profile,
-                    String emulatorName, String emulatorVersion) throws Exception {
+                    String emulatorName, String emulatorVersion) {
         service.createVenv(path, toolchainName, toolchainVersion, profile, emulatorName, emulatorVersion);
     }
 
     /** Creates a virtual environment using the current wizard selections. */
-    public void createVenv() throws Exception {
+    public void createVenv() {
         final var parent = this.venvLocation;
         if (parent == null || parent.isBlank()) {
-            throw new IllegalArgumentException("Venv parent path is empty");
+            throw RuyiCliException.invalidArgument("Venv parent path is empty");
         }
         final var name = this.venvName;
         if (name == null || name.isBlank()) {
-            throw new IllegalArgumentException("Venv name is empty");
+            throw RuyiCliException.invalidArgument("Venv name is empty");
         }
 
         if (selectedToolchainIndex < 0 || selectedToolchainIndex >= toolchains.size()
                         || selectedToolchainVersionIndex < 0) {
-            throw new IllegalArgumentException("No toolchain selected");
+            throw RuyiCliException.invalidArgument("No toolchain selected");
         }
         final var toolchainName = toolchains.get(selectedToolchainIndex).getName();
         final var toolchainVersion =
@@ -297,7 +298,7 @@ public class VenvWizardViewModel {
         if (emulatorEnabled) {
             if (selectedEmulatorIndex < 0 || selectedEmulatorIndex >= emulators.size()
                             || selectedEmulatorVersionIndex < 0) {
-                throw new IllegalArgumentException("Emulator enabled but not selected");
+                throw RuyiCliException.invalidArgument("Emulator enabled but not selected");
             }
             emulatorName = emulators.get(selectedEmulatorIndex).getName();
             emulatorVersion = emulators.get(selectedEmulatorIndex).getVersions().get(selectedEmulatorVersionIndex);

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
@@ -6,6 +6,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.ui.statushandlers.StatusManager;
+import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.venv.viewmodel.VenvWizardViewModel;
 
 /**
@@ -40,7 +41,7 @@ public class VenvWizard extends Wizard {
                 monitor.beginTask("Updating package index...", 100);
                 try {
                     viewModel.refreshAll();
-                } catch (Exception e) {
+                } catch (PluginException e) {
                     throw new InvocationTargetException(e);
                 }
                 monitor.worked(100);
@@ -86,7 +87,7 @@ public class VenvWizard extends Wizard {
 
                     monitor.subTask("create venv");
                     viewModel.createVenv();
-                } catch (Exception e) {
+                } catch (PluginException e) {
                     throw new InvocationTargetException(e);
                 }
             });

--- a/target.target
+++ b/target.target
@@ -30,6 +30,18 @@
 					<type>jar</type>
 				</dependency>
 				<dependency>
+					<groupId>net.bytebuddy</groupId>
+					<artifactId>byte-buddy</artifactId>
+					<version>1.17.8</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.assertj</groupId>
+					<artifactId>assertj-core</artifactId>
+					<version>4.0.0-M1</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
 					<groupId>org.commonmark</groupId>
 					<artifactId>commonmark-ext-gfm-tables</artifactId>
 					<version>0.27.1</version>

--- a/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
+++ b/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
@@ -7,8 +7,10 @@ Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.ruyi.tests
 Require-Bundle: 
+ assertj-core,
  wrapped.junit.junit,
  org.ruyisdk.core,
  org.ruyisdk.packages,
  org.ruyisdk.ruyi,
+ json,
  wrapped.org.hamcrest.hamcrest-core

--- a/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/packages/service/PackageOperationRunnerTest.java
+++ b/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/packages/service/PackageOperationRunnerTest.java
@@ -8,8 +8,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.ruyisdk.packages.model.PackageOperation;
+import org.ruyisdk.ruyi.services.RuyiCliException;
 
 /**
  * Unit tests for {@link PackageOperationRunner} covering streaming output sequencing, failure
@@ -61,7 +63,7 @@ public class PackageOperationRunnerTest {
         PackageOperationRunner.PackageInstaller installer = (op, lineCallback) -> {
             lineCallback.accept("output");
             if ("bad(1.0)".equals(op.packageRef())) {
-                throw new RuntimeException("install failed");
+                throw RuyiCliException.executionFailed("install bad(1.0)", 1, "install failed");
             }
         };
 
@@ -78,7 +80,11 @@ public class PackageOperationRunnerTest {
         assertTrue(events.contains("onStepDone:0"));
 
         // Second step fails
-        assertTrue(events.contains("onStepFailed:1:install failed"));
+        Assertions.assertThat(events).anySatisfy(e -> Assertions.assertThat(e).startsWith("""
+        onStepFailed:1:org.ruyisdk.ruyi.services.RuyiCliException: ruyi command execution failed with code: 1
+        Command: install bad(1.0)
+        CLI Output:
+        install failed"""));
 
         // Third step still runs (runner does not abort on failure)
         assertTrue(events.contains("onStepStart:2:3:after(1.0)"));

--- a/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/model/EntityInfoParserTest.java
+++ b/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/model/EntityInfoParserTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import org.json.JSONException;
 import org.junit.Test;
 
 /**
@@ -256,15 +257,20 @@ public class EntityInfoParserTest {
     }
 
     @Test
-    public void parseAllTolerablyHandlesTruncatedJson() {
-        // Second object is truncated — first should still parse
+    public void parseAllThrowsOnTruncatedJson() {
+        // Second object is truncated — JSONTokener throws on malformed input
         String json = """
                         {"ty":"entitylistoutput-v1","entity_type":"device","entity_id":"good","display_name":"Good","related_refs":[],"reverse_refs":[]}{"ty":"entitylistoutput-v1","entity_type":"device","entity_id":"bad","displ
                         """;
-        List<EntityInfo> result = EntityInfoParser.parseAll(json);
-        assertNotNull(result);
-        assertTrue(result.size() >= 1);
-        assertEquals("good", result.get(0).getEntityId());
+        JSONException ex = null;
+        try {
+            EntityInfoParser.parseAll(json);
+        } catch (JSONException e) {
+            ex = e;
+        }
+        assertNotNull("Expected JSONException for truncated JSON", ex);
+        assertTrue("Message should mention unterminated string: " + ex.getMessage(),
+                        ex.getMessage().contains("Unterminated string"));
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
Key changes:
- Introduce a domain exception hierarchy rooted at "PluginException" (extends "RuntimeException") with subclasses:
  - RuyiApiException
  - RuyiCliException
  - RuyiConfigException
  - RuyiProjectException
  - RuyiInstallException
- Each domain exception uses static factory methods for semantic construction. Tests are updated accordingly.
- Apart from Jobs and "PackageOperationRunner::run()", replace all generic "catch (Exception)" with specific exception types.
- Handling checked exceptions at the boundary. Wrap them in domain exceptions and let domain ones propagate to the framework, or log and continue if recoverable. Remove "throws" declarations from non-override methods.
- Drop unused "PluginLogger" fields and redundant error logs.
- Log warnings when using default values.
- Mute some useless exceptions for specific cases.
- Call "Thread.currentThread().interrupt()" for "InterruptedException".

Specific changes:
- Remove outer "try-catch" blocks that swallowed exceptions from the following classes:
  - CustomIntroPart
  - JsonParser
  - projectcreator's Activator
  - CheckRuyiJob
  - RootPreferencePage
  - RuyiCli
  - RuyiManager
  - VenvDetectionService
- EntityInfoParser: no partial parsing. Test is updated as well.
- NewsFetchService: remove null-as-timeout guard. Deeper logic cares about timeouts and other exceptions and should throw if they occur.
- Introduce AssertJ for better readability for exception assertions.

The design:
Exceptions should not be fuzzy in most cases. Catch what we intend to handle; let the rest crash directly or propagate. Unchecked exceptions will make things simpler by not polluting every functions with "throws" clauses; domain exceptions will make things customizable and understandable.

Coding is not myth.
