### PR TITLE
release: bump to v0.1.4

### DIFF
--- a/features/org.ruyisdk.feature/feature.xml
+++ b/features/org.ruyisdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.ruyisdk.feature"
       label="RuyiSDK IDE Feature"
-      version="0.1.3.qualifier"
+      version="0.1.4.qualifier"
       provider-name="RuyiSDK">
 
    <description url="https://github.com/ruyisdk">

--- a/plugins/org.ruyisdk.core/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Core
 Bundle-SymbolicName: org.ruyisdk.core;singleton:=true
-Bundle-Version: 0.1.3.qualifier
+Bundle-Version: 0.1.4.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.core

--- a/plugins/org.ruyisdk.devices/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.devices/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Devices
 Bundle-SymbolicName: org.ruyisdk.devices;singleton:=true
-Bundle-Version: 0.1.3.qualifier
+Bundle-Version: 0.1.4.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.devices

--- a/plugins/org.ruyisdk.intro/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.intro/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Intro
 Bundle-SymbolicName: org.ruyisdk.intro;singleton:=true
-Bundle-Version: 0.1.3.qualifier
+Bundle-Version: 0.1.4.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.intro

--- a/plugins/org.ruyisdk.news/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.news/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - News
 Bundle-SymbolicName: org.ruyisdk.news;singleton:=true
-Bundle-Version: 0.1.3.qualifier
+Bundle-Version: 0.1.4.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.news

--- a/plugins/org.ruyisdk.packages/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.packages/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Packages
 Bundle-SymbolicName: org.ruyisdk.packages;singleton:=true
-Bundle-Version: 0.1.3.qualifier
+Bundle-Version: 0.1.4.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.packages

--- a/plugins/org.ruyisdk.projectcreator/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.projectcreator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Project Creator
 Bundle-SymbolicName: org.ruyisdk.projectcreator;singleton:=true
-Bundle-Version: 0.1.3.qualifier
+Bundle-Version: 0.1.4.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.projectcreator

--- a/plugins/org.ruyisdk.promotion/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.promotion/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Promotion
 Bundle-SymbolicName: org.ruyisdk.promotion;singleton:=true
-Bundle-Version: 0.1.3.qualifier
+Bundle-Version: 0.1.4.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.promotion

--- a/plugins/org.ruyisdk.ruyi/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.ruyi/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Ruyi
 Bundle-SymbolicName: org.ruyisdk.ruyi;singleton:=true
-Bundle-Version: 0.1.3.qualifier
+Bundle-Version: 0.1.4.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.ruyi

--- a/plugins/org.ruyisdk.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Ui
 Bundle-SymbolicName: org.ruyisdk.ui
-Bundle-Version: 0.1.3.qualifier
+Bundle-Version: 0.1.4.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.ui

--- a/plugins/org.ruyisdk.venv/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.venv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Venv
 Bundle-SymbolicName: org.ruyisdk.venv;singleton:=true
-Bundle-Version: 0.1.3.qualifier
+Bundle-Version: 0.1.4.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.venv

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>org.ruyisdk</groupId>
   <artifactId>ruyisdk-eclipse-plugins-parent</artifactId>
-  <version>0.1.3-SNAPSHOT</version>
+  <version>0.1.4-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>RuyiSDK Eclipse Plugins</name>

--- a/sites/repository/category.xml
+++ b/sites/repository/category.xml
@@ -4,9 +4,9 @@
       Update site for RuyiSDK Eclipse IDE plugins
    </description>
 
-   <feature url="features/org.ruyisdk.feature_0.1.3.qualifier.jar"
+   <feature url="features/org.ruyisdk.feature_0.1.4.qualifier.jar"
             id="org.ruyisdk.feature"
-            version="0.1.3.qualifier">
+            version="0.1.4.qualifier">
       <category name="ruyisdk"/>
    </feature>
 

--- a/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
+++ b/tests/org.ruyisdk.ruyi.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RuyiSDK Plugin - Tests
 Bundle-SymbolicName: org.ruyisdk.ruyi.tests
-Bundle-Version: 0.1.3.qualifier
+Bundle-Version: 0.1.4.qualifier
 Bundle-Vendor: ISCAS
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.ruyisdk.ruyi.tests


### PR DESCRIPTION
## Summary by Sourcery

Bump the RuyiSDK Eclipse plugins project to version 0.1.4 across feature, site, and bundle metadata.

Build:
- Update Maven parent POM version from 0.1.3-SNAPSHOT to 0.1.4-SNAPSHOT.

Chores:
- Align Eclipse feature, update site, and bundle manifest versions to 0.1.4.qualifier for the new release.