### PR TITLE
feat(packages): do not sort the "variants" column

### DIFF
--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/view/DeviceSelectionDialog.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/view/DeviceSelectionDialog.java
@@ -152,10 +152,6 @@ public class DeviceSelectionDialog extends Dialog {
                     case 1:
                         result = d1.getEntityId().compareToIgnoreCase(d2.getEntityId());
                         break;
-                    case 2:
-                        result = Integer.compare(d1.getRelatedRefs().size(),
-                                d2.getRelatedRefs().size());
-                        break;
                     default:
                         result = d1.getLabel().compareToIgnoreCase(d2.getLabel());
                         break;
@@ -169,6 +165,10 @@ public class DeviceSelectionDialog extends Dialog {
         for (int i = 0; i < columns.length; i++) {
             final var colIdx = i;
             columns[i].addListener(SWT.Selection, e -> {
+                if (colIdx == 2) {
+                    // sorting "variants" column makes no sense, so ignore clicks
+                    return;
+                }
                 if (sortColumnIndex == colIdx) {
                     sortDirection = (sortDirection == SWT.UP) ? SWT.DOWN : SWT.UP;
                 } else {


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove comparison logic for the variants column and ignore sort events when its header is clicked in the device selection dialog.