### PR TITLE
fix: ruyi run error handling for index update and version check

### DIFF
--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/Activator.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/Activator.java
@@ -1,14 +1,11 @@
 package org.ruyisdk.ruyi;
 
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.ruyisdk.core.util.PluginLogger;
-import org.ruyisdk.ruyi.core.RuyiCore;
 import org.ruyisdk.ruyi.core.workspace.WorkspaceProjectsMonitor;
 
 /**
@@ -18,7 +15,6 @@ public class Activator extends AbstractUIPlugin {
 
     public static final String PLUGIN_ID = "org.ruyisdk.ruyi";
     private static Activator plugin; // 共享实例
-    private RuyiCore ruyiCore; // 核心服务
 
     private static final PluginLogger LOGGER =
             new PluginLogger(Platform.getLog(FrameworkUtil.getBundle(Activator.class)), PLUGIN_ID);
@@ -31,17 +27,12 @@ public class Activator extends AbstractUIPlugin {
      */
     @Override
     public void start(BundleContext context) throws Exception {
+        LOGGER.logInfo("Ruyi plugin starting");
+
         super.start(context);
         plugin = this;
 
-        // 1. 加载默认首选项
-        // RuyiPreferenceInitializer.doInitializeDefaultPreferences();
-
-        // 2. 启动核心服务
-        ruyiCore = new RuyiCore();
-        ruyiCore.startBackgroundJobs();
-
-        LOGGER.logInfo("Ruyi activated successfully.");
+        LOGGER.logInfo("Ruyi plugin started");
     }
 
     /**
@@ -52,34 +43,18 @@ public class Activator extends AbstractUIPlugin {
      */
     @Override
     public void stop(BundleContext context) throws Exception {
-        try {
-            // 1. 停止核心服务
-            if (ruyiCore != null) {
-                ruyiCore.shutdown();
-            }
-            // 2. 清理资源
-            cleanupResources();
+        LOGGER.logInfo("Ruyi plugin stopping");
 
-            LOGGER.logInfo("Ruyi plugin deactivated");
-        } finally {
-            WorkspaceProjectsMonitor.getInstance().dispose();
-            plugin = null;
-            super.stop(context);
-        }
+        WorkspaceProjectsMonitor.getInstance().dispose();
+        plugin = null;
+        super.stop(context);
+
+        LOGGER.logInfo("Ruyi plugin stopped");
     }
 
     /** Returns the shared instance. */
     public static Activator getDefault() {
         return plugin;
-    }
-
-    /**
-     * Gets the Ruyi core service.
-     *
-     * @return the core service
-     */
-    public RuyiCore getRuyiCore() {
-        return ruyiCore;
     }
 
     /** Returns an Eclipse builtin logger. */
@@ -91,35 +66,4 @@ public class Activator extends AbstractUIPlugin {
     public IPreferenceStore getPreferenceStore() {
         return super.getPreferenceStore();
     }
-
-    private void cleanupResources() {
-        // 清理打开的文件句柄等资源
-    }
-
-    /**
-     * Creates an error status.
-     *
-     * @param message error message
-     * @param ex exception
-     * @return error status
-     */
-    public static IStatus createError(String message, Throwable ex) {
-        return new Status(IStatus.ERROR, PLUGIN_ID, message, ex);
-    }
-
-    // public static void initializeImageRegistry() {
-    // // 示例图片注册 (实际路径需要调整)
-    // Activator.getDefault().getImageRegistry().put("folder",
-    // imageDescriptorFromPlugin(Activator.PLUGIN_ID, "icons/folder.png"));
-    // Activator.getDefault().getImageRegistry().put("version",
-    // imageDescriptorFromPlugin(Activator.PLUGIN_ID, "icons/version.png"));
-    // // 其他图标...
-    // }
-    // @Override
-    // protected void initializeImageRegistry(ImageRegistry reg) {
-    // registerImage(reg, "ruyi_logo", "icons/ruyi_64.png");
-    // registerImage(reg, "install", "icons/wizard/install.png");
-    // registerImage(reg, "upgrade", "icons/wizard/upgrade.png");
-    // // 更多图标...
-    // }
 }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/RuyiCore.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/RuyiCore.java
@@ -1,5 +1,6 @@
 package org.ruyisdk.ruyi.core;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.swt.widgets.Display;
@@ -7,7 +8,6 @@ import org.ruyisdk.core.ruyi.model.CheckResult;
 import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.ruyi.Activator;
 import org.ruyisdk.ruyi.jobs.CheckRuyiJob;
-import org.ruyisdk.ruyi.services.RuyiProperties;
 import org.ruyisdk.ruyi.ui.RuyiInstallWizard;
 
 /**
@@ -15,64 +15,43 @@ import org.ruyisdk.ruyi.ui.RuyiInstallWizard;
  */
 public class RuyiCore {
     private static final PluginLogger LOGGER = Activator.getLogger();
+    private static final AtomicBoolean isChecking = new AtomicBoolean();
 
-    private volatile boolean isChecking;
+    private RuyiCore() {
+
+    }
 
     /**
      * Starts background environment check.
      */
-    public void startBackgroundCheck() {
-        boolean autocheck = autoCheckAtStartup();
-        LOGGER.logInfo("RuyiAutoCheck set :" + autocheck);
-        if (isChecking || !autocheck) {
-            return;
-        }
-
-        isChecking = true;
-        Job.create("Ruyi Environment Check", monitor -> {
-            try {
-                CheckResult result = new CheckRuyiJob().runCheck(monitor);
-                handleCheckResult(result);
-                return Status.OK_STATUS;
-            } catch (Exception e) {
-                return Status.error("Automatic environment check failed", e);
-            } finally {
-                isChecking = false;
-            }
-        }).schedule(2000); // 延迟2秒启动
-    }
-
-    /**
-     * Starts background jobs.
-     */
-    public void startBackgroundJobs() {
-        // 自定义后台任务
-    }
-
-    /**
-     * Shuts down core services.
-     */
-    public void shutdown() {
-        // 自定义清理工作
-        LOGGER.logInfo("RuyiCore services stopped successfully");
+    public static void startBackgroundCheck() {
+        check(2000); // 延迟2秒检测以避免影响IDE启动性能
     }
 
     /**
      * Runs manual check.
      */
-    public void runManualCheck() {
-        Job.create("Manual Ruyi Check", monitor -> {
-            try {
-                CheckResult result = new CheckRuyiJob().runCheck(monitor);
-                handleCheckResult(result);
-                return Status.OK_STATUS;
-            } catch (Exception e) {
-                return Status.error("Manual check failed", e);
-            }
-        }).schedule();
+    public static void runManualCheck() {
+        check(0);
     }
 
-    private void handleCheckResult(CheckResult result) {
+    private static void check(int delayMillis) {
+        if (isChecking.compareAndSet(false, true)) {
+            Job.create("Ruyi Environment Check", monitor -> {
+                try {
+                    CheckResult result = CheckRuyiJob.runCheck(monitor);
+                    handleCheckResult(result);
+                    return Status.OK_STATUS;
+                } catch (Exception e) {
+                    return Status.error("Ruyi environment check failed", e);
+                } finally {
+                    isChecking.set(false);
+                }
+            }).schedule(delayMillis);
+        }
+    }
+
+    private static void handleCheckResult(CheckResult result) {
         Display.getDefault().asyncExec(() -> {
             switch (result.getAction()) {
                 case INSTALL:
@@ -93,12 +72,5 @@ public class RuyiCore {
                     break;
             }
         });
-    }
-
-    private boolean autoCheckAtStartup() {
-        return RuyiProperties.isAutomaticDetectionEnabled();
-        // IPreferenceStore prefs = Activator.getDefault().getPreferenceStore();
-        // return prefs.getBoolean(RuyiPreferenceConstants.P_CHECK_ON_STARTUP) &&
-        // !prefs.getBoolean(RuyiPreferenceConstants.P_SKIP_VERSION_CHECK);
     }
 }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/RuyiStartup.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/RuyiStartup.java
@@ -1,15 +1,24 @@
 package org.ruyisdk.ruyi.core;
 
 import org.eclipse.ui.IStartup;
+import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.ruyi.Activator;
+import org.ruyisdk.ruyi.services.RuyiProperties;
 
 /**
  * Eclipse启动时自动执行的检测逻辑.
  */
 public class RuyiStartup implements IStartup {
+    private static final PluginLogger LOGGER = Activator.getLogger();
+
     @Override
     public void earlyStartup() {
-        // 延迟启动检测以避免影响IDE启动性能
-        Activator.getDefault().getRuyiCore().startBackgroundCheck();
+        {
+            final var autoCheck = RuyiProperties.isAutomaticDetectionEnabled();
+            LOGGER.logInfo("RuyiAutoCheck set: " + autoCheck);
+            if (autoCheck) {
+                RuyiCore.startBackgroundCheck();
+            }
+        }
     }
 }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/handlers/CheckInstallationHandler.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/handlers/CheckInstallationHandler.java
@@ -19,7 +19,7 @@ public class CheckInstallationHandler extends AbstractHandler {
         try {
             LOGGER.logInfo("Manual installation check triggered");
             RuyiCore.runManualCheck();
-            LOGGER.logInfo("Ruyi activated successfully");
+            LOGGER.logInfo("Manual installation check completed");
             return null;
         } catch (PluginException e) {
             LOGGER.logError("Failed to execute check installation command", e);

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/handlers/CheckInstallationHandler.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/handlers/CheckInstallationHandler.java
@@ -14,14 +14,11 @@ import org.ruyisdk.ruyi.core.RuyiCore;
 public class CheckInstallationHandler extends AbstractHandler {
     private static final PluginLogger LOGGER = Activator.getLogger();
 
-    private RuyiCore ruyiCore; // 核心服务
-
     @Override
     public Object execute(ExecutionEvent event) throws ExecutionException {
         try {
             LOGGER.logInfo("Manual installation check triggered");
-            ruyiCore = new RuyiCore();
-            ruyiCore.runManualCheck();
+            RuyiCore.runManualCheck();
             LOGGER.logInfo("Ruyi activated successfully");
             return null;
         } catch (PluginException e) {

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/handlers/UpdatePackageIndexHandler.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/handlers/UpdatePackageIndexHandler.java
@@ -3,40 +3,17 @@ package org.ruyisdk.ruyi.handlers;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.ui.handlers.HandlerUtil;
-import org.ruyisdk.core.exception.PluginException;
-import org.ruyisdk.core.util.PluginLogger;
-import org.ruyisdk.ruyi.Activator;
 import org.ruyisdk.ruyi.services.PackageIndexUpdater;
 
 /**
  * Handler for the "Update Package Index" command. Runs {@code ruyi update} with a progress dialog.
  */
 public class UpdatePackageIndexHandler extends AbstractHandler {
-    private static final PluginLogger LOGGER = Activator.getLogger();
-
     @Override
     public Object execute(ExecutionEvent event) throws ExecutionException {
         final var shell = HandlerUtil.getActiveShell(event);
-        try {
-            PackageIndexUpdater.updateWithProgress(shell);
-            LOGGER.logInfo("Package index updated successfully");
-            if (shell != null) {
-                MessageDialog.openInformation(shell, "Update Package Index",
-                        "Package index updated successfully.");
-            }
-            return null;
-        } catch (PluginException e) {
-            final var msg = "Failed to update the package index";
-            LOGGER.logError(msg, e);
-            if (shell != null) {
-                MessageDialog.openError(shell, msg, String.format("""
-                    Unable to update the Ruyi package index.
-
-                    %s""", e.getMessage()));
-            }
-            throw new ExecutionException(msg, e);
-        }
+        PackageIndexUpdater.updateWithProgress(shell);
+        return null;
     }
 }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/jobs/CheckRuyiJob.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/jobs/CheckRuyiJob.java
@@ -1,6 +1,7 @@
 package org.ruyisdk.ruyi.jobs;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.core.ruyi.model.CheckResult;
 import org.ruyisdk.core.ruyi.model.RuyiVersion;
 import org.ruyisdk.core.ruyi.model.SystemInfo;
@@ -56,9 +57,14 @@ public class CheckRuyiJob {
         if (installDir == null || installDir.isBlank()) {
             return null;
         }
-        final var version = RuyiCliVersionSupport.getInstalledVersion(installDir);
-        LOGGER.logInfo("Installed Ruyi version: " + version);
-        return version;
+        try {
+            final var version = RuyiCliVersionSupport.getInstalledVersion(installDir);
+            LOGGER.logInfo("Installed Ruyi version: " + version);
+            return version;
+        } catch (PluginException e) {
+            LOGGER.logError("Failed to get installed Ruyi version", e);
+            return null;
+        }
     }
 
     private RuyiVersion getLatestRelease() {

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/jobs/CheckRuyiJob.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/jobs/CheckRuyiJob.java
@@ -17,13 +17,15 @@ import org.ruyisdk.ruyi.util.RuyiFileUtils;
 public class CheckRuyiJob {
     private static final PluginLogger LOGGER = Activator.getLogger();
 
+    private CheckRuyiJob() {}
+
     /**
      * Runs Ruyi environment check.
      *
      * @param monitor progress monitor
      * @return check result
      */
-    public CheckResult runCheck(IProgressMonitor monitor) {
+    public static CheckResult runCheck(IProgressMonitor monitor) {
         monitor.beginTask("Checking Ruyi environment", 2);
 
         try {
@@ -52,7 +54,7 @@ public class CheckRuyiJob {
         }
     }
 
-    private RuyiVersion getInstalledVersion() {
+    private static RuyiVersion getInstalledVersion() {
         final var installDir = RuyiFileUtils.findInstallPathWithRuyi();
         if (installDir == null || installDir.isBlank()) {
             return null;
@@ -67,7 +69,7 @@ public class CheckRuyiJob {
         }
     }
 
-    private RuyiVersion getLatestRelease() {
+    private static RuyiVersion getLatestRelease() {
         final var archSuffix = SystemInfo.detectArchitecture().getSuffix();
         final var info = RuyiApi.getLatestRelease(archSuffix);
         final var latest = info.getVersion();

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/PackageIndexUpdater.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/PackageIndexUpdater.java
@@ -4,15 +4,19 @@ import java.lang.reflect.InvocationTargetException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.statushandlers.StatusManager;
+import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.ruyi.Activator;
 
 /**
  * UI helper that runs {@code ruyi update} inside a {@link ProgressMonitorDialog}.
  */
 public final class PackageIndexUpdater {
+    private static final PluginLogger LOGGER = Activator.getLogger();
+
     private PackageIndexUpdater() {}
 
     /**
@@ -21,7 +25,7 @@ public final class PackageIndexUpdater {
      *
      * @param shell parent shell for the progress dialog
      */
-    public static void updateWithProgress(Shell shell) {
+    public static boolean updateWithProgress(Shell shell) {
         try {
             new ProgressMonitorDialog(shell).run(true, false, monitor -> {
                 monitor.beginTask("Updating package index...", IProgressMonitor.UNKNOWN);
@@ -31,6 +35,14 @@ public final class PackageIndexUpdater {
                     monitor.done();
                 }
             });
+
+            LOGGER.logInfo("Package index updated successfully");
+            if (shell != null) {
+                MessageDialog.openInformation(shell, "Update Package Index",
+                        "Package index updated successfully.");
+            }
+
+            return true;
         } catch (InvocationTargetException e) {
             StatusManager.getManager().handle(
                     Status.error("Failed to update package index.", e.getCause()),
@@ -41,5 +53,7 @@ public final class PackageIndexUpdater {
                     new Status(IStatus.CANCEL, Activator.PLUGIN_ID, "Operation was cancelled.", e),
                     StatusManager.LOG | StatusManager.BLOCK);
         }
+
+        return false;
     }
 }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
@@ -8,7 +8,6 @@ import org.eclipse.core.databinding.conversion.Converter;
 import org.eclipse.core.databinding.observable.value.SelectObservableValue;
 import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.jface.databinding.viewers.typed.ViewerProperties;
-import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.TableViewer;
@@ -27,7 +26,6 @@ import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
-import org.ruyisdk.core.exception.PluginException;
 import org.ruyisdk.ruyi.services.PackageIndexUpdater;
 import org.ruyisdk.venv.model.Emulator;
 import org.ruyisdk.venv.model.Profile;
@@ -102,7 +100,8 @@ public class WizardConfigPage extends WizardPage {
             }
 
             final var hintLabel = new Label(refreshComposite, SWT.NONE);
-            hintLabel.setText("If lists are empty, update the package index first.");
+            hintLabel.setText(
+                    "If lists are empty or contain outdated information, update the package index first.");
             hintLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 
             final var refreshButton = new Button(refreshComposite, SWT.PUSH);
@@ -637,14 +636,7 @@ public class WizardConfigPage extends WizardPage {
     }
 
     private void performUpdateAndRefresh() {
-        try {
-            PackageIndexUpdater.updateWithProgress(getShell());
-        } catch (PluginException e) {
-            final var msg = "Failed to update the package index";
-            MessageDialog.openError(getShell(), msg, String.format("""
-                Unable to update the Ruyi package index.
-
-                %s""", e.getMessage()));
+        if (!PackageIndexUpdater.updateWithProgress(getShell())) {
             return;
         }
 


### PR DESCRIPTION
## Summary by Sourcery

Improve Ruyi environment checking and package index update error handling, and simplify plugin startup/shutdown lifecycle.

Bug Fixes:
- Prevent concurrent Ruyi environment checks from running simultaneously.
- Handle failures when reading the installed Ruyi version without crashing the environment check.
- Unify package index update execution so callers receive consistent success/failure signaling instead of throwing exceptions.

Enhancements:
- Make Ruyi environment checks and related utilities static and decouple them from the Activator lifecycle.
- Centralize package index update UI feedback (logging and dialogs) in a shared service.
- Simplify plugin activator startup and shutdown to only manage logging and workspace monitor disposal.