### PR TITLE
Fix(ruyi): first installation and exception handling

### DIFF
--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/TelemetryPreference.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/TelemetryPreference.java
@@ -61,11 +61,17 @@ public class TelemetryPreference {
         label.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 
         // Combo for telemetry mode
+        int telemetryIndex;
+        try {
+            telemetryIndex = getTelemetrySelectionIndex();
+        } catch (Exception e) {
+            telemetryIndex = 0; // default to ON
+        }
         telemetryCombo = new Combo(comboContainer, SWT.DROP_DOWN | SWT.READ_ONLY);
         telemetryCombo.setItems(new String[] {"Enabled: Send anonymous usage data",
                 "Local only: Analyze data locally only", "Disabled: No data collection"});
         // Set default selection
-        telemetryCombo.select(getTelemetrySelectionIndex());
+        telemetryCombo.select(telemetryIndex);
         telemetryCombo.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 
         // 创建一个Link控件来显示描述文本和链接

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/TelemetryPreference.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/TelemetryPreference.java
@@ -64,7 +64,7 @@ public class TelemetryPreference {
         int telemetryIndex;
         try {
             telemetryIndex = getTelemetrySelectionIndex();
-        } catch (Exception e) {
+        } catch (PluginException e) {
             telemetryIndex = 0; // default to ON
         }
         telemetryCombo = new Combo(comboContainer, SWT.DROP_DOWN | SWT.READ_ONLY);

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/TelemetryPreference.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/preferences/TelemetryPreference.java
@@ -11,6 +11,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
+import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.ruyi.model.TelemetryMode;
 import org.ruyisdk.ruyi.services.RuyiCli;
 

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
@@ -462,8 +462,18 @@ public class RuyiCli {
      * @return version or null if not available or command fails
      */
     public static RuyiVersion getInstalledVersion() {
-        final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult())
-                .porcelain(false).args("-V").build();
+        return getInstalledVersion(requireInstallPathResult());
+    }
+
+    /**
+     * Gets installed Ruyi version from the specified install directory.
+     *
+     * @param installDir directory containing the ruyi binary
+     * @return version or null if not available or command fails
+     */
+    public static RuyiVersion getInstalledVersion(String installDir) {
+        final var request = RuyiCliRequest.builder().ruyiInstallDir(installDir).porcelain(false)
+                .args("-V").build();
         final var result = request.execute();
         return parseInstalledVersion(result);
     }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliExecutor.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliExecutor.java
@@ -109,12 +109,7 @@ public final class RuyiCliExecutor {
     }
 
     private static void cleanupProcess(Process process, CompletableFuture<String> outputFuture) {
-        try {
-            outputFuture.cancel(true);
-        } catch (CancellationException e) {
-            // why not "throws CancellationException"???
-            // ignore
-        }
+        outputFuture.cancel(true);
 
         try {
             process.getInputStream().close();
@@ -137,7 +132,9 @@ public final class RuyiCliExecutor {
 
         try {
             outputFuture.get(OUTPUT_JOIN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+        } catch (InterruptedException | ExecutionException | TimeoutException
+                | CancellationException e) {
+            // why not "throws CancellationException" but documents it???
             // ignore
         }
     }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiInstallManager.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiInstallManager.java
@@ -52,7 +52,7 @@ public final class RuyiInstallManager {
             listener.logMessage("Setting executable permissions...");
             setExecutablePermissions(ruyiExecutablePath, listener);
 
-            validateInstallation(listener);
+            validateInstallation(destinationDirectory, listener);
             listener.logMessage("Installation completed successfully");
 
             configureInstalledRuyi(repoUrl, telemetryMode, listener);
@@ -221,10 +221,10 @@ public final class RuyiInstallManager {
         }
     }
 
-    private static void validateInstallation(InstallationListener listener) {
+    private static void validateInstallation(String installDir, InstallationListener listener) {
         listener.logMessage("Validating installation...");
 
-        final var version = RuyiCli.getInstalledVersion();
+        final var version = RuyiCli.getInstalledVersion(installDir);
         if (version == null) {
             throw RuyiInstallException
                     .validationFailed("There are problems in the operation ruyi -V.");

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiManager.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiManager.java
@@ -2,6 +2,7 @@ package org.ruyisdk.ruyi.services;
 
 import org.ruyisdk.core.ruyi.model.RuyiVersion;
 import org.ruyisdk.core.ruyi.model.SystemInfo;
+import org.ruyisdk.ruyi.util.RuyiFileUtils;
 
 /**
  * Manager for Ruyi operations.
@@ -14,7 +15,7 @@ public class RuyiManager {
      * @return true if installed
      */
     public static boolean isRuyiInstalled() {
-        return getInstalledVersion() != null;
+        return !RuyiFileUtils.findInstallPathWithRuyi().isEmpty();
     }
 
     /**


### PR DESCRIPTION
Commits:

- 724eb58 fix(ruyi): exception handling for first installtion and timeout
- 2af2714 fix(ruyi): correctly check downloaded ruyi executable

No squashing.

## Summary by Sourcery

Improve robustness of Ruyi installation detection and CLI execution error handling, particularly for first-time installs.

Bug Fixes:
- Validate the installed Ruyi executable using the explicit installation directory rather than relying on global install path detection.
- Treat Ruyi as installed based on the presence of an install path instead of attempting to parse its version, avoiding failures on first installation.
- Prevent failures in the telemetry preferences UI by defaulting to telemetry ON if reading the stored selection index throws an exception.
- Handle possible CancellationException when cancelling and joining CLI output futures to avoid spurious errors during process cleanup.

Enhancements:
- Expose a new overload of getInstalledVersion that accepts an explicit install directory for more flexible version querying.