### PR TITLE
feat(venv): open wizard without updating index; add menu command

### DIFF
--- a/plugins/org.ruyisdk.ruyi/plugin.xml
+++ b/plugins/org.ruyisdk.ruyi/plugin.xml
@@ -36,6 +36,11 @@
 			name="Flash (Device Provision)"
 			description="Launch the Ruyi Device Provisioning Wizard (ruyi device provision) to flash an OS image">
 		</command>
+		<command
+			id="org.ruyisdk.ruyi.commands.updatePackageIndex"
+			name="Update Package Index"
+			description="Update the Ruyi package index (ruyi update)">
+		</command>
 	</extension>
 
 	<!-- 3. 命令处理器（必须） -->
@@ -47,6 +52,10 @@
 		<handler
 			class="org.ruyisdk.ruyi.handlers.FlashDeviceProvisionHandler"
 			commandId="org.ruyisdk.ruyi.commands.flashDeviceProvision">
+		</handler>
+		<handler
+			class="org.ruyisdk.ruyi.handlers.UpdatePackageIndexHandler"
+			commandId="org.ruyisdk.ruyi.commands.updatePackageIndex">
 		</handler>
 	</extension>
 
@@ -64,6 +73,11 @@
 					commandId="org.ruyisdk.ruyi.commands.flashDeviceProvision"
 					label="Flash (Device Provision)"
 					tooltip="Run ruyi device provision in the built-in terminal">
+				</command>
+				<command
+					commandId="org.ruyisdk.ruyi.commands.updatePackageIndex"
+					label="Update Package Index"
+					tooltip="Update the Ruyi package index">
 				</command>
 			</menu>
 		</menuContribution>

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/handlers/UpdatePackageIndexHandler.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/handlers/UpdatePackageIndexHandler.java
@@ -1,0 +1,42 @@
+package org.ruyisdk.ruyi.handlers;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.ruyisdk.core.exception.PluginException;
+import org.ruyisdk.core.util.PluginLogger;
+import org.ruyisdk.ruyi.Activator;
+import org.ruyisdk.ruyi.services.PackageIndexUpdater;
+
+/**
+ * Handler for the "Update Package Index" command. Runs {@code ruyi update} with a progress dialog.
+ */
+public class UpdatePackageIndexHandler extends AbstractHandler {
+    private static final PluginLogger LOGGER = Activator.getLogger();
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        final var shell = HandlerUtil.getActiveShell(event);
+        try {
+            PackageIndexUpdater.updateWithProgress(shell);
+            LOGGER.logInfo("Package index updated successfully");
+            if (shell != null) {
+                MessageDialog.openInformation(shell, "Update Package Index",
+                        "Package index updated successfully.");
+            }
+            return null;
+        } catch (PluginException e) {
+            final var msg = "Failed to update the package index";
+            LOGGER.logError(msg, e);
+            if (shell != null) {
+                MessageDialog.openError(shell, msg, String.format("""
+                    Unable to update the Ruyi package index.
+
+                    %s""", e.getMessage()));
+            }
+            throw new ExecutionException(msg, e);
+        }
+    }
+}

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/PackageIndexUpdater.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/PackageIndexUpdater.java
@@ -21,8 +21,6 @@ public final class PackageIndexUpdater {
      * parented at the given shell.
      *
      * @param shell parent shell for the progress dialog
-     * @throws PluginException if the underlying CLI invocation fails or the operation is
-     *         interrupted
      */
     public static void updateWithProgress(Shell shell) {
         try {

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/PackageIndexUpdater.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/PackageIndexUpdater.java
@@ -1,0 +1,50 @@
+package org.ruyisdk.ruyi.services;
+
+import java.lang.reflect.InvocationTargetException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.dialogs.ProgressMonitorDialog;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.statushandlers.StatusManager;
+import org.ruyisdk.core.exception.PluginException;
+import org.ruyisdk.ruyi.Activator;
+
+/**
+ * UI helper that runs {@code ruyi update} inside a {@link ProgressMonitorDialog}.
+ */
+public final class PackageIndexUpdater {
+    private PackageIndexUpdater() {}
+
+    /**
+     * Runs {@link RuyiCli#updatePackageIndex()} in a non-cancelable {@link ProgressMonitorDialog}
+     * parented at the given shell.
+     *
+     * @param shell parent shell for the progress dialog
+     * @throws PluginException if the underlying CLI invocation fails or the operation is
+     *         interrupted
+     */
+    public static void updateWithProgress(Shell shell) {
+        try {
+            new ProgressMonitorDialog(shell).run(true, false, monitor -> {
+                monitor.beginTask("Updating package index...", IProgressMonitor.UNKNOWN);
+                try {
+                    RuyiCli.updatePackageIndex();
+                } catch (RuntimeException e) {
+                    throw new InvocationTargetException(e);
+                } finally {
+                    monitor.done();
+                }
+            });
+        } catch (InvocationTargetException e) {
+            StatusManager.getManager().handle(
+                    Status.error("Failed to update package index.", e.getCause()),
+                    StatusManager.LOG | StatusManager.BLOCK);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            StatusManager.getManager().handle(
+                    new Status(IStatus.CANCEL, Activator.PLUGIN_ID, "Operation was cancelled.", e),
+                    StatusManager.LOG | StatusManager.BLOCK);
+        }
+    }
+}

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/PackageIndexUpdater.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/PackageIndexUpdater.java
@@ -7,7 +7,6 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.statushandlers.StatusManager;
-import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.ruyi.Activator;
 
 /**
@@ -28,8 +27,6 @@ public final class PackageIndexUpdater {
                 monitor.beginTask("Updating package index...", IProgressMonitor.UNKNOWN);
                 try {
                     RuyiCli.updatePackageIndex();
-                } catch (RuntimeException e) {
-                    throw new InvocationTargetException(e);
                 } finally {
                     monitor.done();
                 }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvDetectionService.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvDetectionService.java
@@ -79,13 +79,6 @@ public class VenvDetectionService {
         return RuyiCli.listEmulators();
     }
 
-    /** Updates the local package index via the Ruyi CLI. */
-    public void updateIndex() {
-        LOGGER.logInfo("Updating Ruyi package index");
-        RuyiCli.updatePackageIndex();
-        LOGGER.logInfo("Ruyi package index update finished successfully");
-    }
-
     /** Installs a package via the Ruyi CLI. */
     public void installPackage(String name, String version) {
         LOGGER.logInfo("Installing package: name=" + name + ", version=" + version);

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
@@ -150,9 +150,7 @@ public class VenvWizardViewModel {
         return sb.toString();
     }
 
-    private void refreshLists() {
-        service.updateIndex();
-
+    private void loadLists() {
         profiles.clear();
         allToolchains.clear();
         allEmulators.clear();
@@ -227,9 +225,9 @@ public class VenvWizardViewModel {
         return providedByPackage.containsAll(neededByProfile);
     }
 
-    /** Updates the CLI index and refreshes all view model data. */
-    public void refreshAll() {
-        refreshLists();
+    /** Loads package lists from the Ruyi CLI and refreshes all view model data. */
+    public void loadAll() {
+        loadLists();
         filterPackagesBySelectedProfile();
         recomputeDerivedState();
     }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
@@ -3,7 +3,6 @@ package org.ruyisdk.venv.views;
 import java.lang.reflect.InvocationTargetException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.ui.statushandlers.StatusManager;
 import org.ruyisdk.core.exception.PluginException;
@@ -32,34 +31,7 @@ public class VenvWizard extends Wizard {
 
     @Override
     public void addPages() {
-        try {
-            final var pmd = new ProgressMonitorDialog(getShell());
-            if (pmd.getShell() != null) {
-                pmd.getShell().setText("Updating package index");
-            }
-            pmd.run(true, true, monitor -> {
-                monitor.beginTask("Updating package index...", 100);
-                try {
-                    viewModel.refreshAll();
-                } catch (PluginException e) {
-                    throw new InvocationTargetException(e);
-                }
-                monitor.worked(100);
-            });
-        } catch (InvocationTargetException e) {
-            StatusManager.getManager()
-                    .handle(new Status(IStatus.ERROR, "org.ruyisdk.venv",
-                            "Failed to update package index; wizard will abort.", e.getCause()),
-                            StatusManager.LOG | StatusManager.BLOCK);
-            return;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            StatusManager.getManager()
-                    .handle(new Status(IStatus.CANCEL, "org.ruyisdk.venv",
-                            "Package index update was cancelled; wizard will abort.", e),
-                            StatusManager.LOG | StatusManager.BLOCK);
-            return;
-        }
+        viewModel.loadAll();
 
         configurationPage = new WizardConfigPage(viewModel);
         addPage(configurationPage);

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
@@ -8,6 +8,7 @@ import org.eclipse.core.databinding.conversion.Converter;
 import org.eclipse.core.databinding.observable.value.SelectObservableValue;
 import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.jface.databinding.viewers.typed.ViewerProperties;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.TableViewer;
@@ -26,6 +27,8 @@ import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
+import org.ruyisdk.core.exception.PluginException;
+import org.ruyisdk.ruyi.services.PackageIndexUpdater;
 import org.ruyisdk.venv.model.Emulator;
 import org.ruyisdk.venv.model.Profile;
 import org.ruyisdk.venv.model.Toolchain;
@@ -78,6 +81,29 @@ public class WizardConfigPage extends WizardPage {
     private void createLayouts(Composite parent) {
         container = new Composite(parent, SWT.NONE);
         container.setLayout(new GridLayout(1, false));
+
+        // Refresh button row
+        {
+            final var refreshComposite = new Composite(container, SWT.NONE);
+            refreshComposite.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+            final var refreshLayout = new GridLayout(2, false);
+            refreshLayout.marginWidth = 0;
+            refreshComposite.setLayout(refreshLayout);
+
+            final var hintLabel = new Label(refreshComposite, SWT.NONE);
+            hintLabel.setText("If lists are empty, update the package index first.");
+            hintLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+
+            final var refreshButton = new Button(refreshComposite, SWT.PUSH);
+            refreshButton.setText("Update Package Index");
+            refreshButton.setLayoutData(new GridData(SWT.END, SWT.CENTER, false, false));
+            refreshButton.addSelectionListener(new SelectionAdapter() {
+                @Override
+                public void widgetSelected(SelectionEvent e) {
+                    performUpdateAndRefresh();
+                }
+            });
+        }
 
         profileComposite = new Composite(container, SWT.NONE);
         profileComposite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
@@ -581,5 +607,25 @@ public class WizardConfigPage extends WizardPage {
         if (getWizard() != null && getWizard().getContainer() != null) {
             getWizard().getContainer().updateButtons();
         }
+    }
+
+    private void performUpdateAndRefresh() {
+        try {
+            PackageIndexUpdater.updateWithProgress(getShell());
+        } catch (PluginException e) {
+            final var msg = "Failed to update the package index";
+            MessageDialog.openError(getShell(), msg, String.format("""
+                Unable to update the Ruyi package index.
+
+                %s""", e.getMessage()));
+            return;
+        }
+
+        viewModel.loadAll();
+        profileTableViewer.setInput(viewModel.getProfiles());
+        toolchainNamesViewer.setInput(viewModel.getToolchains());
+        toolchainVersionsViewer.setInput(List.of());
+        emulatorNamesViewer.setInput(viewModel.getEmulators());
+        emulatorVersionsViewer.setInput(List.of());
     }
 }


### PR DESCRIPTION
Screenshot:

<img width="600" alt="Two entrances of the newly added function for updating index" src="https://github.com/user-attachments/assets/5913e4d5-5e33-4ace-a90c-1d6d447d50ec" />

## Summary by Sourcery

Decouple the virtual environment configuration wizard from automatic package index updates and provide explicit UI entry points for updating the index.

New Features:
- Add an in‑wizard "Update Package Index" button with guidance text to refresh package lists when they are empty.
- Introduce a top-level "Update Package Index" menu command with a dedicated handler that runs the update with a progress dialog and user feedback.

Enhancements:
- Change the venv wizard to load existing package data without implicitly updating the package index on open.
- Extract package index update logic into a reusable PackageIndexUpdater UI service and simplify the venv view model to only load lists without triggering CLI index updates.