### PR TITLE
feat: use CompletableFuture for asnyc op; use custom error dialogs; MVVM

### DIFF
--- a/plugins/org.ruyisdk.core/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.core/META-INF/MANIFEST.MF
@@ -12,6 +12,7 @@ Bundle-ClassPath:
  .,
  icons/
 Require-Bundle: 
+ org.eclipse.core.databinding.observable,
  org.eclipse.core.runtime,
  org.eclipse.jface,
  org.eclipse.ui.console,
@@ -22,4 +23,5 @@ Export-Package:
  org.ruyisdk.core.console,
  org.ruyisdk.core.exception,
  org.ruyisdk.core.ruyi.model,
- org.ruyisdk.core.util
+ org.ruyisdk.core.util,
+ org.ruyisdk.core.util.dialog

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/exception/PluginException.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/exception/PluginException.java
@@ -33,22 +33,6 @@ public class PluginException extends RuntimeException {
      * @param cause the underlying cause
      */
     protected PluginException(String message, Throwable cause) {
-        super(makeMessage(message, cause), cause);
-    }
-
-    private static String makeMessage(String message, Throwable cause) {
-        if (cause == null) {
-            return message;
-        }
-        final var exType = cause.getClass().getSimpleName();
-        final var exMsg = cause.getMessage();
-        if (exMsg != null) {
-            return String.format("""
-                %s
-                %s: %s""", message, exType, exMsg);
-        }
-        return String.format("""
-            %s
-            %s""", message, exType);
+        super(message, cause);
     }
 }

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/util/dialog/DialogBinder.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/util/dialog/DialogBinder.java
@@ -1,0 +1,78 @@
+package org.ruyisdk.core.util.dialog;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+
+/**
+ * Subscribes to provider status updates and displays them as message dialogs.
+ *
+ * <p>
+ * Each non-null status change triggers a dialog on the UI thread.
+ */
+public class DialogBinder {
+
+    private static final String errorSuffix = "See the \"Error Log\" view for details.";
+
+    record DialogSpec(int kind, String message) {
+    }
+
+    /**
+     * Attaches a listener to {@link IDialogStatusProvider#getLastStatus()}.
+     *
+     * <p>
+     * The status severity is mapped to the dialog kind (error, warning, information, or default).
+     * For every dialog attempt, the method also tries to open the Eclipse Error Log view first.
+     *
+     * @param shell parent shell used to display dialogs
+     * @param provider source of status updates
+     * @param title dialog title
+     */
+    public static void bind(Shell shell, IDialogStatusProvider provider, String title) {
+        provider.getLastStatus().addValueChangeListener(ev -> {
+            final var s = ev.diff.getNewValue();
+            if (s != null) {
+                final var spec = constructSpec(s);
+
+                shell.getDisplay().asyncExec(() -> {
+                    try {
+                        PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage()
+                                .showView("org.eclipse.pde.runtime.LogView");
+                    } catch (PartInitException e) {
+                        // ignore
+                    }
+                    MessageDialog.open(spec.kind, shell, title, spec.message, SWT.NONE);
+                });
+            }
+        });
+    }
+
+    private static DialogSpec constructSpec(IStatus status) {
+        var kind = MessageDialog.OK;
+        var message = status.getMessage();
+
+        switch (status.getSeverity()) {
+            case IStatus.ERROR:
+                kind = MessageDialog.ERROR;
+                message = String.format("""
+                    %s
+
+                    %s
+                    """, message, errorSuffix);
+                break;
+            case IStatus.WARNING:
+                kind = MessageDialog.WARNING;
+                break;
+            case IStatus.INFO:
+                kind = MessageDialog.INFORMATION;
+                break;
+            default:
+                break;
+        }
+
+        return new DialogSpec(kind, message);
+    }
+}

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/util/dialog/DialogBinder.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/util/dialog/DialogBinder.java
@@ -38,11 +38,18 @@ public class DialogBinder {
                 final var spec = constructSpec(s);
 
                 shell.getDisplay().asyncExec(() -> {
-                    try {
-                        PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage()
-                                .showView("org.eclipse.pde.runtime.LogView");
-                    } catch (PartInitException e) {
-                        // ignore
+                    {
+                        final var window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+                        if (window != null) {
+                            final var page = window.getActivePage();
+                            if (page != null) {
+                                try {
+                                    page.showView("org.eclipse.pde.runtime.LogView");
+                                } catch (PartInitException e) {
+                                    // ignore
+                                }
+                            }
+                        }
                     }
                     MessageDialog.open(spec.kind, shell, title, spec.message, SWT.NONE);
                 });

--- a/plugins/org.ruyisdk.core/src/org/ruyisdk/core/util/dialog/IDialogStatusProvider.java
+++ b/plugins/org.ruyisdk.core/src/org/ruyisdk/core/util/dialog/IDialogStatusProvider.java
@@ -1,0 +1,20 @@
+package org.ruyisdk.core.util.dialog;
+
+import org.eclipse.core.databinding.observable.value.IObservableValue;
+import org.eclipse.core.runtime.IStatus;
+
+/**
+ * Provides observable status updates for dialog presentation.
+ */
+public interface IDialogStatusProvider {
+
+    /**
+     * Returns the observable that publishes the latest user-facing status.
+     *
+     * <p>
+     * Consumers treat non-null value changes as dialog events.
+     *
+     * @return observable latest status, usually initialized with {@code null}
+     */
+    public IObservableValue<IStatus> getLastStatus();
+}

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsFetchService.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsFetchService.java
@@ -23,6 +23,7 @@ public class NewsFetchService {
             try {
                 final var result = RuyiCli.readNewsItem(id);
                 if (result == null || result.getContent() == null) {
+                    // TODO: do not use runtimeException.
                     throw new RuntimeException("News item not found, id=" + id);
                 }
                 LOGGER.logInfo("Fetched news details, id=" + id);

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsFetchService.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/model/NewsFetchService.java
@@ -3,9 +3,10 @@ package org.ruyisdk.news.model;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.ui.progress.IProgressConstants;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.news.Activator;
 import org.ruyisdk.ruyi.services.RuyiCli;
@@ -14,67 +15,63 @@ import org.ruyisdk.ruyi.services.RuyiCli;
 public class NewsFetchService {
     private static final PluginLogger LOGGER = Activator.getLogger();
 
-    /** Fetches news details asynchronously with an optional error callback. */
-    public void fetchNewsDetailsAsync(String id, Consumer<String> callback,
-            Consumer<String> errorCallback) {
-        final var fetchJob = Job.create("Fetching News Details", monitor -> {
-            LOGGER.logInfo("Fetching news details: id=" + id);
+    /** Fetches news details asynchronously. */
+    public CompletableFuture<String> fetchNewsDetailsAsync(String id) {
+        final var future = new CompletableFuture<String>();
+        final var job = Job.create("Fetching News Details", monitor -> {
+            LOGGER.logInfo("Fetching news details, id=" + id);
             try {
                 final var result = RuyiCli.readNewsItem(id);
-                if (result == null) {
-                    final var msg = "News item not found: id=" + id;
-                    LOGGER.logError(msg);
-                    errorCallback.accept(msg);
-                    return Status.CANCEL_STATUS; // avoid Eclipse error dialog
+                if (result == null || result.getContent() == null) {
+                    throw new RuntimeException("News item not found, id=" + id);
                 }
-                final var content = result.getContent() == null ? "" : result.getContent();
-                LOGGER.logInfo("Fetched news details: id=" + id + ", length=" + content.length());
-                callback.accept(content);
+                LOGGER.logInfo("Fetched news details, id=" + id);
+                future.complete(result.getContent());
                 return Status.OK_STATUS;
             } catch (Exception e) {
-                final var msg = "Failed to read news details: id=" + id;
-                LOGGER.logError(msg, e);
-                errorCallback.accept(msg);
-                return Status.CANCEL_STATUS; // avoid Eclipse error dialog
+                future.completeExceptionally(e);
+                return Status.error("Failed to read news details, id=" + id, e);
             }
         });
-        fetchJob.schedule();
+        // no error dialog
+        job.setProperty(IProgressConstants.NO_IMMEDIATE_ERROR_PROMPT_PROPERTY, Boolean.TRUE);
+        job.schedule();
+        return future;
     }
 
     /** Fetches the news list asynchronously. */
-    public void fetchNewsListAsync(Consumer<List<NewsItem>> callback) {
-        final var fetchJob = Job.create("Fetching News List", monitor -> {
+    public CompletableFuture<List<NewsItem>> fetchNewsListAsync() {
+        final var future = new CompletableFuture<List<NewsItem>>();
+        final var job = Job.create("Fetching News List", monitor -> {
             LOGGER.logInfo("Fetching news list");
             try {
+                final var fetchedItems = RuyiCli.listNewsItems(false);
+                LOGGER.logInfo(String.format("Fetched news list: count=%d", fetchedItems.size()));
+
                 final var newsList = new ArrayList<NewsItem>();
-                int unreadCount = 0;
-                for (final var item : RuyiCli.listNewsItems(false)) {
+                for (final var item : fetchedItems) {
                     if (item == null) {
                         continue;
                     }
-
-                    final var isRead = item.isRead();
-                    final var unread = isRead == null || !isRead.booleanValue();
-                    if (unread) {
-                        unreadCount++;
-                    }
-
                     final var ordObj = item.getOrd();
                     final var ord = ordObj == null ? -1 : ordObj.intValue();
                     final var title = item.getTitle() == null ? "" : item.getTitle();
                     final var id = item.getId() == null ? "" : item.getId();
+                    final var isRead = item.isRead();
+                    final var unread = isRead == null || !isRead.booleanValue();
                     newsList.add(new NewsItem(ord, title, id, unread));
                 }
-                LOGGER.logInfo(String.format("Fetched news list: count=%d, unread=%d",
-                        newsList.size(), unreadCount));
                 newsList.sort(Comparator.comparingInt(NewsItem::getOrd).reversed());
-                callback.accept(newsList);
+                future.complete(newsList);
                 return Status.OK_STATUS;
             } catch (Exception e) {
-                callback.accept(null);
+                future.completeExceptionally(e);
                 return Status.error("Failed to fetch news list", e);
             }
         });
-        fetchJob.schedule();
+        // no error dialog
+        job.setProperty(IProgressConstants.NO_IMMEDIATE_ERROR_PROMPT_PROPERTY, Boolean.TRUE);
+        job.schedule();
+        return future;
     }
 }

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/viewmodel/NewsDetailsViewModel.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/viewmodel/NewsDetailsViewModel.java
@@ -49,18 +49,27 @@ public class NewsDetailsViewModel {
         selected.setDetailsHtml(MarkdownRenderer.renderToHtml("*fetching news details...*"));
         isFetching = true;
 
-        service.fetchNewsDetailsAsync(selected.getId(), result -> {
-            isFetching = false;
+        service.fetchNewsDetailsAsync(selected.getId()).thenAccept(result -> {
             final var markdown = result == null ? "" : result;
             selected.setDetails(markdown);
             selected.setDetailsHtml(MarkdownRenderer.renderToHtml(markdown));
             selected.setDetailsFetched(true);
-        }, result -> {
-            isFetching = false;
-            final var errorMarkdown = "*failed to fetch news details: " + result + "*";
-            selected.setDetails(errorMarkdown);
-            selected.setDetailsHtml(MarkdownRenderer.renderToHtml(errorMarkdown));
+        }).exceptionally(e -> {
+            // unwrap CompletionException
+            final var cause = e.getCause();
+            final var markdown = String.format("""
+                *failed to fetch news details*
+
+                %s
+
+                See the \"Error Log\" view for details.
+                """, cause.getMessage());
+            selected.setDetails(markdown);
+            selected.setDetailsHtml(MarkdownRenderer.renderToHtml(markdown));
             selected.setDetailsFetched(false);
+            return null;
+        }).whenComplete((result, e) -> {
+            isFetching = false;
         });
     }
 }

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/viewmodel/NewsListViewModel.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/viewmodel/NewsListViewModel.java
@@ -7,13 +7,17 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import org.eclipse.core.databinding.observable.list.IObservableList;
 import org.eclipse.core.databinding.observable.list.WritableList;
+import org.eclipse.core.databinding.observable.value.IObservableValue;
+import org.eclipse.core.databinding.observable.value.WritableValue;
+import org.eclipse.core.runtime.IStatus;
+import org.ruyisdk.core.util.dialog.IDialogStatusProvider;
 import org.ruyisdk.news.model.NewsFetchService;
 import org.ruyisdk.news.model.NewsItem;
 
 /**
  * View model for the news list view.
  */
-public class NewsListViewModel {
+public class NewsListViewModel implements IDialogStatusProvider {
     private boolean isFetching = false;
     private String infoText = UpdatingState.notUpdated;
 
@@ -22,6 +26,7 @@ public class NewsListViewModel {
     private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
     private final IObservableList<NewsItem> observableNewsList =
             new WritableList<>(new ArrayList<>(), NewsItem.class);
+    private final IObservableValue<IStatus> lastStatus = new WritableValue<>(null, IStatus.class);
 
     private class UpdatingState {
         private static final String notUpdated = "Not Updated, yet";
@@ -114,7 +119,7 @@ public class NewsListViewModel {
         setFetching(true);
         setInfoText(UpdatingState.updating);
 
-        service.fetchNewsListAsync(result -> {
+        service.fetchNewsListAsync().thenAccept(result -> {
             observableNewsList.getRealm().asyncExec(() -> {
                 observableNewsList.clear();
                 if (result != null) {
@@ -125,7 +130,22 @@ public class NewsListViewModel {
                     setInfoText(UpdatingState.updateFailed);
                 }
             });
+        }).exceptionally(e -> {
+            // unwrap CompletionException
+            final var cause = e.getCause();
+            observableNewsList.getRealm().asyncExec(() -> {
+                observableNewsList.clear();
+                setInfoText(UpdatingState.updateFailed);
+                lastStatus.setValue(org.eclipse.core.runtime.Status.error(null, cause));
+            });
+            return null;
+        }).whenComplete((result, e) -> {
             setFetching(false);
         });
+    }
+
+    @Override
+    public IObservableValue<IStatus> getLastStatus() {
+        return lastStatus;
     }
 }

--- a/plugins/org.ruyisdk.news/src/org/ruyisdk/news/views/NewsView.java
+++ b/plugins/org.ruyisdk.news/src/org/ruyisdk/news/views/NewsView.java
@@ -30,6 +30,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.part.ViewPart;
+import org.ruyisdk.core.util.dialog.DialogBinder;
 import org.ruyisdk.news.Activator;
 import org.ruyisdk.news.model.NewsItem;
 import org.ruyisdk.news.viewmodel.NewsDetailsViewModel;
@@ -263,6 +264,8 @@ public class NewsView extends ViewPart {
                         }
                     });
         }
+
+        DialogBinder.bind(getSite().getShell(), newsListViewModel, "News");
     }
 
     private void toggleDetailControls(Boolean isShow) {

--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/view/PackageExplorerView.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/view/PackageExplorerView.java
@@ -103,7 +103,8 @@ public class PackageExplorerView extends ViewPart {
             case PackageExplorerViewModel.PROP_ERROR:
                 final var msg = (String) evt.getNewValue();
                 if (msg != null) {
-                    MessageDialog.openError(Display.getDefault().getActiveShell(), "Error", msg);
+                    MessageDialog.openError(Display.getDefault().getActiveShell(),
+                            "Package Explorer", msg);
                 }
                 break;
             default:

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvConfigurationService.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvConfigurationService.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
 import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.core.envvar.IEnvironmentVariable;
 import org.eclipse.cdt.core.settings.model.ICConfigurationDescription;
@@ -17,6 +17,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.ui.progress.IProgressConstants;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.venv.Activator;
 
@@ -218,20 +219,25 @@ public class VenvConfigurationService {
     }
 
     /** Applies the venv configuration to the project asynchronously. */
-    public void applyToProjectAsync(Venv venv, Consumer<ApplyResult> callback) {
-        final var applyJob = Job.create("Applying venv configuration to CDT project", monitor -> {
+    public CompletableFuture<ApplyResult> applyToProjectAsync(Venv venv) {
+        final var future = new CompletableFuture<ApplyResult>();
+        final var job = Job.create("Applying venv configuration to CDT project", monitor -> {
             try {
                 final var result = applyToProject(venv);
-                callback.accept(result);
-                return result.isSuccess() ? Status.OK_STATUS : Status.warning(result.getMessage());
+                if (!result.isSuccess()) {
+                    throw new RuntimeException(result.getMessage());
+                }
+                future.complete(result);
+                return Status.OK_STATUS;
             } catch (Exception e) {
-                final var msg = "Failed to apply venv configuration";
-                LOGGER.logError(msg, e);
-                callback.accept(new ApplyResult(false, msg));
-                return Status.CANCEL_STATUS; // avoid Eclipse error dialog
+                future.completeExceptionally(e);
+                return Status.error("Failed to apply venv configuration", e);
             }
         });
-        applyJob.schedule();
+        // no error dialog
+        job.setProperty(IProgressConstants.NO_IMMEDIATE_ERROR_PROMPT_PROPERTY, Boolean.TRUE);
+        job.schedule();
+        return future;
     }
 
     /** Finds a project by its file system path, using normalized path comparison. */

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvConfigurationService.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvConfigurationService.java
@@ -225,6 +225,7 @@ public class VenvConfigurationService {
             try {
                 final var result = applyToProject(venv);
                 if (!result.isSuccess()) {
+                    // TODO: do not use runtimeException.
                     throw new RuntimeException(result.getMessage());
                 }
                 future.complete(result);

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvDetectionService.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvDetectionService.java
@@ -12,7 +12,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -20,6 +20,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.ui.progress.IProgressConstants;
 import org.ruyisdk.core.exception.RuyiConfigException;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.ruyi.services.RuyiCli;
@@ -138,35 +139,32 @@ public class VenvDetectionService {
         return out;
     }
 
-    /**
-     * Detects project venvs asynchronously for the provided project roots and passes them to the
-     * callback.
-     */
-    public void detectProjectVenvsAsync(List<String> projectRootPaths,
-            Consumer<List<Venv>> callback) {
-        final var detectJob = Job.create("Detecting virtual environments", monitor -> {
+    /** Detects project venvs asynchronously for the provided project roots. */
+    public CompletableFuture<List<Venv>> detectProjectVenvsAsync(List<String> projectRootPaths) {
+        final var future = new CompletableFuture<List<Venv>>();
+        final var job = Job.create("Detecting virtual environments", monitor -> {
             LOGGER.logInfo("Detecting project venvs (async)");
-
             try {
                 final var projectPaths = toPathList(projectRootPaths);
                 final var result = detectProjectVenvs(projectPaths);
                 LOGGER.logInfo("Project venv detection finished: count=" + result.size());
-                callback.accept(result);
+                future.complete(result);
                 return Status.OK_STATUS;
             } catch (Exception e) {
+                future.completeExceptionally(e);
                 return Status.error("Failed to detect project venvs", e);
             }
         });
-        detectJob.schedule();
+        // no error dialog
+        job.setProperty(IProgressConstants.NO_IMMEDIATE_ERROR_PROMPT_PROPERTY, Boolean.TRUE);
+        job.schedule();
+        return future;
     }
 
-    /**
-     * Deletes venv directories asynchronously and reports completion or errors through the
-     * callback.
-     */
-    public void deleteVenvDirectoriesAsync(List<String> venvDirectoryPaths,
-            Consumer<Exception> callback) {
-        final var deleteJob = Job.create("Deleting virtual environments", monitor -> {
+    /** Deletes venv directories asynchronously. */
+    public CompletableFuture<Void> deleteVenvDirectoriesAsync(List<String> venvDirectoryPaths) {
+        final var future = new CompletableFuture<Void>();
+        final var job = Job.create("Deleting virtual environments", monitor -> {
             LOGGER.logInfo("Deleting venv directories: count="
                     + (venvDirectoryPaths == null ? 0 : venvDirectoryPaths.size()));
             try {
@@ -176,18 +174,20 @@ public class VenvDetectionService {
                         LOGGER.logInfo("Deleting venv directory: path=" + dir);
                         deleteDirectoryRecursively(dir);
                     }
-
                     refreshWorkspaceProjects(monitor);
                 }
                 LOGGER.logInfo("Venv directories deletion finished");
-                callback.accept(null);
+                future.complete(null);
                 return Status.OK_STATUS;
             } catch (Exception e) {
-                callback.accept(e);
-                return Status.CANCEL_STATUS; // avoid Eclipse error dialog
+                future.completeExceptionally(e);
+                return Status.error("Failed to delete venv directories", e);
             }
         });
-        deleteJob.schedule();
+        // no error dialog
+        job.setProperty(IProgressConstants.NO_IMMEDIATE_ERROR_PROMPT_PROPERTY, Boolean.TRUE);
+        job.schedule();
+        return future;
     }
 
     private static final class DetectedVenvConfig {

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
@@ -4,10 +4,14 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 import org.eclipse.core.databinding.observable.list.IObservableList;
 import org.eclipse.core.databinding.observable.list.WritableList;
+import org.eclipse.core.databinding.observable.value.IObservableValue;
+import org.eclipse.core.databinding.observable.value.WritableValue;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.ruyisdk.core.util.PluginLogger;
+import org.ruyisdk.core.util.dialog.IDialogStatusProvider;
 import org.ruyisdk.ruyi.core.workspace.WorkspaceProjectsMonitor;
 import org.ruyisdk.ruyi.core.workspace.WorkspaceProjectsMonitor.EventKind;
 import org.ruyisdk.venv.Activator;
@@ -18,11 +22,12 @@ import org.ruyisdk.venv.model.VenvDetectionService;
 /**
  * View model for the venv list view.
  */
-public class VenvListViewModel {
+public class VenvListViewModel implements IDialogStatusProvider {
 
     private static final PluginLogger LOGGER = Activator.getLogger();
 
     private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+    private final IObservableValue<IStatus> lastStatus = new WritableValue<>(null, IStatus.class);
 
     private boolean fetching = false;
     private boolean canDelete = false;
@@ -236,15 +241,24 @@ public class VenvListViewModel {
 
         setFetching(true);
         final var projectRootPaths = workspaceProjectsMonitor.getOpenProjectRootPaths();
-        detectionService.detectProjectVenvsAsync(projectRootPaths, result -> {
+        detectionService.detectProjectVenvsAsync(projectRootPaths).whenComplete((result, e) -> {
             observableVenvList.getRealm().asyncExec(() -> {
                 observableVenvList.clear();
-                if (result != null) {
-                    observableVenvList.addAll(result);
-                    LOGGER.logInfo("Venv list refreshed; count=" + result.size());
-                } else {
-                    LOGGER.logError("Venv list failed to refresh");
-                }
+            });
+        }).thenAccept(result -> {
+            LOGGER.logInfo("Venv list refreshed; count=" + result.size());
+            observableVenvList.getRealm().asyncExec(() -> {
+                observableVenvList.addAll(result);
+            });
+        }).exceptionally(e -> {
+            // unwrap CompletionException
+            final var cause = e.getCause();
+            lastStatus.getRealm().asyncExec(() -> {
+                lastStatus.setValue(Status.error(null, cause));
+            });
+            return null;
+        }).whenComplete((result, e) -> {
+            observableVenvList.getRealm().asyncExec(() -> {
                 updateHasOpenProjects();
                 setFetching(false);
             });
@@ -262,74 +276,70 @@ public class VenvListViewModel {
 
     /**
      * Deletes the selected venv directories.
-     *
-     * @param callback callback invoked with an error, or {@code null} on success
      */
-    public void onDeleteSelectedVenvDirectories(Consumer<Exception> callback) {
+    public void onDeleteSelectedVenvDirectories() {
         if (busy) {
             return;
         }
 
         final var venvPaths = getSelectedVenvDirectoryPaths();
         if (venvPaths.isEmpty()) {
-            if (callback != null) {
-                callback.accept(null);
-            }
             return;
         }
 
-        LOGGER.logInfo("Deleting selected venv directories: count=" + venvPaths.size());
-
         setFetching(true);
-        detectionService.deleteVenvDirectoriesAsync(venvPaths, err -> {
+        detectionService.deleteVenvDirectoriesAsync(venvPaths).thenAccept(v -> {
+            observableVenvList.getRealm().asyncExec(() -> {
+                onRefreshVenvListAsync();
+            });
+        }).exceptionally(e -> {
+            // unwrap CompletionException
+            final var cause = e.getCause();
+            lastStatus.getRealm().asyncExec(() -> {
+                lastStatus.setValue(Status.error(null, cause));
+            });
+            return null;
+        }).whenComplete((result, e) -> {
             observableVenvList.getRealm().asyncExec(() -> {
                 setFetching(false);
-                if (err == null) {
-                    onRefreshVenvListAsync();
-                }
-                if (callback != null) {
-                    callback.accept(err);
-                }
             });
         });
     }
 
     /**
      * Applies the selected venv's configuration to its associated project.
-     *
-     * @param callback callback invoked with the result
      */
-    public void onApplySelectedVenvConfig(Consumer<VenvConfigurationService.ApplyResult> callback) {
+    public void onApplySelectedVenvConfig() {
         if (busy) {
-            if (callback != null) {
-                callback.accept(
-                        new VenvConfigurationService.ApplyResult(false, "Operation in progress"));
-            }
             return;
         }
 
         if (selectedVenvs.size() != 1) {
-            if (callback != null) {
-                callback.accept(
-                        new VenvConfigurationService.ApplyResult(false, "No venv selected"));
-            }
             return;
         }
 
+        setFetching(true);
         final var selected = selectedVenvs.get(0);
         LOGGER.logInfo("Applying venv configuration to project: venv=" + selected.getPath());
-        setFetching(true);
-        configService.applyToProjectAsync(selected, result -> {
+        configService.applyToProjectAsync(selected).thenAccept(result -> {
+            if (result.isSuccess()) {
+                LOGGER.logInfo("Venv configuration applied successfully");
+            } else {
+                LOGGER.logWarning("Venv configuration failed: " + result.getMessage());
+            }
+            observableVenvList.getRealm().asyncExec(() -> {
+                lastStatus.setValue(Status.info(result.getMessage()));
+            });
+        }).exceptionally(e -> {
+            // unwrap CompletionException
+            final var cause = e.getCause();
+            lastStatus.getRealm().asyncExec(() -> {
+                lastStatus.setValue(Status.error(null, cause));
+            });
+            return null;
+        }).whenComplete((result, e) -> {
             observableVenvList.getRealm().asyncExec(() -> {
                 setFetching(false);
-                if (result.isSuccess()) {
-                    LOGGER.logInfo("Venv configuration applied successfully");
-                } else {
-                    LOGGER.logWarning("Venv configuration failed: " + result.getMessage());
-                }
-                if (callback != null) {
-                    callback.accept(result);
-                }
             });
         });
     }
@@ -391,5 +401,10 @@ public class VenvListViewModel {
     public void dispose() {
         disposed = true;
         workspaceProjectsMonitor.removeListener(workspaceProjectsListener);
+    }
+
+    @Override
+    public IObservableValue<IStatus> getLastStatus() {
+        return lastStatus;
     }
 }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvView.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvView.java
@@ -23,6 +23,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.part.ViewPart;
+import org.ruyisdk.core.util.dialog.DialogBinder;
 import org.ruyisdk.venv.Activator;
 import org.ruyisdk.venv.model.Venv;
 import org.ruyisdk.venv.viewmodel.VenvListViewModel;
@@ -213,12 +214,7 @@ public class VenvView extends ViewPart {
         applyButton.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent e) {
-                venvListViewModel.onApplySelectedVenvConfig(result -> {
-                    container.getDisplay().asyncExec(() -> {
-                        MessageDialog.openInformation(container.getShell(), "Apply Configuration",
-                                result.getMessage());
-                    });
-                });
+                venvListViewModel.onApplySelectedVenvConfig();
             }
         });
 
@@ -251,12 +247,7 @@ public class VenvView extends ViewPart {
                     return;
                 }
 
-                venvListViewModel.onDeleteSelectedVenvDirectories(err -> {
-                    if (err != null) {
-                        MessageDialog.openError(container.getShell(),
-                                "Delete virtual environment failed", err.getMessage());
-                    }
-                });
+                venvListViewModel.onDeleteSelectedVenvDirectories();
             }
         });
 
@@ -275,6 +266,8 @@ public class VenvView extends ViewPart {
                 }
             }
         });
+
+        DialogBinder.bind(container.getShell(), venvListViewModel, "Venv");
     }
 
     private void updateTableAreaState(boolean showTable) {


### PR DESCRIPTION
Commit message:

```
Try suppressing the built-in ugly error dialog created by the "Job"
  ("StatusManager" actually), and introduce "DialogBinder" to use custom
  error dialogs. It's the MVVM-ish way.

Also remove the message constuction in "PluginException". Embedding
  exception details in message is ultimately useless. Exceptions have
  already been chained.

Needs vary, design goes first?

```

Screenshot:

| Before | After |
|:-:|:-:|
| <img width="350" alt="image" src="https://github.com/user-attachments/assets/3b542585-8803-4812-99a7-d4d31dc7d316" /> | <img width="350" alt="image" src="https://github.com/user-attachments/assets/4584c4fa-00cd-4294-9546-d52f0499cbc8" /> |

.

## Summary by Sourcery

Adopt CompletableFuture-based async operations and centralized dialog-driven error reporting for news and virtual environment features.

New Features:
- Introduce DialogBinder and IDialogStatusProvider to surface view model status updates via custom dialogs tied to the Eclipse Error Log view.

Bug Fixes:
- Avoid duplicated or confusing error messaging by suppressing the default Eclipse job error dialog in favor of unified custom dialogs.

Enhancements:
- Refactor venv, news, and package views/view models to use observable status and dialog binding instead of ad-hoc callbacks and message dialogs.
- Standardize async services (news fetching, venv detection/deletion, venv configuration) on CompletableFuture with explicit error propagation and no built-in Eclipse error dialogs.
- Simplify PluginException messaging by removing automatic embedding of cause details into the exception message.