### PR TITLE
fix: bundle builtin terminal for solving dependency issue

### DIFF
--- a/features/org.ruyisdk.feature/feature.xml
+++ b/features/org.ruyisdk.feature/feature.xml
@@ -11,7 +11,7 @@
    </description>
 
    <copyright>
-Copyright (C) Institute of Software, Chinese Academy of Sciences (ISCAS).
+      Copyright (C) Institute of Software, Chinese Academy of Sciences (ISCAS).
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v2.0
 which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ https://www.eclipse.org/legal/epl-2.0/
    </copyright>
 
    <license url="https://www.eclipse.org/legal/epl-2.0/">
-Eclipse Public License - v 2.0
+      Eclipse Public License - v 2.0
 
 THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
 PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE, REPRODUCTION OR DISTRIBUTION
@@ -297,111 +297,70 @@ You may add additional accurate notices of copyright ownership.
 
    <plugin
          id="org.ruyisdk.promotion"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.ruyisdk.core"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.ruyisdk.devices"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.ruyisdk.intro"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.ruyisdk.news"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.ruyisdk.packages"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.ruyisdk.projectcreator"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.ruyisdk.ruyi"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.ruyisdk.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.ruyisdk.venv"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
-   <!-- Third-party bundles required by our plugins.
-        These are pulled from Eclipse Orbit (p2) and included in the feature
-        so they get installed along with our plugins. -->
    <plugin
          id="org.glassfish.javax.json"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="com.google.gson"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
-   <!-- org.json library wrapped as OSGi bundle (bundle symbolic name is "json") -->
    <plugin
          id="json"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.commonmark"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.commonmark.ext-gfm-tables"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.tm.terminal.connector.process"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.tm.terminal.view.core"
+         version="0.0.0"/>
 
 </feature>

--- a/plugins/org.ruyisdk.ruyi/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.ruyi/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Require-Bundle:
  org.eclipse.core.runtime,
  org.eclipse.equinox.app,
  org.eclipse.jface,
+ org.eclipse.tm.terminal.connector.process,
  org.eclipse.tm.terminal.view.core,
  org.eclipse.ui,
  org.ruyisdk.core,


### PR DESCRIPTION
```
Cannot complete the install because one or more required items could not be found.
  Software being installed: RuyiSDK IDE Feature 0.1.2.20260421-0632 (org.ruyisdk.feature.feature.group 0.1.2.20260421-0632)
  Missing requirement: Ruyi 0.1.2.20260421-0632 (org.ruyisdk.ruyi 0.1.2.20260421-0632) requires 'osgi.bundle; org.eclipse.tm.terminal.view.core 0.0.0' but it could not be found
  Cannot satisfy dependency:
    From: RuyiSDK IDE Feature 0.1.2.20260421-0632 (org.ruyisdk.feature.feature.group 0.1.2.20260421-0632)
    To: org.eclipse.equinox.p2.iu; org.ruyisdk.ruyi [0.1.2.20260421-0632,0.1.2.20260421-0632]

```

## Summary by Sourcery

Bundle the Eclipse TM terminal plugins in the RuyiSDK feature to satisfy the builtin terminal dependency and clean up feature plugin declarations.

New Features:
- Include the Eclipse TM terminal process connector and core view plugins in the RuyiSDK feature so the builtin terminal is available out of the box.

Enhancements:
- Simplify feature plugin declarations by removing redundant size and unpack attributes from listed plugins.