### PR TITLE
feat: reorganize entries about views into a submenu in the menu

### DIFF
--- a/plugins/org.ruyisdk.news/plugin.xml
+++ b/plugins/org.ruyisdk.news/plugin.xml
@@ -15,7 +15,7 @@
 
     <extension point="org.eclipse.ui.menus">
         <menuContribution
-            locationURI="menu:org.ruyisdk.ruyi.menus.main?after=additions">
+            locationURI="menu:org.ruyisdk.ruyi.menus.views?after=additions">
             <command
                 commandId="org.eclipse.ui.views.showView"
                 label="News"

--- a/plugins/org.ruyisdk.packages/plugin.xml
+++ b/plugins/org.ruyisdk.packages/plugin.xml
@@ -15,7 +15,7 @@
 
     <extension point="org.eclipse.ui.menus">
         <menuContribution
-            locationURI="menu:org.ruyisdk.ruyi.menus.main?after=additions">
+            locationURI="menu:org.ruyisdk.ruyi.menus.views?after=additions">
             <command
                 commandId="org.eclipse.ui.views.showView"
                 label="Package Explorer"

--- a/plugins/org.ruyisdk.promotion/plugin.xml
+++ b/plugins/org.ruyisdk.promotion/plugin.xml
@@ -4,7 +4,7 @@
 
     <extension point="org.eclipse.ui.menus">
         <menuContribution
-            locationURI="menu:org.ruyisdk.ruyi.menus.main?after=additions">
+            locationURI="menu:org.ruyisdk.ruyi.menus.views?after=additions">
             <command
                 commandId="org.eclipse.ui.views.showView"
                 label="RuyiSDK Website"

--- a/plugins/org.ruyisdk.ruyi/plugin.xml
+++ b/plugins/org.ruyisdk.ruyi/plugin.xml
@@ -70,15 +70,18 @@
 					tooltip="Verify Ruyi installation">
 				</command>
 				<command
-					commandId="org.ruyisdk.ruyi.commands.flashDeviceProvision"
-					label="Flash (Device Provision)"
-					tooltip="Run ruyi device provision in the built-in terminal">
-				</command>
-				<command
 					commandId="org.ruyisdk.ruyi.commands.updatePackageIndex"
 					label="Update Package Index"
 					tooltip="Update the Ruyi package index">
 				</command>
+				<separator name="additions" visible="true" />
+				<menu id="org.ruyisdk.ruyi.menus.views" label="Views">
+					<command
+						commandId="org.ruyisdk.ruyi.commands.flashDeviceProvision"
+						label="Flash (Device Provision)"
+						tooltip="Run ruyi device provision in the built-in terminal">
+					</command>
+				</menu>
 			</menu>
 		</menuContribution>
 	</extension>

--- a/plugins/org.ruyisdk.venv/plugin.xml
+++ b/plugins/org.ruyisdk.venv/plugin.xml
@@ -35,7 +35,7 @@
 
     <extension point="org.eclipse.ui.menus">
         <menuContribution
-            locationURI="menu:org.ruyisdk.ruyi.menus.main?after=additions">
+            locationURI="menu:org.ruyisdk.ruyi.menus.views?after=additions">
             <command
                 commandId="org.eclipse.ui.views.showView"
                 label="Venv (Virtual Environments)"


### PR DESCRIPTION
Screenshot of the new menu:

<img width="600" alt="new menu" src="https://github.com/user-attachments/assets/117f33c9-cc1d-4207-91c8-b698fd8f45af" />

.

## Summary by Sourcery

Group Ruyi-related view entries into a dedicated "Views" submenu and update existing view commands to contribute to it instead of the main Ruyi menu.

New Features:
- Introduce a "Views" submenu under the main Ruyi menu to contain view-related commands.

Enhancements:
- Move the Flash (Device Provision) command and existing view contributions from the main Ruyi menu into the new Views submenu for a more organized menu structure.