### PR TITLE
feat(venv): add right-click menu items to projects for venv management

### DIFF
--- a/plugins/org.ruyisdk.venv/plugin.xml
+++ b/plugins/org.ruyisdk.venv/plugin.xml
@@ -13,6 +13,26 @@
             category="org.ruyisdk.venv.category"/>
     </extension>
 
+    <extension point="org.eclipse.ui.commands">
+        <command
+            id="org.ruyisdk.venv.commands.newProjectVenv"
+            name="New Venv"
+            description="Create a venv under the selected project"/>
+        <command
+            id="org.ruyisdk.venv.commands.applyProjectVenv"
+            name="Apply venv"
+            description="Apply a venv to the selected project"/>
+    </extension>
+
+    <extension point="org.eclipse.ui.handlers">
+        <handler
+            class="org.ruyisdk.venv.handlers.NewProjectVenvHandler"
+            commandId="org.ruyisdk.venv.commands.newProjectVenv"/>
+        <handler
+            class="org.ruyisdk.venv.handlers.ApplyProjectVenvHandler"
+            commandId="org.ruyisdk.venv.commands.applyProjectVenv"/>
+    </extension>
+
     <extension point="org.eclipse.ui.menus">
         <menuContribution
             locationURI="menu:org.ruyisdk.ruyi.menus.main?after=additions">
@@ -24,6 +44,32 @@
                     name="org.eclipse.ui.views.showView.viewId"
                     value="org.ruyisdk.venv.view" />
             </command>
+        </menuContribution>
+
+        <menuContribution
+            locationURI="popup:org.eclipse.ui.popup.any?after=additions">
+            <menu
+                id="org.ruyisdk.venv.menu.projectContext"
+                label="RuyiSDK">
+                <visibleWhen checkEnabled="false">
+                    <with variable="selection">
+                        <count value="1"/>
+                        <iterate ifEmpty="false">
+                            <adapt type="org.eclipse.core.resources.IProject">
+                                <test
+                                    property="org.eclipse.core.resources.open"
+                                    value="true"/>
+                            </adapt>
+                        </iterate>
+                    </with>
+                </visibleWhen>
+                <command
+                    commandId="org.ruyisdk.venv.commands.newProjectVenv"
+                    label="New Venv..."/>
+                <command
+                    commandId="org.ruyisdk.venv.commands.applyProjectVenv"
+                    label="Apply venv..."/>
+            </menu>
         </menuContribution>
     </extension>
 </plugin>

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/handlers/ApplyProjectVenvHandler.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/handlers/ApplyProjectVenvHandler.java
@@ -1,0 +1,66 @@
+package org.ruyisdk.venv.handlers;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.window.Window;
+import org.eclipse.ui.dialogs.ElementListSelectionDialog;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.ruyisdk.core.util.PluginLogger;
+import org.ruyisdk.venv.Activator;
+import org.ruyisdk.venv.model.Venv;
+import org.ruyisdk.venv.viewmodel.ProjectVenvContextMenuViewModel;
+
+/**
+ * Handler applying a selected venv from the project context menu.
+ */
+public class ApplyProjectVenvHandler extends AbstractHandler {
+
+    private static final PluginLogger LOGGER = Activator.getLogger();
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        final var selection = (IStructuredSelection) HandlerUtil.getCurrentSelection(event);
+        final var firstElement = selection.getFirstElement();
+        final var project = firstElement instanceof IProject ? (IProject) firstElement
+                : ((IAdaptable) firstElement).getAdapter(IProject.class);
+        final var projectPath = project.getLocation().toOSString();
+
+        final var activator = Activator.getDefault();
+        final var viewModel = new ProjectVenvContextMenuViewModel(activator.getDetectionService(),
+                activator.getConfigService());
+        final var candidates = viewModel.listProjectVenvs(projectPath);
+
+        final var dialog = new ElementListSelectionDialog(HandlerUtil.getActiveShell(event),
+                new LabelProvider() {
+                    @Override
+                    public String getText(Object element) {
+                        return ProjectVenvContextMenuViewModel
+                                .toApplyVenvDisplayText((Venv) element);
+                    }
+                });
+        dialog.setTitle("Apply venv");
+        dialog.setMessage(
+                "Select a virtual environment to apply to project \"" + project.getName() + "\".");
+        dialog.setElements(candidates.toArray(Venv[]::new));
+        dialog.setMultipleSelection(false);
+
+        if (dialog.open() != Window.OK) {
+            return null;
+        }
+
+        final var selectedVenv = (Venv) dialog.getFirstResult();
+        final var result = viewModel.applyVenv(selectedVenv);
+
+        LOGGER.logInfo("Applied venv from project context menu: project=" + projectPath + ", venv="
+                + selectedVenv.getPath());
+        MessageDialog.openInformation(HandlerUtil.getActiveShell(event), "Apply venv",
+                result.getMessage());
+        return null;
+    }
+}

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/handlers/NewProjectVenvHandler.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/handlers/NewProjectVenvHandler.java
@@ -1,0 +1,42 @@
+package org.ruyisdk.venv.handlers;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.ruyisdk.core.util.PluginLogger;
+import org.ruyisdk.venv.Activator;
+import org.ruyisdk.venv.viewmodel.ProjectVenvContextMenuViewModel;
+import org.ruyisdk.venv.views.VenvWizard;
+
+/**
+ * Handler opening the venv creation wizard from a project context menu.
+ */
+public class NewProjectVenvHandler extends AbstractHandler {
+
+    private static final PluginLogger LOGGER = Activator.getLogger();
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        final var selection = (IStructuredSelection) HandlerUtil.getCurrentSelection(event);
+        final var firstElement = selection.getFirstElement();
+        final var project = firstElement instanceof IProject ? (IProject) firstElement
+                : ((IAdaptable) firstElement).getAdapter(IProject.class);
+        final var projectPath = project.getLocation().toOSString();
+
+        LOGGER.logInfo("Opening new venv wizard from project context: project=" + projectPath);
+
+        final var activator = Activator.getDefault();
+        final var viewModel = new ProjectVenvContextMenuViewModel(activator.getDetectionService(),
+                activator.getConfigService());
+        final var wizardViewModel = viewModel.createWizardViewModel(projectPath);
+        final var dialog = new WizardDialog(HandlerUtil.getActiveShell(event),
+                new VenvWizard(wizardViewModel));
+        dialog.open();
+        return null;
+    }
+}

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvDetectionService.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvDetectionService.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Stream;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -30,6 +31,48 @@ import org.ruyisdk.venv.Activator;
 public class VenvDetectionService {
     private static final String VENV_CONFIG_FILE_NAME = "ruyi-venv.toml";
     private static final PluginLogger LOGGER = Activator.getLogger();
+    private final List<VenvInventoryListener> inventoryListeners = new CopyOnWriteArrayList<>();
+
+    /** Listener notified when venv inventory changes (create/delete). */
+    @FunctionalInterface
+    public interface VenvInventoryListener {
+        /** Called after venv inventory has changed successfully. */
+        void onVenvInventoryChanged();
+    }
+
+    /**
+     * Registers a venv inventory listener.
+     *
+     * @param listener listener to register
+     */
+    public void addVenvInventoryListener(VenvInventoryListener listener) {
+        if (listener == null) {
+            return;
+        }
+        inventoryListeners.add(listener);
+    }
+
+    /**
+     * Unregisters a venv inventory listener.
+     *
+     * @param listener listener to unregister
+     */
+    public void removeVenvInventoryListener(VenvInventoryListener listener) {
+        if (listener == null) {
+            return;
+        }
+        inventoryListeners.remove(listener);
+    }
+
+    private void notifyVenvInventoryChanged() {
+        for (final var listener : inventoryListeners) {
+            try {
+                listener.onVenvInventoryChanged();
+            } catch (RuntimeException e) {
+                LOGGER.logWarning("Ignoring venv inventory listener exception", e);
+            }
+        }
+    }
 
     /** Returns unique venv directory paths from the given venv list. */
     public List<String> getVenvDirectoryPathsFromVenvs(List<Venv> venvs) {
@@ -96,6 +139,7 @@ public class VenvDetectionService {
         RuyiCli.createVenv(path, toolchainName, toolchainVersion, profile, emulatorName,
                 emulatorVersion);
         refreshWorkspaceProjects(null);
+        notifyVenvInventoryChanged();
         LOGGER.logInfo("Venv creation finished: path=" + path);
     }
 
@@ -175,6 +219,7 @@ public class VenvDetectionService {
                         deleteDirectoryRecursively(dir);
                     }
                     refreshWorkspaceProjects(monitor);
+                    notifyVenvInventoryChanged();
                 }
                 LOGGER.logInfo("Venv directories deletion finished");
                 future.complete(null);

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/ProjectVenvContextMenuViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/ProjectVenvContextMenuViewModel.java
@@ -1,0 +1,73 @@
+package org.ruyisdk.venv.viewmodel;
+
+import java.util.List;
+import org.ruyisdk.venv.model.Venv;
+import org.ruyisdk.venv.model.VenvConfigurationService;
+import org.ruyisdk.venv.model.VenvDetectionService;
+
+/**
+ * View model backing venv actions in project context menus.
+ */
+public class ProjectVenvContextMenuViewModel {
+
+    private final VenvDetectionService detectionService;
+    private final VenvConfigurationService configService;
+
+    /**
+     * Creates a new view model.
+     *
+     * @param detectionService venv detection service
+     * @param configService venv configuration service
+     */
+    public ProjectVenvContextMenuViewModel(VenvDetectionService detectionService,
+            VenvConfigurationService configService) {
+        this.detectionService = detectionService;
+        this.configService = configService;
+    }
+
+    /**
+     * Creates a wizard view model for the selected project.
+     *
+     * @param projectPath selected project path
+     * @return preconfigured wizard view model
+     */
+    public VenvWizardViewModel createWizardViewModel(String projectPath) {
+        final var wizardViewModel = new VenvWizardViewModel(detectionService);
+        wizardViewModel.setProjectRootPaths(List.of(projectPath));
+        wizardViewModel.setVenvLocation(projectPath);
+        wizardViewModel.setVenvLocationReadOnly(true);
+        return wizardViewModel;
+    }
+
+    /**
+     * Lists detected venvs under the selected project.
+     *
+     * @param projectPath selected project path
+     * @return detected venvs for the selected project
+     */
+    public List<Venv> listProjectVenvs(String projectPath) {
+        return detectionService.detectProjectVenvsAsync(List.of(projectPath)).join();
+    }
+
+    /**
+     * Applies the selected venv to its associated project.
+     *
+     * @param venv selected venv
+     * @return apply result
+     */
+    public VenvConfigurationService.ApplyResult applyVenv(Venv venv) {
+        return configService.applyToProjectAsync(venv).join();
+    }
+
+    /**
+     * Returns display text for the apply-venv selection list.
+     *
+     * @param venv venv row
+     * @return display text
+     */
+    public static String toApplyVenvDisplayText(Venv venv) {
+        return String.format("%s | profile=%s | toolchain=%s",
+                VenvListViewModel.getDisplayPath(venv), venv.getProfile(),
+                venv.getToolchainPrefix());
+    }
+}

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
@@ -68,6 +68,22 @@ public class VenvListViewModel implements IDialogStatusProvider {
             }
         });
     };
+    private final VenvDetectionService.VenvInventoryListener venvInventoryListener = () -> {
+        if (disposed) {
+            return;
+        }
+        observableVenvList.getRealm().asyncExec(() -> {
+            if (disposed) {
+                return;
+            }
+            if (fetching) {
+                setRefreshScheduled(true);
+                updateDerivedState();
+                return;
+            }
+            onRefreshVenvListAsync();
+        });
+    };
 
     /**
      * Creates a new view model.
@@ -82,6 +98,7 @@ public class VenvListViewModel implements IDialogStatusProvider {
 
         this.workspaceProjectsMonitor = WorkspaceProjectsMonitor.getInstance();
         this.workspaceProjectsMonitor.addListener(workspaceProjectsListener);
+        this.detectionService.addVenvInventoryListener(venvInventoryListener);
 
         selectedVenvs.addListChangeListener(e -> {
             updateActionStates();
@@ -170,8 +187,16 @@ public class VenvListViewModel implements IDialogStatusProvider {
         this.fetching = isFetching;
         if (this.fetching) {
             setRefreshScheduled(false);
+            updateDerivedState();
+            return;
         }
+
         updateDerivedState();
+
+        if (refreshScheduled) {
+            onRefreshVenvListAsync();
+            return;
+        }
     }
 
     private void setHasOpenProjects(boolean hasOpenProjects) {
@@ -289,11 +314,7 @@ public class VenvListViewModel implements IDialogStatusProvider {
         }
 
         setFetching(true);
-        detectionService.deleteVenvDirectoriesAsync(venvPaths).thenAccept(v -> {
-            observableVenvList.getRealm().asyncExec(() -> {
-                onRefreshVenvListAsync();
-            });
-        }).exceptionally(e -> {
+        detectionService.deleteVenvDirectoriesAsync(venvPaths).exceptionally(e -> {
             // unwrap CompletionException
             final var cause = e.getCause();
             lastStatus.getRealm().asyncExec(() -> {
@@ -401,6 +422,7 @@ public class VenvListViewModel implements IDialogStatusProvider {
      */
     public void dispose() {
         disposed = true;
+        detectionService.removeVenvInventoryListener(venvInventoryListener);
         workspaceProjectsMonitor.removeListener(workspaceProjectsListener);
     }
 

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
@@ -40,6 +40,7 @@ public class VenvWizardViewModel {
     private boolean emulatorEnabled = false;
     private SysrootOption sysrootOption = SysrootOption.DEFAULT_SYSROOT;
     private String venvLocation = "";
+    private boolean venvLocationReadOnly = false;
     private String venvName = "";
     private final IObservableList<String> projectRootPaths =
             new WritableList<>(new ArrayList<>(), String.class);
@@ -443,6 +444,18 @@ public class VenvWizardViewModel {
         final var old = this.venvLocation;
         this.venvLocation = location == null ? "" : location;
         pcs.firePropertyChange("venvLocation", old, this.venvLocation);
+    }
+
+    /** Returns whether the venv parent directory can be edited by users. */
+    public boolean isVenvLocationReadOnly() {
+        return venvLocationReadOnly;
+    }
+
+    /** Sets whether the venv parent directory can be edited by users. */
+    public void setVenvLocationReadOnly(boolean readOnly) {
+        final var old = this.venvLocationReadOnly;
+        this.venvLocationReadOnly = readOnly;
+        pcs.firePropertyChange("venvLocationReadOnly", old, this.venvLocationReadOnly);
     }
 
     /** Returns the list of project root paths. */

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvView.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvView.java
@@ -63,6 +63,16 @@ public class VenvView extends ViewPart {
         updateTableAreaState(false);
 
         // initial data load
+        refreshVenvListAsync();
+    }
+
+    /**
+     * Triggers an asynchronous refresh of the venv list in this view.
+     */
+    private void refreshVenvListAsync() {
+        if (venvListViewModel == null) {
+            return;
+        }
         venvListViewModel.onRefreshVenvListAsync();
     }
 
@@ -210,7 +220,7 @@ public class VenvView extends ViewPart {
         refreshButton.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent e) {
-                venvListViewModel.onRefreshVenvListAsync();
+                refreshVenvListAsync();
             }
         });
 
@@ -280,9 +290,7 @@ public class VenvView extends ViewPart {
                 wizardViewModel.setProjectRootPaths(venvListViewModel.getOpenProjectRootPaths());
                 final var dialog =
                         new WizardDialog(container.getShell(), new VenvWizard(wizardViewModel));
-                if (dialog.open() == WizardDialog.OK) {
-                    venvListViewModel.onRefreshVenvListAsync();
-                }
+                dialog.open();
             }
         });
 

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardLocationPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardLocationPage.java
@@ -102,7 +102,11 @@ public class WizardLocationPage extends WizardPage {
                 venvPathCombo.select(0);
             }
         } else {
-            venvPathCombo.setText(initialLocation);
+            if (initialLocation != null && !initialLocation.isBlank()) {
+                venvPathCombo.setText(initialLocation);
+            } else {
+                venvPathCombo.setText("");
+            }
         }
         venvPathCombo.setEnabled(!locationReadOnly);
         venvPathComboViewer = new ComboViewer(venvPathCombo);

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardLocationPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardLocationPage.java
@@ -88,13 +88,28 @@ public class WizardLocationPage extends WizardPage {
 
         final var locationLabel = new Label(container, SWT.NONE);
         locationLabel.setText("Venv Path:");
-        venvPathCombo = new Combo(container, SWT.BORDER | SWT.DROP_DOWN);
+        final var locationReadOnly = viewModel.isVenvLocationReadOnly();
+        final var initialLocation = viewModel.getVenvLocation();
+        var comboStyle = SWT.BORDER | SWT.DROP_DOWN;
+        if (locationReadOnly) {
+            comboStyle |= SWT.READ_ONLY;
+        }
+        venvPathCombo = new Combo(container, comboStyle);
         venvPathCombo.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-        venvPathCombo.setText("");
+        if (locationReadOnly) {
+            if (initialLocation != null && !initialLocation.isBlank()) {
+                venvPathCombo.add(initialLocation);
+                venvPathCombo.select(0);
+            }
+        } else {
+            venvPathCombo.setText(initialLocation);
+        }
+        venvPathCombo.setEnabled(!locationReadOnly);
         venvPathComboViewer = new ComboViewer(venvPathCombo);
 
         browseButton = new Button(container, SWT.PUSH);
         browseButton.setText("Browse...");
+        browseButton.setEnabled(!locationReadOnly);
     }
 
     private void registerEvents() {
@@ -117,8 +132,10 @@ public class WizardLocationPage extends WizardPage {
         dbc.bindValue(WidgetProperties.text().observe(summaryText), BeanProperties
                 .value(VenvWizardViewModel.class, "summaryText", String.class).observe(viewModel));
 
-        ViewerSupport.bind(venvPathComboViewer, viewModel.getProjectRootPaths(),
-                Properties.selfValue(String.class));
+        if (!viewModel.isVenvLocationReadOnly()) {
+            ViewerSupport.bind(venvPathComboViewer, viewModel.getProjectRootPaths(),
+                    Properties.selfValue(String.class));
+        }
 
         browseButton.addListener(SWT.Selection, e -> {
             final var directoryDialog = new DirectoryDialog(getShell());


### PR DESCRIPTION
Screenshot:

<img width="600" alt="Screenshot about the newly added components in and launched from the right-click menu" src="https://github.com/user-attachments/assets/3b89d5f3-7dbd-42e5-be0c-275ac2380533" />

## Summary by Sourcery

Add project context menu support for managing virtual environments and improve venv list synchronization with underlying changes.

New Features:
- Expose 'New Venv' and 'Apply venv' commands in the project right-click menu for creating and applying virtual environments tied to the selected project.
- Provide a project-specific context view model to preconfigure the venv creation wizard and apply selected venvs to projects.

Enhancements:
- Introduce a venv inventory listener mechanism so views can react to venv creation and deletion events and refresh automatically.
- Allow the venv creation wizard to use a read-only venv location when invoked from a project context menu, prefilled with the project path.
- Refine venv list view refresh behavior to schedule updates while data is being fetched rather than performing redundant refreshes.