### PR TITLE
feat(venv): selecting projects instead of browsing or typing in wizard

### DIFF
--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvListViewModel.java
@@ -462,7 +462,21 @@ public class VenvListViewModel implements IDialogStatusProvider {
             return "";
         }
 
-        return Path.of(venv.getProjectPath().trim()).getFileName().toString();
+        return toDisplayProjectNameFromPath(venv.getProjectPath());
+    }
+
+    /**
+     * Creates display text for a project path.
+     *
+     * @param projectPath the project root path
+     * @return display text for the project name column
+     */
+    private static String toDisplayProjectNameFromPath(String projectPath) {
+        if (projectPath == null || projectPath.isBlank()) {
+            return "";
+        }
+
+        return Path.of(projectPath.trim()).getFileName().toString();
     }
 
     /**

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardLocationPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardLocationPage.java
@@ -11,10 +11,8 @@ import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.DirectoryDialog;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.ruyisdk.venv.viewmodel.VenvWizardViewModel;
@@ -33,7 +31,6 @@ public class WizardLocationPage extends WizardPage {
     private Text venvNameText;
     private Combo venvPathCombo;
     private ComboViewer venvPathComboViewer;
-    private Button browseButton;
 
 
     WizardLocationPage(VenvWizardViewModel viewModel) {
@@ -53,7 +50,7 @@ public class WizardLocationPage extends WizardPage {
 
     private void createLayouts(Composite parent) {
         container = new Composite(parent, SWT.NONE);
-        container.setLayout(new GridLayout(3, false));
+        container.setLayout(new GridLayout(2, false));
 
         setControl(container);
     }
@@ -62,7 +59,7 @@ public class WizardLocationPage extends WizardPage {
         final var summaryLabel = new Label(container, SWT.NONE);
         {
             final var gridData = new GridData(GridData.FILL_HORIZONTAL);
-            gridData.horizontalSpan = 3;
+            gridData.horizontalSpan = 2;
             summaryLabel.setLayoutData(gridData);
         }
         summaryLabel.setText("Summary:");
@@ -70,7 +67,7 @@ public class WizardLocationPage extends WizardPage {
         summaryText = new Text(container, SWT.BORDER | SWT.MULTI | SWT.WRAP | SWT.V_SCROLL);
         {
             final var gridData = new GridData(GridData.FILL_HORIZONTAL | GridData.FILL_VERTICAL);
-            gridData.horizontalSpan = 3;
+            gridData.horizontalSpan = 2;
             summaryText.setLayoutData(gridData);
         }
         summaryText.setText(viewModel.getSummaryText());
@@ -80,20 +77,13 @@ public class WizardLocationPage extends WizardPage {
         nameLabel.setText("Venv Name:");
 
         venvNameText = new Text(container, SWT.BORDER);
-        {
-            var gridData = new GridData(GridData.FILL_HORIZONTAL);
-            gridData.horizontalSpan = 2;
-            venvNameText.setLayoutData(gridData);
-        }
+        venvNameText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
         final var locationLabel = new Label(container, SWT.NONE);
-        locationLabel.setText("Venv Path:");
+        locationLabel.setText("Project:");
         final var locationReadOnly = viewModel.isVenvLocationReadOnly();
         final var initialLocation = viewModel.getVenvLocation();
-        var comboStyle = SWT.BORDER | SWT.DROP_DOWN;
-        if (locationReadOnly) {
-            comboStyle |= SWT.READ_ONLY;
-        }
+        final var comboStyle = SWT.BORDER | SWT.DROP_DOWN | SWT.READ_ONLY;
         venvPathCombo = new Combo(container, comboStyle);
         venvPathCombo.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
         if (locationReadOnly) {
@@ -110,10 +100,6 @@ public class WizardLocationPage extends WizardPage {
         }
         venvPathCombo.setEnabled(!locationReadOnly);
         venvPathComboViewer = new ComboViewer(venvPathCombo);
-
-        browseButton = new Button(container, SWT.PUSH);
-        browseButton.setText("Browse...");
-        browseButton.setEnabled(!locationReadOnly);
     }
 
     private void registerEvents() {
@@ -140,15 +126,6 @@ public class WizardLocationPage extends WizardPage {
             ViewerSupport.bind(venvPathComboViewer, viewModel.getProjectRootPaths(),
                     Properties.selfValue(String.class));
         }
-
-        browseButton.addListener(SWT.Selection, e -> {
-            final var directoryDialog = new DirectoryDialog(getShell());
-            directoryDialog.setFilterPath(venvPathCombo.getText());
-            final var selectedPath = directoryDialog.open();
-            if (selectedPath != null) {
-                venvPathCombo.setText(selectedPath);
-            }
-        });
 
         final var completeObservable = new ComputedValue<Boolean>() {
             @Override


### PR DESCRIPTION
Screenshot:

<img width="600" alt="New layout of the location page in the wizard" src="https://github.com/user-attachments/assets/7a39220c-0202-4d8f-9307-be4918af0a9a" />

## Summary by Sourcery

Update the virtual environment wizard to select an existing project instead of manually browsing or typing a path, and add a reusable helper for deriving display project names from paths.

New Features:
- Allow selecting projects in the virtual environment wizard via a read-only combo box instead of entering arbitrary paths.

Enhancements:
- Simplify the wizard layout by removing the browse button and adjusting grid spans and column count.
- Extract a helper method for computing display project names from project paths for reuse.