### PR TITLE
feat(venv): support specifying sysroot from another package

### DIFF
--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
@@ -745,11 +745,14 @@ public class RuyiCli {
      * @param toolchainName toolchain package name (required)
      * @param toolchainVersion toolchain version (required)
      * @param profile profile name (required)
+     * @param withSysroot whether to use the included sysroot (may be null)
+     * @param sysrootFrom optional toolchain for {@code --sysroot-from} (may be null)
      * @param emulatorName optional emulator package name (may be null)
      * @param emulatorVersion optional emulator version (may be null)
      */
     public static void createVenv(String path, String toolchainName, String toolchainVersion,
-            String profile, String emulatorName, String emulatorVersion) {
+            String profile, Boolean withSysroot, String sysrootFrom, String emulatorName,
+            String emulatorVersion) {
         if (path == null || path.isBlank()) {
             throw RuyiCliException.invalidArgument("Empty venv path");
         }
@@ -769,7 +772,8 @@ public class RuyiCli {
         }
         final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult())
                 .porcelain(true).venv().profile(profile).dest(path).toolchain(toolchainAtom)
-                .emulator(emulatorAtom).end().build();
+                .sysrootFrom(sysrootFrom).withSysroot(withSysroot).emulator(emulatorAtom).end()
+                .build();
         request.execute();
     }
 

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliRequest.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliRequest.java
@@ -605,7 +605,7 @@ public class RuyiCliRequest {
         private String name;
         private String toolchain;
         private String emulator;
-        private boolean withSysroot = true;
+        private Boolean withSysroot = null;
         private String sysrootFrom;
         private String extraCommandsFrom;
 
@@ -645,7 +645,7 @@ public class RuyiCliRequest {
         }
 
         /** Enables or disables inclusion of a sysroot. */
-        public VenvCommandBuilder withSysroot(boolean withSysroot) {
+        public VenvCommandBuilder withSysroot(Boolean withSysroot) {
             this.withSysroot = withSysroot;
             return this;
         }
@@ -677,10 +677,12 @@ public class RuyiCliRequest {
             if (emulator != null && !emulator.isBlank()) {
                 parent.args("--emulator", emulator);
             }
-            if (withSysroot) {
-                parent.args("--with-sysroot");
-            } else {
-                parent.args("--without-sysroot");
+            if (withSysroot != null) {
+                if (withSysroot.booleanValue()) {
+                    parent.args("--with-sysroot");
+                } else {
+                    parent.args("--without-sysroot");
+                }
             }
             if (sysrootFrom != null && !sysrootFrom.isBlank()) {
                 parent.args("--sysroot-from", sysrootFrom);

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvDetectionService.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvDetectionService.java
@@ -132,12 +132,14 @@ public class VenvDetectionService {
 
     /** Creates a new venv via the Ruyi CLI. */
     public void createVenv(String path, String toolchainName, String toolchainVersion,
-            String profile, String emulatorName, String emulatorVersion) {
+            String profile, Boolean withSysroot, String sysrootFrom, String emulatorName,
+            String emulatorVersion) {
         LOGGER.logInfo(String.format(
-                "Creating venv: path=%s, profile=%s, toolchain=%s:%s, emulator=%s:%s", path,
-                profile, toolchainName, toolchainVersion, emulatorName, emulatorVersion));
-        RuyiCli.createVenv(path, toolchainName, toolchainVersion, profile, emulatorName,
-                emulatorVersion);
+                "Creating venv: path=%s, profile=%s, toolchain=%s:%s, withSysroot=%s, sysrootFrom=%s, emulator=%s:%s",
+                path, profile, toolchainName, toolchainVersion, withSysroot, sysrootFrom,
+                emulatorName, emulatorVersion));
+        RuyiCli.createVenv(path, toolchainName, toolchainVersion, profile, withSysroot, sysrootFrom,
+                emulatorName, emulatorVersion);
         refreshWorkspaceProjects(null);
         notifyVenvInventoryChanged();
         LOGGER.logInfo("Venv creation finished: path=" + path);

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
@@ -32,13 +32,18 @@ public class VenvWizardViewModel {
     private final List<Toolchain> allToolchains = new ArrayList<>();
     private int selectedToolchainIndex = -1;
     private int selectedToolchainVersionIndex = -1;
+
     private final List<Emulator> emulators = new ArrayList<>();
     private final List<Emulator> allEmulators = new ArrayList<>();
     private int selectedEmulatorIndex = -1;
     private int selectedEmulatorVersionIndex = -1;
-
     private boolean emulatorEnabled = false;
+
     private SysrootOption sysrootOption = SysrootOption.DEFAULT_SYSROOT;
+    private int selectedSysrootPackageIndex = -1;
+    private int selectedSysrootPackageVersionIndex = -1;
+    private String sysrootPackageDisplayText = "";
+
     private String venvLocation = "";
     private boolean venvLocationReadOnly = false;
     private String venvName = "";
@@ -47,7 +52,12 @@ public class VenvWizardViewModel {
 
     /** Available sysroot selection strategies. */
     public enum SysrootOption {
-        NONE_SYSROOT, DEFAULT_SYSROOT, FOREIGN_TOOLCHAIN
+        /** Do not include a sysroot. */
+        NONE_SYSROOT,
+        /** Use the sysroot included with the selected toolchain. */
+        DEFAULT_SYSROOT,
+        /** Use the sysroot from another installed package. */
+        FOREIGN_TOOLCHAIN
     }
 
     /** Creates a new view model instance. */
@@ -88,6 +98,12 @@ public class VenvWizardViewModel {
             return false;
         }
 
+        if (sysrootOption == SysrootOption.FOREIGN_TOOLCHAIN) {
+            if (!isSysrootPackageSelected()) {
+                return false;
+            }
+        }
+
         if (!emulatorEnabled) {
             return true;
         }
@@ -106,6 +122,16 @@ public class VenvWizardViewModel {
         }
 
         return true;
+    }
+
+    private boolean isSysrootPackageSelected() {
+        if (!(selectedSysrootPackageIndex >= 0
+                && selectedSysrootPackageIndex < toolchains.size())) {
+            return false;
+        }
+        final var versions = toolchains.get(selectedSysrootPackageIndex).getVersions();
+        return versions != null && selectedSysrootPackageVersionIndex >= 0
+                && selectedSysrootPackageVersionIndex < versions.size();
     }
 
     private String buildSummaryText() {
@@ -147,7 +173,14 @@ public class VenvWizardViewModel {
         }
         sb.append('\n');
 
-        sb.append("Sysroot: ").append(sysrootOption.toString());
+        sb.append("Sysroot: ");
+        if (sysrootOption == SysrootOption.FOREIGN_TOOLCHAIN && isSysrootPackageSelected()) {
+            final var pkg = toolchains.get(selectedSysrootPackageIndex);
+            final var ver = pkg.getVersions().get(selectedSysrootPackageVersionIndex);
+            sb.append(String.format("copy from %s(%s)", pkg.getName(), ver));
+        } else {
+            sb.append(sysrootOption.toString());
+        }
         return sb.toString();
     }
 
@@ -212,6 +245,7 @@ public class VenvWizardViewModel {
 
         // Reset selections since the lists changed
         setSelectedToolchainIndex(-1);
+        setSelectedSysrootPackageIndex(-1);
         setSelectedEmulatorIndex(-1);
     }
 
@@ -268,10 +302,30 @@ public class VenvWizardViewModel {
         installEmulator(name, version);
     }
 
+    private void installPackageForSysroot(String name, String version) {
+        service.installPackage(name, version);
+    }
+
+    /** Installs the currently-selected sysroot package when enabled. */
+    public void installPackageForSysroot() {
+        if (sysrootOption != SysrootOption.FOREIGN_TOOLCHAIN) {
+            throw RuyiCliException.invalidArgument("No need to install package for sysroot");
+        }
+        if (selectedSysrootPackageIndex < 0 || selectedSysrootPackageIndex >= toolchains.size()
+                || selectedSysrootPackageVersionIndex < 0) {
+            throw RuyiCliException.invalidArgument("Sysroot enabled but not selected");
+        }
+        final var name = toolchains.get(selectedSysrootPackageIndex).getName();
+        final var version = toolchains.get(selectedSysrootPackageIndex).getVersions()
+                .get(selectedSysrootPackageVersionIndex);
+        installPackageForSysroot(name, version);
+    }
+
     private void createVenv(String path, String toolchainName, String toolchainVersion,
-            String profile, String emulatorName, String emulatorVersion) {
-        service.createVenv(path, toolchainName, toolchainVersion, profile, emulatorName,
-                emulatorVersion);
+            String profile, Boolean withSysroot, String sysrootFrom, String emulatorName,
+            String emulatorVersion) {
+        service.createVenv(path, toolchainName, toolchainVersion, profile, withSysroot, sysrootFrom,
+                emulatorName, emulatorVersion);
     }
 
     /** Creates a virtual environment using the current wizard selections. */
@@ -298,6 +352,22 @@ public class VenvWizardViewModel {
             profile = profiles.get(selectedProfileIndex).getName();
         }
 
+        Boolean withSysroot = null;
+        String sysrootFromAtom = null;
+        if (this.sysrootOption == SysrootOption.DEFAULT_SYSROOT) {
+            withSysroot = true;
+        } else if (this.sysrootOption == SysrootOption.NONE_SYSROOT) {
+            withSysroot = false;
+        } else if (this.sysrootOption == SysrootOption.FOREIGN_TOOLCHAIN) {
+            if (!isSysrootPackageSelected()) {
+                throw RuyiCliException
+                        .invalidArgument("Sysroot from package selected but no package chosen");
+            }
+            final var pkg = toolchains.get(selectedSysrootPackageIndex);
+            final var ver = pkg.getVersions().get(selectedSysrootPackageVersionIndex);
+            sysrootFromAtom = String.format("%s(%s)", pkg.getName(), ver);
+        }
+
         String emulatorName = null;
         String emulatorVersion = null;
         if (emulatorEnabled) {
@@ -312,7 +382,8 @@ public class VenvWizardViewModel {
 
         final var target = new File(parent, name);
         final var path = target.getPath();
-        createVenv(path, toolchainName, toolchainVersion, profile, emulatorName, emulatorVersion);
+        createVenv(path, toolchainName, toolchainVersion, profile, withSysroot, sysrootFromAtom,
+                emulatorName, emulatorVersion);
     }
 
     /** Returns available profiles. */
@@ -431,7 +502,61 @@ public class VenvWizardViewModel {
         final var old = this.sysrootOption;
         this.sysrootOption = option;
         pcs.firePropertyChange("sysrootOption", old, this.sysrootOption);
+        if (option != SysrootOption.FOREIGN_TOOLCHAIN) {
+            setSelectedSysrootPackageIndex(-1);
+            setSelectedSysrootPackageVersionIndex(-1);
+        }
         recomputeDerivedState();
+    }
+
+    /** Returns the selected sysroot package index within the toolchains list. */
+    public int getSelectedSysrootPackageIndex() {
+        return selectedSysrootPackageIndex;
+    }
+
+    /** Sets the selected sysroot package index within the toolchains list. */
+    public void setSelectedSysrootPackageIndex(int index) {
+        final var old = this.selectedSysrootPackageIndex;
+        this.selectedSysrootPackageIndex = index;
+        pcs.firePropertyChange("selectedSysrootPackageIndex", old,
+                this.selectedSysrootPackageIndex);
+        if (old != index) {
+            setSelectedSysrootPackageVersionIndex(-1);
+        }
+        updateSysrootPackageDisplayText();
+        recomputeDerivedState();
+    }
+
+    /** Returns the selected sysroot package version index. */
+    public int getSelectedSysrootPackageVersionIndex() {
+        return selectedSysrootPackageVersionIndex;
+    }
+
+    /** Sets the selected sysroot package version index. */
+    public void setSelectedSysrootPackageVersionIndex(int index) {
+        final var old = this.selectedSysrootPackageVersionIndex;
+        this.selectedSysrootPackageVersionIndex = index;
+        pcs.firePropertyChange("selectedSysrootPackageVersionIndex", old,
+                this.selectedSysrootPackageVersionIndex);
+        updateSysrootPackageDisplayText();
+        recomputeDerivedState();
+    }
+
+    /** Returns the display text describing the selected sysroot package. */
+    public String getSysrootPackageDisplayText() {
+        return sysrootPackageDisplayText;
+    }
+
+    private void updateSysrootPackageDisplayText() {
+        final var old = this.sysrootPackageDisplayText;
+        if (isSysrootPackageSelected()) {
+            final var pkg = toolchains.get(selectedSysrootPackageIndex);
+            final var ver = pkg.getVersions().get(selectedSysrootPackageVersionIndex);
+            this.sysrootPackageDisplayText = String.format("%s(%s)", pkg.getName(), ver);
+        } else {
+            this.sysrootPackageDisplayText = "";
+        }
+        pcs.firePropertyChange("sysrootPackageDisplayText", old, this.sysrootPackageDisplayText);
     }
 
     /** Returns the configured venv parent directory. */

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/SysrootPackageSelectionDialog.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/SysrootPackageSelectionDialog.java
@@ -27,8 +27,7 @@ import org.ruyisdk.venv.viewmodel.VenvWizardViewModel;
  *
  * <p>
  * Displays a name list and a version list side-by-side, identical to the toolchain selection tables
- * on the wizard configuration page. The OK button is only enabled once both a package and a version
- * are selected.
+ * on the wizard configuration page.
  */
 class SysrootPackageSelectionDialog extends Dialog {
 

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/SysrootPackageSelectionDialog.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/SysrootPackageSelectionDialog.java
@@ -1,0 +1,232 @@
+package org.ruyisdk.venv.views;
+
+import java.util.List;
+import org.eclipse.core.databinding.DataBindingContext;
+import org.eclipse.core.databinding.UpdateValueStrategy;
+import org.eclipse.core.databinding.beans.typed.BeanProperties;
+import org.eclipse.core.databinding.conversion.Converter;
+import org.eclipse.jface.databinding.viewers.typed.ViewerProperties;
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+import org.ruyisdk.venv.model.Toolchain;
+import org.ruyisdk.venv.viewmodel.VenvWizardViewModel;
+
+/**
+ * Dialog for selecting a toolchain package and version to use as a sysroot source.
+ *
+ * <p>
+ * Displays a name list and a version list side-by-side, identical to the toolchain selection tables
+ * on the wizard configuration page. The OK button is only enabled once both a package and a version
+ * are selected.
+ */
+class SysrootPackageSelectionDialog extends Dialog {
+
+    private final VenvWizardViewModel viewModel;
+    private DataBindingContext dbc;
+
+    private TableViewer packageNamesViewer;
+    private TableViewer packageVersionsViewer;
+
+    SysrootPackageSelectionDialog(Shell parentShell, VenvWizardViewModel viewModel) {
+        super(parentShell);
+        this.viewModel = viewModel;
+    }
+
+    @Override
+    protected boolean isResizable() {
+        return true;
+    }
+
+    @Override
+    protected void configureShell(Shell shell) {
+        super.configureShell(shell);
+        shell.setText("Select the Source Package for Sysroot");
+    }
+
+    @Override
+    protected Point getInitialSize() {
+        return new Point(600, 400);
+    }
+
+    @Override
+    protected Control createDialogArea(Composite parent) {
+        final var container = (Composite) super.createDialogArea(parent);
+        final var gridLayout = new GridLayout(2, false);
+        container.setLayout(gridLayout);
+
+        final var nameLabel = new Label(container, SWT.NONE);
+        nameLabel.setText("Package");
+        final var versionLabel = new Label(container, SWT.NONE);
+        versionLabel.setText("Version");
+
+        packageNamesViewer = new TableViewer(container, SWT.BORDER | SWT.FULL_SELECTION);
+        {
+            final var table = packageNamesViewer.getTable();
+            {
+                final var gridData = new GridData(SWT.FILL, SWT.FILL, true, true);
+                gridData.widthHint = 280;
+                table.setLayoutData(gridData);
+            }
+            table.setHeaderVisible(false);
+            table.setLinesVisible(true);
+        }
+        packageNamesViewer.setContentProvider(ArrayContentProvider.getInstance());
+        packageNamesViewer.setLabelProvider(new ColumnLabelProvider() {
+            @Override
+            public String getText(Object element) {
+                return ((Toolchain) element).getName();
+            }
+        });
+        packageNamesViewer.setInput(viewModel.getToolchains());
+
+        packageVersionsViewer = new TableViewer(container, SWT.BORDER | SWT.FULL_SELECTION);
+        {
+            final var table = packageVersionsViewer.getTable();
+            {
+                final var gridData = new GridData(SWT.FILL, SWT.FILL, true, true);
+                gridData.widthHint = 280;
+                table.setLayoutData(gridData);
+            }
+            table.setHeaderVisible(false);
+            table.setLinesVisible(true);
+        }
+        packageVersionsViewer.setContentProvider(ArrayContentProvider.getInstance());
+        packageVersionsViewer.setLabelProvider(new ColumnLabelProvider());
+
+        dbc = new DataBindingContext();
+
+        container.addDisposeListener(e -> {
+            if (dbc != null) {
+                dbc.dispose();
+                dbc = null;
+            }
+        });
+
+        // package names
+        {
+            final var packageSelection =
+                    ViewerProperties.singleSelection(Toolchain.class).observe(packageNamesViewer);
+            final var packageIndexObservable = BeanProperties
+                    .value(VenvWizardViewModel.class, "selectedSysrootPackageIndex", Integer.class)
+                    .observe(viewModel);
+            final var packageToIndex = new UpdateValueStrategy<Toolchain, Integer>();
+            packageToIndex.setConverter(
+                    new Converter<Toolchain, Integer>(Toolchain.class, Integer.class) {
+                        @Override
+                        public Integer convert(Toolchain fromObject) {
+                            if (fromObject == null) {
+                                return Integer.valueOf(-1);
+                            }
+                            return Integer.valueOf(viewModel.getToolchains().indexOf(fromObject));
+                        }
+                    });
+            final var indexToToolchain = new UpdateValueStrategy<Integer, Toolchain>();
+            indexToToolchain.setConverter(
+                    new Converter<Integer, Toolchain>(Integer.class, Toolchain.class) {
+                        @Override
+                        public Toolchain convert(Integer fromObject) {
+                            final var idx = ((Integer) fromObject).intValue();
+                            if (idx >= 0 && idx < viewModel.getToolchains().size()) {
+                                return viewModel.getToolchains().get(idx);
+                            }
+                            return null;
+                        }
+                    });
+            dbc.bindValue(packageSelection, packageIndexObservable, packageToIndex,
+                    indexToToolchain);
+
+            packageIndexObservable.addValueChangeListener(e -> {
+                updatePackagesVersions();
+            });
+        }
+
+        // package versions
+        {
+            final var packageVersionSelection =
+                    ViewerProperties.singleSelection(String.class).observe(packageVersionsViewer);
+            final var packageVersionIndexObservable =
+                    BeanProperties.value(VenvWizardViewModel.class,
+                            "selectedSysrootPackageVersionIndex", Integer.class).observe(viewModel);
+            final var packageVersionToIndex = new UpdateValueStrategy<String, Integer>();
+            packageVersionToIndex
+                    .setConverter(new Converter<String, Integer>(String.class, Integer.class) {
+                        @Override
+                        public Integer convert(String fromObject) {
+                            final var idx = viewModel.getSelectedSysrootPackageIndex();
+                            if (idx < 0 || idx >= viewModel.getToolchains().size()) {
+                                return Integer.valueOf(-1);
+                            }
+                            final var vers = viewModel.getToolchains().get(idx).getVersions();
+                            return Integer.valueOf(vers == null ? -1 : vers.indexOf(fromObject));
+                        }
+                    });
+            final var indexToToolchainVersion = new UpdateValueStrategy<Integer, String>();
+            indexToToolchainVersion
+                    .setConverter(new Converter<Integer, String>(Integer.class, String.class) {
+                        @Override
+                        public String convert(Integer fromObject) {
+                            final var idx = viewModel.getSelectedSysrootPackageIndex();
+                            if (idx < 0 || idx >= viewModel.getToolchains().size()) {
+                                return null;
+                            }
+                            final var vers = viewModel.getToolchains().get(idx).getVersions();
+                            final var verIdx = ((Integer) fromObject).intValue();
+                            return vers != null && verIdx >= 0 && verIdx < vers.size()
+                                    ? vers.get(verIdx)
+                                    : null;
+                        }
+                    });
+            dbc.bindValue(packageVersionSelection, packageVersionIndexObservable,
+                    packageVersionToIndex, indexToToolchainVersion);
+        }
+
+        // initial states
+        updatePackagesVersions();
+
+        return container;
+    }
+
+    private void updatePackagesVersions() {
+        if (packageVersionsViewer == null || packageVersionsViewer.getControl() == null
+                || packageVersionsViewer.getControl().isDisposed()) {
+            return;
+        }
+        final var selectedPackageIndex = viewModel.getSelectedSysrootPackageIndex();
+        if (selectedPackageIndex >= 0 && selectedPackageIndex < viewModel.getToolchains().size()) {
+            final var toolchain = viewModel.getToolchains().get(selectedPackageIndex);
+            packageVersionsViewer.setInput(toolchain.getVersions());
+
+            final var selectedVersionIndex = viewModel.getSelectedSysrootPackageVersionIndex();
+            if (selectedVersionIndex >= 0 && toolchain.getVersions() != null
+                    && selectedVersionIndex < toolchain.getVersions().size()) {
+                packageVersionsViewer.getTable().select(selectedVersionIndex);
+                packageVersionsViewer.getTable().showSelection();
+            }
+        } else {
+            packageVersionsViewer.setInput(List.of());
+        }
+    }
+
+    @Override
+    protected void createButtonsForButtonBar(Composite parent) {
+        createButton(parent, IDialogConstants.CLOSE_ID, IDialogConstants.CLOSE_LABEL, true);
+    }
+
+    @Override
+    protected void buttonPressed(int buttonId) {
+        if (buttonId == IDialogConstants.CLOSE_ID) {
+            okPressed();
+        }
+    }
+}

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
@@ -52,6 +52,12 @@ public class VenvWizard extends Wizard {
                     monitor.subTask("install toolchain");
                     viewModel.installToolchain();
 
+                    if (viewModel
+                            .getSysrootOption() == VenvWizardViewModel.SysrootOption.FOREIGN_TOOLCHAIN) {
+                        monitor.subTask("install package for sysroot");
+                        viewModel.installPackageForSysroot();
+                    }
+
                     if (viewModel.isEmulatorEnabled()) {
                         monitor.subTask("install emulator");
                         viewModel.installEmulator();

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.ruyisdk.ruyi.services.PackageIndexUpdater;
@@ -58,6 +59,7 @@ public class WizardConfigPage extends WizardPage {
     private Button sysrootDefaultRadio;
     private Button sysrootNoneRadio;
     private Button sysrootForeignRadio;
+    private Link sysrootPackageLink;
 
     WizardConfigPage(VenvWizardViewModel viewModel) {
         super("configurationPage");
@@ -167,7 +169,8 @@ public class WizardConfigPage extends WizardPage {
         sysrootGroup.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
         sysrootGroup.setText("");
         {
-            final var gridLayout = new GridLayout(3, false);
+            // columns: radio buttons, a package info link.
+            final var gridLayout = new GridLayout(2, false);
             gridLayout.marginWidth = 0;
             sysrootGroup.setLayout(gridLayout);
         }
@@ -368,12 +371,35 @@ public class WizardConfigPage extends WizardPage {
         // sysroot
         {
             sysrootDefaultRadio = new Button(sysrootGroup, SWT.RADIO);
-            sysrootDefaultRadio.setText("With sysroot");
+            sysrootDefaultRadio.setText("Using included sysroot");
+            {
+                final var gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+                gridData.horizontalSpan = 2;
+                sysrootDefaultRadio.setLayoutData(gridData);
+            }
+
             sysrootNoneRadio = new Button(sysrootGroup, SWT.RADIO);
-            sysrootNoneRadio.setText("Without sysroot");
+            sysrootNoneRadio.setText("None sysroot (only for advanced users)");
+            {
+                final var gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+                gridData.horizontalSpan = 2;
+                sysrootNoneRadio.setLayoutData(gridData);
+            }
+
             sysrootForeignRadio = new Button(sysrootGroup, SWT.RADIO);
-            sysrootForeignRadio.setText("Use sysroot from specified package");
-            sysrootForeignRadio.setEnabled(false); // TODO: implement this option later
+            sysrootForeignRadio.setText("Use sysroot from specified package:");
+            sysrootForeignRadio.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
+
+            sysrootPackageLink = new Link(sysrootGroup, SWT.NONE);
+            sysrootPackageLink.setText("<a>(select package)</a>");
+            sysrootPackageLink.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false));
+            sysrootPackageLink.setEnabled(false);
+            sysrootPackageLink.addSelectionListener(new SelectionAdapter() {
+                @Override
+                public void widgetSelected(SelectionEvent e) {
+                    openSysrootPackageDialog();
+                }
+            });
         }
     }
 
@@ -611,15 +637,37 @@ public class WizardConfigPage extends WizardPage {
         {
             final var sysrootSelection =
                     new SelectObservableValue<VenvWizardViewModel.SysrootOption>();
-            sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.DEFAULT_SYSROOT,
-                    WidgetProperties.buttonSelection().observe(sysrootDefaultRadio));
-            sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.NONE_SYSROOT,
-                    WidgetProperties.buttonSelection().observe(sysrootNoneRadio));
-            sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.FOREIGN_TOOLCHAIN,
-                    WidgetProperties.buttonSelection().observe(sysrootForeignRadio));
+            {
+                sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.DEFAULT_SYSROOT,
+                        WidgetProperties.buttonSelection().observe(sysrootDefaultRadio));
+                sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.NONE_SYSROOT,
+                        WidgetProperties.buttonSelection().observe(sysrootNoneRadio));
+                sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.FOREIGN_TOOLCHAIN,
+                        WidgetProperties.buttonSelection().observe(sysrootForeignRadio));
+            }
+            final var sysrootOptionObservable = BeanProperties.value(VenvWizardViewModel.class,
+                    "sysrootOption", VenvWizardViewModel.SysrootOption.class).observe(viewModel);
+            final var displayTextObservable = BeanProperties
+                    .value(VenvWizardViewModel.class, "sysrootPackageDisplayText", String.class)
+                    .observe(viewModel);
 
-            dbc.bindValue(sysrootSelection, BeanProperties.value(VenvWizardViewModel.class,
-                    "sysrootOption", VenvWizardViewModel.SysrootOption.class).observe(viewModel));
+            dbc.bindValue(sysrootSelection, sysrootOptionObservable);
+
+            sysrootOptionObservable.addValueChangeListener(e -> {
+                final var fromPkg = viewModel
+                        .getSysrootOption() == VenvWizardViewModel.SysrootOption.FOREIGN_TOOLCHAIN;
+                sysrootPackageLink.setEnabled(fromPkg);
+            });
+
+            displayTextObservable.addValueChangeListener(e -> {
+                final var text = viewModel.getSysrootPackageDisplayText();
+                if (text == null || text.isEmpty()) {
+                    sysrootPackageLink.setText("<a>(select package)</a>");
+                } else {
+                    sysrootPackageLink.setText("<a>" + text + "</a>");
+                }
+                sysrootGroup.requestLayout();
+            });
         }
 
         final var completeObservable = BeanProperties
@@ -633,6 +681,11 @@ public class WizardConfigPage extends WizardPage {
         if (getWizard() != null && getWizard().getContainer() != null) {
             getWizard().getContainer().updateButtons();
         }
+    }
+
+    private void openSysrootPackageDialog() {
+        final var dialog = new SysrootPackageSelectionDialog(getShell(), viewModel);
+        dialog.open();
     }
 
     private void performUpdateAndRefresh() {


### PR DESCRIPTION
Screenshot of the new dialog in Venv Wizard:

<img width="600" alt="gnu-plct in the package selection dialog of the Venv Wizard" src="https://github.com/user-attachments/assets/c19310cb-1c5d-439e-8020-db100f4ce4e2" />

.

## Summary by Sourcery

Allow configuring virtual environments to use a sysroot from another installed package and plumb that choice through to the Ruyi CLI.

New Features:
- Add support in the venv wizard to select a separate package and version as the sysroot source via a dedicated selection dialog and link UI.
- Allow venv creation to specify sysroot usage explicitly, including referencing a foreign toolchain package, when invoking the Ruyi CLI.

Enhancements:
- Refine sysroot option labels and validation in the venv configuration workflow and summary text to better reflect the selected strategy.