### PR TITLE
feat(venv): display project name and venv path instead in venv list

### DIFF
--- a/plugins/org.ruyisdk.venv/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.venv/META-INF/MANIFEST.MF
@@ -23,3 +23,6 @@ Require-Bundle:
  org.eclipse.ui,
  org.ruyisdk.core,
  org.ruyisdk.ruyi
+Export-Package: 
+ org.ruyisdk.venv.model,
+ org.ruyisdk.venv.viewmodel

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
@@ -454,10 +454,11 @@ public class VenvListViewModel implements IDialogStatusProvider {
             return "";
         }
 
-        final var venvPath = venv.getPath();
+        var venvPath = venv.getPath();
         if (venvPath == null || venvPath.isBlank()) {
             return "";
         }
+        venvPath = venvPath.trim();
 
         final var relativePath = Path.of(venv.getProjectPath().trim()).relativize(Path.of(venvPath))
                 .toString().replace('\\', '/');

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
@@ -2,6 +2,7 @@ package org.ruyisdk.venv.viewmodel;
 
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.core.databinding.observable.list.IObservableList;
@@ -406,5 +407,69 @@ public class VenvListViewModel implements IDialogStatusProvider {
     @Override
     public IObservableValue<IStatus> getLastStatus() {
         return lastStatus;
+    }
+
+    /**
+     * Returns the project name text for table display.
+     *
+     * @param venv the venv row
+     * @return display text for the project name column
+     */
+    public static String getDisplayProjectName(Venv venv) {
+        return toDisplayProjectName(venv);
+    }
+
+    /**
+     * Returns the relative venv path text for table display.
+     *
+     * @param venv the venv row
+     * @return display text for the path column
+     */
+    public static String getDisplayPath(Venv venv) {
+        return toDisplayRelativePath(venv);
+    }
+
+    /**
+     * Creates display text for the project name column.
+     *
+     * @param venv the venv row
+     * @return display text for the project name column
+     */
+    public static String toDisplayProjectName(Venv venv) {
+        if (venv == null) {
+            return "";
+        }
+
+        return Path.of(venv.getProjectPath().trim()).getFileName().toString();
+    }
+
+    /**
+     * Creates display text for the path column.
+     *
+     * @param venv the venv row
+     * @return relative path display text
+     */
+    public static String toDisplayRelativePath(Venv venv) {
+        if (venv == null) {
+            return "";
+        }
+
+        final var venvPath = venv.getPath();
+        if (venvPath == null || venvPath.isBlank()) {
+            return "";
+        }
+
+        final var relativePath = Path.of(venv.getProjectPath().trim()).relativize(Path.of(venvPath))
+                .toString().replace('\\', '/');
+        if (relativePath.isEmpty()) {
+            return "./";
+        }
+        if (relativePath.equals("..") || relativePath.startsWith("../")) {
+            return relativePath;
+        }
+        if (relativePath.startsWith("./")) {
+            return relativePath;
+        }
+        return "./" + relativePath;
     }
 }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvView.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvView.java
@@ -42,7 +42,6 @@ public class VenvView extends ViewPart {
     private Composite tableComposite;
     private Composite buttonBar;
 
-    private Button absPathCheckBox;
     private TableViewer tableViewer;
     private Label tableAreaMessageLabel;
     private Button refreshButton;
@@ -101,11 +100,6 @@ public class VenvView extends ViewPart {
         headerLabel.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
         headerLabel.setText("Detected virtual environments in open projects:");
 
-        absPathCheckBox = new Button(header, SWT.CHECK);
-        absPathCheckBox.setText("Show absolute path");
-        absPathCheckBox.setEnabled(false);
-        absPathCheckBox.setSelection(true);
-
         // table
         {
             tableViewer =
@@ -113,23 +107,23 @@ public class VenvView extends ViewPart {
             final var tableColumnLayout = new TableColumnLayout();
             {
                 final var column = new TableViewerColumn(tableViewer, SWT.LEFT);
+                column.getColumn().setText("Project");
+                tableColumnLayout.setColumnData(column.getColumn(), new ColumnWeightData(20));
+            }
+            {
+                final var column = new TableViewerColumn(tableViewer, SWT.LEFT);
+                column.getColumn().setText("Venv Path");
+                tableColumnLayout.setColumnData(column.getColumn(), new ColumnWeightData(30));
+            }
+            {
+                final var column = new TableViewerColumn(tableViewer, SWT.LEFT);
                 column.getColumn().setText("Profile");
-                tableColumnLayout.setColumnData(column.getColumn(), new ColumnWeightData(15, 120));
+                tableColumnLayout.setColumnData(column.getColumn(), new ColumnWeightData(20));
             }
             {
                 final var column = new TableViewerColumn(tableViewer, SWT.LEFT);
                 column.getColumn().setText("Toolchain Prefix");
-                tableColumnLayout.setColumnData(column.getColumn(), new ColumnWeightData(20, 180));
-            }
-            {
-                final var column = new TableViewerColumn(tableViewer, SWT.LEFT);
-                column.getColumn().setText("Sysroot");
-                tableColumnLayout.setColumnData(column.getColumn(), new ColumnWeightData(30, 250));
-            }
-            {
-                final var column = new TableViewerColumn(tableViewer, SWT.LEFT);
-                column.getColumn().setText("Project Path");
-                tableColumnLayout.setColumnData(column.getColumn(), new ColumnWeightData(35, 300));
+                tableColumnLayout.setColumnData(column.getColumn(), new ColumnWeightData(30));
             }
             tableComposite.setLayout(tableColumnLayout);
 
@@ -139,8 +133,33 @@ public class VenvView extends ViewPart {
             final var contentProvider = new ObservableListContentProvider<Venv>();
             tableViewer.setContentProvider(contentProvider);
             tableViewer.setLabelProvider(new ObservableMapLabelProvider(Properties.observeEach(
-                    contentProvider.getKnownElements(), BeanProperties.values(Venv.class, "profile",
-                            "toolchainPrefix", "sysroot", "projectPath"))));
+                    contentProvider.getKnownElements(), BeanProperties.values(Venv.class,
+                            "projectPath", "path", "profile", "toolchainPrefix"))) {
+                @Override
+                public String getColumnText(Object element, int columnIndex) {
+                    if (!(element instanceof Venv)) {
+                        return super.getColumnText(element, columnIndex);
+                    }
+                    final var venv = (Venv) element;
+                    if (columnIndex == 0) {
+                        // Project
+                        return VenvListViewModel.getDisplayProjectName(venv);
+                    }
+                    if (columnIndex == 1) {
+                        // Venv Path
+                        return VenvListViewModel.getDisplayPath(venv);
+                    }
+                    if (columnIndex == 2) {
+                        // Profile
+                        return venv.getProfile();
+                    }
+                    if (columnIndex == 3) {
+                        // Toolchain Prefix
+                        return venv.getToolchainPrefix();
+                    }
+                    return super.getColumnText(element, columnIndex);
+                }
+            });
 
             tableViewer.setInput(venvListViewModel.getVenvList());
         }

--- a/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
+++ b/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
@@ -12,5 +12,6 @@ Require-Bundle:
  org.ruyisdk.core,
  org.ruyisdk.packages,
  org.ruyisdk.ruyi,
+ org.ruyisdk.venv,
  json,
  wrapped.org.hamcrest.hamcrest-core

--- a/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/venv/viewmodel/VenvListViewModelDisplayTest.java
+++ b/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/venv/viewmodel/VenvListViewModelDisplayTest.java
@@ -1,0 +1,55 @@
+package org.ruyisdk.venv.viewmodel;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.junit.Test;
+import org.ruyisdk.venv.model.Venv;
+
+/**
+ * Unit tests for venv table display formatting.
+ */
+public class VenvListViewModelDisplayTest {
+
+    @Test
+    public void duplicateProjectNamesStillShowBaseNameOnly() {
+        final var first =
+                Venv.createForProject("/workspace/project-a/.venv", "p", "s", "/workspace/demo");
+        final var second =
+                Venv.createForProject("/workspace/project-b/.venv", "p", "s", "/opt/demo");
+
+        assertEquals("demo", VenvListViewModel.toDisplayProjectName(first));
+        assertEquals("demo", VenvListViewModel.toDisplayProjectName(second));
+    }
+
+    @Test
+    public void uniqueProjectNameShowsBaseNameOnly() {
+        final var venv = Venv.createForProject("/workspace/project-a/.venv", "p", "s",
+                "/workspace/riscv-app");
+
+        assertEquals("riscv-app", VenvListViewModel.toDisplayProjectName(venv));
+    }
+
+    @Test
+    public void relativePathInsideProjectStartsWithDotSlash() {
+        final var venv = Venv.createForProject("/workspace/riscv-app/.venv/debug", "p", "s",
+                "/workspace/riscv-app");
+
+        assertEquals("./.venv/debug", VenvListViewModel.toDisplayRelativePath(venv));
+    }
+
+    @Test
+    public void relativePathOutsideProjectUsesDotDotSegments() {
+        final var venv =
+                Venv.createForProject("/workspace/venv", "p", "s", "/workspace/project-a");
+
+        assertEquals("../venv", VenvListViewModel.toDisplayRelativePath(venv));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void missingProjectPathIsRejected() {
+        final var venv = Venv.createStandalone("/workspace/project-a/.venv", "p", "s", List.of());
+
+        VenvListViewModel.toDisplayRelativePath(venv);
+    }
+}

--- a/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/venv/viewmodel/VenvListViewModelDisplayTest.java
+++ b/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/venv/viewmodel/VenvListViewModelDisplayTest.java
@@ -31,6 +31,11 @@ public class VenvListViewModelDisplayTest {
     }
 
     @Test
+    public void toDisplayProjectNameNullVenvReturnsEmptyString() {
+        assertEquals("", VenvListViewModel.toDisplayProjectName(null));
+    }
+
+    @Test
     public void relativePathInsideProjectStartsWithDotSlash() {
         final var venv = Venv.createForProject("/workspace/riscv-app/.venv/debug", "p", "s",
                 "/workspace/riscv-app");
@@ -44,6 +49,25 @@ public class VenvListViewModelDisplayTest {
                 Venv.createForProject("/workspace/venv", "p", "s", "/workspace/project-a");
 
         assertEquals("../venv", VenvListViewModel.toDisplayRelativePath(venv));
+    }
+
+    @Test
+    public void toDisplayRelativePathNullVenvReturnsEmptyString() {
+        assertEquals("", VenvListViewModel.toDisplayRelativePath(null));
+    }
+
+    @Test
+    public void toDisplayRelativePathNullOrBlankPathReturnsEmptyString() {
+        final var nullPathVenv =
+                Venv.createForProject("/workspace/project-a/.venv", "p", "s", "/workspace/demo");
+        nullPathVenv.setPath(null);
+
+        final var blankPathVenv =
+                Venv.createForProject("/workspace/project-b/.venv", "p", "s", "/workspace/demo");
+        blankPathVenv.setPath("   ");
+
+        assertEquals("", VenvListViewModel.toDisplayRelativePath(nullPathVenv));
+        assertEquals("", VenvListViewModel.toDisplayRelativePath(blankPathVenv));
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Screenshot:

<img width="600" alt="Comparison of the venv view" src="https://github.com/user-attachments/assets/e30bdf9f-127f-4d77-b60f-3d8329a829f6" />

## Summary by Sourcery

Update the virtual environment list view to show project names and relative venv paths, and add tests for the new display formatting.

New Features:
- Display the project name and venv path in the venv list instead of raw project paths and sysroot information.

Enhancements:
- Simplify the venv table layout by reordering and renaming columns to focus on project and venv path information.

Tests:
- Add unit tests for VenvListViewModel display formatting of project names and relative venv paths, including edge cases.