### PR TITLE
ci: add infinite waiting for release deletion; release: bump to v0.1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,14 @@ jobs:
           set -ex
           set -o pipefail
 
-          echo "::notice:: Now, remove the existing release of the tag '$ver_num' in 60 seconds if this workflow run is triggered by creating releases on GitHub Web UI."
-          sleep 60
+          tag_name="v$ver_num"
+
+          echo "::notice:: Now, remove the existing release of the tag '$tag_name' if this workflow run is triggered by creating releases on GitHub Web UI."
+          # https://cli.github.com/manual/gh_release
+          while gh release view "$tag_name" >/dev/null; do
+            echo "::notice::   the release '$tag_name' is still there"
+            sleep 5
+          done
 
           # "0.1.0-SNAPSHOT"
           current_ver="$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)"
@@ -229,10 +235,10 @@ jobs:
           set -ex
 
           # https://cli.github.com/manual/gh_release
-          if gh release view 'continuous'; then
+          if gh release view 'continuous' >/dev/null; then
             gh release delete 'continuous' --cleanup-tag --yes
 
-            while gh release view 'continuous'; do
+            while gh release view 'continuous' >/dev/null; do
               echo 'the release is still there'
               sleep 5
             done

--- a/features/org.ruyisdk.feature/feature.xml
+++ b/features/org.ruyisdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.ruyisdk.feature"
       label="RuyiSDK IDE Feature"
-      version="0.1.2.qualifier"
+      version="0.1.3.qualifier"
       provider-name="RuyiSDK">
 
    <description url="https://github.com/ruyisdk">

--- a/plugins/org.ruyisdk.core/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Core
 Bundle-SymbolicName: org.ruyisdk.core;singleton:=true
-Bundle-Version: 0.1.2.qualifier
+Bundle-Version: 0.1.3.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.core

--- a/plugins/org.ruyisdk.devices/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.devices/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Devices
 Bundle-SymbolicName: org.ruyisdk.devices;singleton:=true
-Bundle-Version: 0.1.2.qualifier
+Bundle-Version: 0.1.3.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.devices

--- a/plugins/org.ruyisdk.intro/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.intro/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Intro
 Bundle-SymbolicName: org.ruyisdk.intro;singleton:=true
-Bundle-Version: 0.1.2.qualifier
+Bundle-Version: 0.1.3.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.intro

--- a/plugins/org.ruyisdk.news/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.news/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - News
 Bundle-SymbolicName: org.ruyisdk.news;singleton:=true
-Bundle-Version: 0.1.2.qualifier
+Bundle-Version: 0.1.3.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.news

--- a/plugins/org.ruyisdk.packages/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.packages/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Packages
 Bundle-SymbolicName: org.ruyisdk.packages;singleton:=true
-Bundle-Version: 0.1.2.qualifier
+Bundle-Version: 0.1.3.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.packages

--- a/plugins/org.ruyisdk.projectcreator/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.projectcreator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Project Creator
 Bundle-SymbolicName: org.ruyisdk.projectcreator;singleton:=true
-Bundle-Version: 0.1.2.qualifier
+Bundle-Version: 0.1.3.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.projectcreator

--- a/plugins/org.ruyisdk.promotion/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.promotion/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Promotion
 Bundle-SymbolicName: org.ruyisdk.promotion;singleton:=true
-Bundle-Version: 0.1.2.qualifier
+Bundle-Version: 0.1.3.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.promotion

--- a/plugins/org.ruyisdk.ruyi/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.ruyi/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Ruyi
 Bundle-SymbolicName: org.ruyisdk.ruyi;singleton:=true
-Bundle-Version: 0.1.2.qualifier
+Bundle-Version: 0.1.3.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.ruyi

--- a/plugins/org.ruyisdk.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Ui
 Bundle-SymbolicName: org.ruyisdk.ui
-Bundle-Version: 0.1.2.qualifier
+Bundle-Version: 0.1.3.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.ui

--- a/plugins/org.ruyisdk.venv/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.venv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Venv
 Bundle-SymbolicName: org.ruyisdk.venv;singleton:=true
-Bundle-Version: 0.1.2.qualifier
+Bundle-Version: 0.1.3.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.venv

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>org.ruyisdk</groupId>
   <artifactId>ruyisdk-eclipse-plugins-parent</artifactId>
-  <version>0.1.2-SNAPSHOT</version>
+  <version>0.1.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>RuyiSDK Eclipse Plugins</name>

--- a/sites/repository/category.xml
+++ b/sites/repository/category.xml
@@ -4,9 +4,9 @@
       Update site for RuyiSDK Eclipse IDE plugins
    </description>
 
-   <feature url="features/org.ruyisdk.feature_0.1.2.qualifier.jar"
+   <feature url="features/org.ruyisdk.feature_0.1.3.qualifier.jar"
             id="org.ruyisdk.feature"
-            version="0.1.2.qualifier">
+            version="0.1.3.qualifier">
       <category name="ruyisdk"/>
    </feature>
 

--- a/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
+++ b/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Tests
 Bundle-SymbolicName: org.ruyisdk.ruyi.tests
-Bundle-Version: 0.1.2.qualifier
+Bundle-Version: 0.1.3.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.ruyi.tests


### PR DESCRIPTION
## Summary by Sourcery

Update release automation to wait until GitHub releases are fully deleted and bump the Eclipse plugin suite to version 0.1.3.

Enhancements:
- Change CI release cleanup step to poll GitHub releases until deletion completes instead of relying on a fixed delay.
- Silence non-error output from GitHub CLI release checks in CI to reduce workflow log noise.

Build:
- Bump parent Maven project version from 0.1.2-SNAPSHOT to 0.1.3-SNAPSHOT.
- Update Eclipse feature and update site metadata to version 0.1.3 and align plugin manifests accordingly.