### PR TITLE
fix: NPE when installing Ruyi for the first time

### DIFF
--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/ruyi/model/CheckResult.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/ruyi/model/CheckResult.java
@@ -48,8 +48,8 @@ public class CheckResult {
      *
      * @return new CheckResult instance with INSTALL action
      */
-    public static CheckResult needInstall() {
-        return new CheckResult(ActionType.INSTALL, null, null, null);
+    public static CheckResult needInstall(RuyiVersion latest) {
+        return new CheckResult(ActionType.INSTALL, null, null, latest);
     }
 
     /**

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/RuyiCore.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/RuyiCore.java
@@ -76,7 +76,7 @@ public class RuyiCore {
         Display.getDefault().asyncExec(() -> {
             switch (result.getAction()) {
                 case INSTALL:
-                    RuyiInstallWizard.openForInstall();
+                    RuyiInstallWizard.openForInstall(result.getLatestVersion());
                     break;
 
                 case UPGRADE:

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/jobs/CheckRuyiJob.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/jobs/CheckRuyiJob.java
@@ -30,13 +30,13 @@ public class CheckRuyiJob {
             final var current = getInstalledVersion();
             monitor.worked(1);
 
-            if (current == null) {
-                return CheckResult.needInstall();
-            }
-
             monitor.subTask("Checking latest version");
             final var latest = getLatestRelease();
             monitor.worked(1);
+
+            if (current == null) {
+                return CheckResult.needInstall(latest);
+            }
 
             if (latest != null) {
                 if (!RuyiCliVersionSupport.isSupportedVersion(current)

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/ui/RuyiInstallWizard.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/ui/RuyiInstallWizard.java
@@ -49,8 +49,8 @@ public class RuyiInstallWizard extends Wizard {
     /**
      * Opens wizard for fresh installation.
      */
-    public static void openForInstall() {
-        new RuyiInstallWizard(Mode.INSTALL, null, null).open();
+    public static void openForInstall(RuyiVersion latest) {
+        new RuyiInstallWizard(Mode.INSTALL, null, latest).open();
     }
 
     /**


### PR DESCRIPTION
Then the latest version number will be shown in the dialog as before.

## Summary by Sourcery

Bug Fixes:
- Fix a null pointer issue when opening the Ruyi install wizard on a fresh installation by propagating the latest version information instead of passing nulls.