### PR TITLE
Feat

### DIFF
--- a/plugins/org.ruyisdk.core/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.core/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Core
+Bundle-Name: RuyiSDK Plugin - Core
 Bundle-SymbolicName: org.ruyisdk.core;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS

--- a/plugins/org.ruyisdk.devices/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.devices/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Devices
+Bundle-Name: RuyiSDK Plugin - Devices
 Bundle-SymbolicName: org.ruyisdk.devices;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS

--- a/plugins/org.ruyisdk.intro/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.intro/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: RuyiSDK Intro
+Bundle-Name: RuyiSDK Plugin - Intro
 Bundle-SymbolicName: org.ruyisdk.intro;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS

--- a/plugins/org.ruyisdk.news/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.news/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: News
+Bundle-Name: RuyiSDK Plugin - News
 Bundle-SymbolicName: org.ruyisdk.news;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS

--- a/plugins/org.ruyisdk.packages/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.packages/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Ruyi SDK Packages
+Bundle-Name: RuyiSDK Plugin - Packages
 Bundle-SymbolicName: org.ruyisdk.packages;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS

--- a/plugins/org.ruyisdk.packages/plugin.xml
+++ b/plugins/org.ruyisdk.packages/plugin.xml
@@ -12,4 +12,18 @@
             class="org.ruyisdk.packages.view.PackageExplorerView"
             category="org.ruyisdk.packages.category"/>
     </extension>
+
+    <extension point="org.eclipse.ui.menus">
+        <menuContribution
+            locationURI="menu:org.ruyisdk.ruyi.menus.main?after=additions">
+            <command
+                commandId="org.eclipse.ui.views.showView"
+                label="Package Explorer"
+                tooltip="Open Ruyi Package Explorer view">
+                <parameter
+                    name="org.eclipse.ui.views.showView.viewId"
+                    value="org.ruyisdk.packages.view" />
+            </command>
+        </menuContribution>
+    </extension>
 </plugin>

--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/view/DeviceSelectionDialog.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/view/DeviceSelectionDialog.java
@@ -2,6 +2,7 @@ package org.ruyisdk.packages.view;
 
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
@@ -34,9 +35,11 @@ import org.ruyisdk.ruyi.model.DeviceEntityInfo;
 public class DeviceSelectionDialog extends Dialog {
 
     private static final int CLEAR_ID = IDialogConstants.CLIENT_ID + 1;
+    private static final int REFRESH_ID = IDialogConstants.CLIENT_ID + 2;
 
     private final DeviceSelectionViewModel viewModel;
     private final BiConsumer<DeviceEntityInfo, Runnable> onConfirm;
+    private final Consumer<Runnable> onRefresh;
 
     private TableViewer tableViewer;
     private Text statusText;
@@ -50,12 +53,15 @@ public class DeviceSelectionDialog extends Dialog {
      * @param viewModel the device-selection ViewModel
      * @param onConfirm callback invoked on OK: {@code (selectedDevice, onDone)}. The caller must
      *        invoke {@code onDone} (on the UI thread) to close the dialog.
+     * @param onRefresh callback invoked on Refresh; caller should reload devices then invoke
+     *        {@code onDone} on the UI thread
      */
     public DeviceSelectionDialog(Shell parentShell, DeviceSelectionViewModel viewModel,
-            BiConsumer<DeviceEntityInfo, Runnable> onConfirm) {
+            BiConsumer<DeviceEntityInfo, Runnable> onConfirm, Consumer<Runnable> onRefresh) {
         super(parentShell);
         this.viewModel = viewModel;
         this.onConfirm = onConfirm;
+        this.onRefresh = onRefresh;
     }
 
     @Override
@@ -227,6 +233,7 @@ public class DeviceSelectionDialog extends Dialog {
 
     @Override
     protected void createButtonsForButtonBar(Composite parent) {
+        createButton(parent, REFRESH_ID, "Refresh", false);
         createButton(parent, CLEAR_ID, "Clear", false);
         createButton(parent, CANCEL, "Cancel", false);
         createButton(parent, OK, "OK", true);
@@ -248,12 +255,39 @@ public class DeviceSelectionDialog extends Dialog {
         }
     }
 
+    private void refreshDevices() {
+        tableViewer.getTable().setEnabled(false);
+        getButton(REFRESH_ID).setEnabled(false);
+        getButton(CLEAR_ID).setEnabled(false);
+        getButton(OK).setEnabled(false);
+        statusText.setText("Refreshing devices...");
+
+        onRefresh.accept(() -> {
+            if (getShell() == null || getShell().isDisposed()) {
+                return;
+            }
+
+            tableViewer.setInput(viewModel.getDevices());
+            tableViewer.refresh();
+
+            statusText.setText(viewModel.getStatusText());
+            tableViewer.getTable().setEnabled(true);
+            getButton(REFRESH_ID).setEnabled(true);
+            getButton(OK).setEnabled(viewModel.hasDevices());
+            getButton(CLEAR_ID).setEnabled(viewModel.getSelectedDevice() != null);
+        });
+    }
+
     @Override
     protected void buttonPressed(int buttonId) {
+        if (buttonId == REFRESH_ID) {
+            refreshDevices();
+            return;
+        }
         if (buttonId == CLEAR_ID) {
             tableViewer.setSelection(StructuredSelection.EMPTY);
-        } else {
-            super.buttonPressed(buttonId);
+            return;
         }
+        super.buttonPressed(buttonId);
     }
 }

--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/view/PackageExplorerView.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/view/PackageExplorerView.java
@@ -196,7 +196,12 @@ public class PackageExplorerView extends ViewPart {
         final var dialogVm = new DeviceSelectionViewModel(viewModel.getDevices(),
                 viewModel.getChosenDevice(), viewModel.getDeviceListErrorMessage());
         final var dialog = new DeviceSelectionDialog(parentShell, dialogVm,
-                (device, onDone) -> viewModel.setChosenDeviceAndReload(device, onDone));
+                (device, onDone) -> viewModel.setChosenDeviceAndReload(device, onDone),
+                onDone -> viewModel.refreshDevices(() -> {
+                    dialogVm.refreshDevices(viewModel.getDevices(),
+                            viewModel.getDeviceListErrorMessage());
+                    onDone.run();
+                }));
         dialog.open();
     }
 

--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/DeviceSelectionViewModel.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/DeviceSelectionViewModel.java
@@ -70,7 +70,7 @@ public class DeviceSelectionViewModel extends BaseViewModel {
      * Replace the current device snapshot and refresh status text.
      *
      * <p>
-     * If the previously selected device is no longer present, selection is cleared.
+     * Always clear the selection.
      */
     public void refreshDevices(List<DeviceEntityInfo> newDevices, String newErrorMessage) {
         devices = List.copyOf(newDevices);

--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/DeviceSelectionViewModel.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/DeviceSelectionViewModel.java
@@ -7,17 +7,18 @@ import org.ruyisdk.ruyi.model.DeviceEntityInfo;
  * ViewModel for the device-selection dialog.
  *
  * <p>
- * Receives an immutable snapshot of the device list and tracks the user's selection. The dialog
- * reads properties from this ViewModel and forwards user-selection changes back into it; it never
- * touches the main {@link PackageExplorerViewModel} directly.
+ * Receives an initial snapshot of the device list, tracks the user's selection, and can refresh its
+ * snapshot after a reload. The dialog reads properties from this ViewModel and forwards
+ * user-selection changes back into it; it never touches the main {@link PackageExplorerViewModel}
+ * directly.
  */
 public class DeviceSelectionViewModel extends BaseViewModel {
 
     public static final String PROP_SELECTED_DEVICE = "selectedDevice";
     public static final String PROP_STATUS_TEXT = "statusText";
 
-    private final List<DeviceEntityInfo> devices;
-    private final String errorMessage;
+    private List<DeviceEntityInfo> devices;
+    private String errorMessage;
     private DeviceEntityInfo selectedDevice;
 
     /**
@@ -63,6 +64,21 @@ public class DeviceSelectionViewModel extends BaseViewModel {
     /** Whether devices are available. */
     public boolean hasDevices() {
         return !devices.isEmpty();
+    }
+
+    /**
+     * Replace the current device snapshot and refresh status text.
+     *
+     * <p>
+     * If the previously selected device is no longer present, selection is cleared.
+     */
+    public void refreshDevices(List<DeviceEntityInfo> newDevices, String newErrorMessage) {
+        devices = List.copyOf(newDevices);
+        errorMessage = newErrorMessage;
+
+        clearSelection();
+
+        firePropertyChange(PROP_STATUS_TEXT, null, getStatusText());
     }
 
     /** Build the status text from the current state. */

--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/PackageExplorerViewModel.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/PackageExplorerViewModel.java
@@ -94,7 +94,13 @@ public class PackageExplorerViewModel extends BaseViewModel {
     public void initialize() {
         loadPackagesAsync(() -> {
         });
-        loadDevicesAsync();
+        loadDevicesAsync(() -> {
+        });
+    }
+
+    /** Reload available devices. */
+    public void refreshDevices(Runnable onLoaded) {
+        loadDevicesAsync(onLoaded);
     }
 
     /** Reload the package list for the currently chosen device. */
@@ -238,18 +244,27 @@ public class PackageExplorerViewModel extends BaseViewModel {
         job.schedule();
     }
 
-    private void loadDevicesAsync() {
+    private void loadDevicesAsync(Runnable onFinished) {
         final var job = Job.create("Loading device entities", monitor -> {
+            if (monitor.isCanceled()) {
+                uiExecutor.accept(onFinished);
+                return Status.CANCEL_STATUS;
+            }
+
             try {
                 final var fetched = DeviceList.loadDevices();
                 uiExecutor.accept(() -> {
                     setDevices(fetched);
                     setDeviceListErrorMessage(null);
+                    onFinished.run();
                 });
                 return Status.OK_STATUS;
             } catch (Exception e) {
                 final var msg = e.getMessage();
-                uiExecutor.accept(() -> setDeviceListErrorMessage(msg));
+                uiExecutor.accept(() -> {
+                    setDeviceListErrorMessage(msg);
+                    onFinished.run();
+                });
                 return Status.error("Failed to load device data: " + msg, e);
             }
         });

--- a/plugins/org.ruyisdk.projectcreator/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.projectcreator/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: RuyiSDK Project Creator
+Bundle-Name: RuyiSDK Plugin - Project Creator
 Bundle-SymbolicName: org.ruyisdk.projectcreator;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS

--- a/plugins/org.ruyisdk.promotion/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.promotion/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Promotion
+Bundle-Name: RuyiSDK Plugin - Promotion
 Bundle-SymbolicName: org.ruyisdk.promotion;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS

--- a/plugins/org.ruyisdk.ruyi/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.ruyi/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Ruyi
+Bundle-Name: RuyiSDK Plugin - Ruyi
 Bundle-SymbolicName: org.ruyisdk.ruyi;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS

--- a/plugins/org.ruyisdk.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.ui/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Ui
+Bundle-Name: RuyiSDK Plugin - Ui
 Bundle-SymbolicName: org.ruyisdk.ui
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS

--- a/plugins/org.ruyisdk.venv/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.venv/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Venv
+Bundle-Name: RuyiSDK Plugin - Venv
 Bundle-SymbolicName: org.ruyisdk.venv;singleton:=true
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS

--- a/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
+++ b/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Ruyi Tests
+Bundle-Name: RuyiSDK Plugin - Tests
 Bundle-SymbolicName: org.ruyisdk.ruyi.tests
 Bundle-Version: 0.1.2.qualifier
 Bundle-Vendor: ISCAS


### PR DESCRIPTION
Commits:

- 9d8a711 feat: device list can be manually refreshed in the Package Explorer view
- 8cf050c feat: add menu entry to open package explorer view
- 4ea7e52 chore: make the name of all plugins meaningful in Eclipse's list

No squashing.

## Summary by Sourcery

Add manual device list refresh support in the Package Explorer device selection dialog and expose the Package Explorer via the main Ruyi menu, while improving device loading and plugin metadata.

New Features:
- Allow users to manually refresh the device list from the device selection dialog in the Package Explorer view.
- Add a main menu entry to open the Ruyi Package Explorer view from the Ruyi menu.

Enhancements:
- Enable the Package Explorer ViewModel and device selection ViewModel to reload and propagate updated device lists asynchronously.
- Update plugin manifest metadata to use meaningful plugin names across Ruyi plugins.

Chores:
- Adjust device loading jobs to accept completion callbacks and handle cancellation more gracefully.