### PR TITLE
feat: adjust layout of venv wizard; "browse" button follows current path

### DIFF
--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
@@ -43,8 +43,6 @@ public class WizardConfigPage extends WizardPage {
     private DataBindingContext dbc;
 
     private Composite container;
-    private Composite leftColumn;
-    private Composite rightColumn;
     private Composite profileComposite;
     private Composite toolchainComposite;
     private Composite emulatorHeader;
@@ -118,7 +116,7 @@ public class WizardConfigPage extends WizardPage {
             });
         }
 
-        leftColumn = new Composite(container, SWT.NONE);
+        final var leftColumn = new Composite(container, SWT.NONE);
         leftColumn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         {
             final var gridLayout = new GridLayout(1, false);
@@ -126,7 +124,7 @@ public class WizardConfigPage extends WizardPage {
             leftColumn.setLayout(gridLayout);
         }
 
-        rightColumn = new Composite(container, SWT.NONE);
+        final var rightColumn = new Composite(container, SWT.NONE);
         rightColumn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         {
             final var gridLayout = new GridLayout(1, false);

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
@@ -43,6 +43,8 @@ public class WizardConfigPage extends WizardPage {
     private DataBindingContext dbc;
 
     private Composite container;
+    private Composite leftColumn;
+    private Composite rightColumn;
     private Composite profileComposite;
     private Composite toolchainComposite;
     private Composite emulatorHeader;
@@ -80,15 +82,26 @@ public class WizardConfigPage extends WizardPage {
 
     private void createLayouts(Composite parent) {
         container = new Composite(parent, SWT.NONE);
-        container.setLayout(new GridLayout(1, false));
+        {
+            final var gridLayout = new GridLayout(2, false);
+            gridLayout.makeColumnsEqualWidth = true;
+            gridLayout.horizontalSpacing = 16;
+            container.setLayout(gridLayout);
+        }
 
         // Refresh button row
         {
             final var refreshComposite = new Composite(container, SWT.NONE);
-            refreshComposite.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
-            final var refreshLayout = new GridLayout(2, false);
-            refreshLayout.marginWidth = 0;
-            refreshComposite.setLayout(refreshLayout);
+            {
+                final var gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+                gridData.horizontalSpan = 2;
+                refreshComposite.setLayoutData(gridData);
+            }
+            {
+                final var gridLayout = new GridLayout(2, false);
+                gridLayout.marginWidth = 0;
+                refreshComposite.setLayout(gridLayout);
+            }
 
             final var hintLabel = new Label(refreshComposite, SWT.NONE);
             hintLabel.setText("If lists are empty, update the package index first.");
@@ -105,43 +118,59 @@ public class WizardConfigPage extends WizardPage {
             });
         }
 
-        profileComposite = new Composite(container, SWT.NONE);
-        profileComposite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        leftColumn = new Composite(container, SWT.NONE);
+        leftColumn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         {
-            var gridLayout = new GridLayout(1, false);
+            final var gridLayout = new GridLayout(1, false);
+            gridLayout.marginWidth = 0;
+            leftColumn.setLayout(gridLayout);
+        }
+
+        rightColumn = new Composite(container, SWT.NONE);
+        rightColumn.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        {
+            final var gridLayout = new GridLayout(1, false);
+            gridLayout.marginWidth = 0;
+            rightColumn.setLayout(gridLayout);
+        }
+
+        profileComposite = new Composite(leftColumn, SWT.NONE);
+        profileComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        {
+            final var gridLayout = new GridLayout(1, false);
             gridLayout.marginWidth = 0;
             profileComposite.setLayout(gridLayout);
         }
 
-        toolchainComposite = new Composite(container, SWT.NONE);
-        toolchainComposite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        toolchainComposite = new Composite(rightColumn, SWT.NONE);
+        toolchainComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         {
-            var gridLayout = new GridLayout(2, false);
+            final var gridLayout = new GridLayout(2, false);
             gridLayout.marginWidth = 0;
             toolchainComposite.setLayout(gridLayout);
         }
 
-        emulatorHeader = new Composite(container, SWT.NONE);
-        emulatorHeader.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        emulatorHeader = new Composite(rightColumn, SWT.NONE);
+        emulatorHeader.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
         {
-            var gridLayout = new GridLayout(2, false);
+            final var gridLayout = new GridLayout(2, false);
             gridLayout.marginWidth = 0;
             emulatorHeader.setLayout(gridLayout);
         }
 
-        emulatorComposite = new Composite(container, SWT.NONE);
-        emulatorComposite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        emulatorComposite = new Composite(rightColumn, SWT.NONE);
+        emulatorComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         {
-            var gridLayout = new GridLayout(2, false);
+            final var gridLayout = new GridLayout(2, false);
             gridLayout.marginWidth = 0;
             emulatorComposite.setLayout(gridLayout);
         }
 
-        sysrootGroup = new Group(container, SWT.NONE);
+        sysrootGroup = new Group(leftColumn, SWT.NONE);
         sysrootGroup.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
         sysrootGroup.setText("");
         {
-            var gridLayout = new GridLayout(3, false);
+            final var gridLayout = new GridLayout(3, false);
             gridLayout.marginWidth = 0;
             sysrootGroup.setLayout(gridLayout);
         }
@@ -158,7 +187,7 @@ public class WizardConfigPage extends WizardPage {
             profileTableViewer = new TableViewer(profileComposite, SWT.BORDER | SWT.FULL_SELECTION);
             final var profileTable = profileTableViewer.getTable();
             {
-                final var gridData = new GridData(GridData.FILL_HORIZONTAL);
+                final var gridData = new GridData(SWT.FILL, SWT.FILL, true, true);
                 gridData.heightHint = 150;
                 profileTable.setLayoutData(gridData);
             }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardLocationPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardLocationPage.java
@@ -121,7 +121,9 @@ public class WizardLocationPage extends WizardPage {
                 Properties.selfValue(String.class));
 
         browseButton.addListener(SWT.Selection, e -> {
-            String selectedPath = new DirectoryDialog(getShell()).open();
+            final var directoryDialog = new DirectoryDialog(getShell());
+            directoryDialog.setFilterPath(venvPathCombo.getText());
+            final var selectedPath = directoryDialog.open();
             if (selectedPath != null) {
                 venvPathCombo.setText(selectedPath);
             }


### PR DESCRIPTION
175% DPI scaling:

| Before | After |
|:-:|:-:|
| <img width="350" alt="before this PR, the bottom part of the dialog cannot be seen" src="https://github.com/user-attachments/assets/d9a0eb04-200c-44e5-be84-324cf4cc06b3" /> | <img width="350" alt="after this PR, the whole dialog is in landscape layout, and nothing will be hidden" src="https://github.com/user-attachments/assets/83b7e5ba-9d3b-4f3f-b58f-9acd3b6cb660" /> |

.

## Summary by Sourcery

Rework the venv configuration and location wizards to improve layout and path selection usability.

New Features:
- Make the venv location "Browse" directory chooser start in the currently entered path.

Enhancements:
- Change the venv configuration page to a two-column layout so sections are visible on high-DPI displays and resize more effectively.