### PR TITLE
feat(ruyi): make env check result visible if user manually checks it

### DIFF
--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/RuyiCore.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/RuyiCore.java
@@ -37,9 +37,10 @@ public class RuyiCore {
     }
 
     private static void check(boolean isManual, int delayMillis) {
+        final var checkType = isManual ? "Manual" : "Background";
+
         if (isChecking.compareAndSet(false, true)) {
-            LOGGER.logInfo(String.format("Ruyi environment check starting (%s)",
-                    isManual ? "Manual" : "Background"));
+            LOGGER.logInfo(String.format("Ruyi environment check starting (%s)", checkType));
 
             final var checkJob = Job.create("Ruyi Environment Check", monitor -> {
                 try {
@@ -49,8 +50,8 @@ public class RuyiCore {
                 } catch (Exception e) {
                     return Status.error("Ruyi environment check failed", e);
                 } finally {
-                    LOGGER.logInfo(String.format("Ruyi environment check finished (%s)",
-                            isManual ? "Manual" : "Background"));
+                    LOGGER.logInfo(
+                            String.format("Ruyi environment check finished (%s)", checkType));
                     isChecking.set(false);
                 }
             });
@@ -61,13 +62,14 @@ public class RuyiCore {
 
             checkJob.schedule(delayMillis);
         } else {
-            LOGGER.logError("Ruyi environment check is already running", null);
+            LOGGER.logInfo("Ruyi environment check is already running");
         }
     }
 
     private static void handleCheckResult(CheckResult result, boolean isManual) {
         final var action = result.getAction();
-        LOGGER.logInfo(String.format("Ruyi environment check result action: %s", action));
+        LOGGER.logInfo(String.format("Ruyi environment check result: action: %s, message: %s",
+                action, result.getMessage()));
 
         Display.getDefault().asyncExec(() -> {
             switch (action) {

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/RuyiCore.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/RuyiCore.java
@@ -68,8 +68,9 @@ public class RuyiCore {
 
     private static void handleCheckResult(CheckResult result, boolean isManual) {
         final var action = result.getAction();
+        final var message = result.getMessage();
         LOGGER.logInfo(String.format("Ruyi environment check result: action: %s, message: %s",
-                action, result.getMessage()));
+                action, message));
 
         Display.getDefault().asyncExec(() -> {
             switch (action) {
@@ -85,7 +86,7 @@ public class RuyiCore {
                 case NOTHING:
                     if (isManual) {
                         MessageDialog.openInformation(Display.getDefault().getActiveShell(),
-                                "Ruyi Environment Check", "Ruyi environment is up to date.");
+                                "Ruyi Environment Check", message);
                     }
                     break;
 

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/RuyiCore.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/core/RuyiCore.java
@@ -3,6 +3,7 @@ package org.ruyisdk.ruyi.core;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.widgets.Display;
 import org.ruyisdk.core.ruyi.model.CheckResult;
 import org.ruyisdk.core.util.PluginLogger;
@@ -25,35 +26,51 @@ public class RuyiCore {
      * Starts background environment check.
      */
     public static void startBackgroundCheck() {
-        check(2000); // 延迟2秒检测以避免影响IDE启动性能
+        check(false, 2000); // 延迟2秒检测以避免影响IDE启动性能
     }
 
     /**
      * Runs manual check.
      */
     public static void runManualCheck() {
-        check(0);
+        check(true, 0);
     }
 
-    private static void check(int delayMillis) {
+    private static void check(boolean isManual, int delayMillis) {
         if (isChecking.compareAndSet(false, true)) {
-            Job.create("Ruyi Environment Check", monitor -> {
+            LOGGER.logInfo(String.format("Ruyi environment check starting (%s)",
+                    isManual ? "Manual" : "Background"));
+
+            final var checkJob = Job.create("Ruyi Environment Check", monitor -> {
                 try {
-                    CheckResult result = CheckRuyiJob.runCheck(monitor);
-                    handleCheckResult(result);
+                    final var result = CheckRuyiJob.runCheck(monitor);
+                    handleCheckResult(result, isManual);
                     return Status.OK_STATUS;
                 } catch (Exception e) {
                     return Status.error("Ruyi environment check failed", e);
                 } finally {
+                    LOGGER.logInfo(String.format("Ruyi environment check finished (%s)",
+                            isManual ? "Manual" : "Background"));
                     isChecking.set(false);
                 }
-            }).schedule(delayMillis);
+            });
+
+            if (isManual) {
+                checkJob.setUser(true);
+            }
+
+            checkJob.schedule(delayMillis);
+        } else {
+            LOGGER.logError("Ruyi environment check is already running", null);
         }
     }
 
-    private static void handleCheckResult(CheckResult result) {
+    private static void handleCheckResult(CheckResult result, boolean isManual) {
+        final var action = result.getAction();
+        LOGGER.logInfo(String.format("Ruyi environment check result action: %s", action));
+
         Display.getDefault().asyncExec(() -> {
-            switch (result.getAction()) {
+            switch (action) {
                 case INSTALL:
                     RuyiInstallWizard.openForInstall(result.getLatestVersion());
                     break;
@@ -64,7 +81,10 @@ public class RuyiCore {
                     break;
 
                 case NOTHING:
-                    LOGGER.logInfo(result.getMessage());
+                    if (isManual) {
+                        MessageDialog.openInformation(Display.getDefault().getActiveShell(),
+                                "Ruyi Environment Check", "Ruyi environment is up to date.");
+                    }
                     break;
 
                 default:


### PR DESCRIPTION
## Summary by Sourcery

Make Ruyi environment checks distinguish between manual and background runs and provide user-visible feedback for manual checks.

Enhancements:
- Log start, finish, and result actions for Ruyi environment checks and prevent concurrent checks from running.
- Mark manual environment checks as user-initiated jobs so their progress is visible in the IDE UI.
- Show an informational dialog when a manually triggered environment check finds that the environment is already up to date.