### PR TITLE
feat(promotion): automatically open official website view; feat: reorganize the layout of views

### DIFF
--- a/plugins/org.ruyisdk.promotion/META-INF/MANIFEST.MF
+++ b/plugins/org.ruyisdk.promotion/META-INF/MANIFEST.MF
@@ -13,4 +13,5 @@ Bundle-ClassPath:
 Require-Bundle: 
  org.eclipse.core.runtime,
  org.eclipse.swt,
- org.eclipse.ui
+ org.eclipse.ui,
+ org.ruyisdk.core

--- a/plugins/org.ruyisdk.promotion/plugin.xml
+++ b/plugins/org.ruyisdk.promotion/plugin.xml
@@ -26,4 +26,7 @@
             class="org.ruyisdk.promotion.views.WebsiteView"
             category="org.ruyisdk.promotion.category"/>
     </extension>
+    <extension point="org.eclipse.ui.startup">
+        <startup class="org.ruyisdk.promotion.PromotionStartup"/>
+    </extension>
 </plugin>

--- a/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/Activator.java
+++ b/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/Activator.java
@@ -1,7 +1,10 @@
 package org.ruyisdk.promotion;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.ruyisdk.core.util.PluginLogger;
 
 /** Plugin lifecycle activator. */
 public class Activator extends AbstractUIPlugin {
@@ -9,6 +12,9 @@ public class Activator extends AbstractUIPlugin {
     public static final String PLUGIN_ID = "org.ruyisdk.promotion";
 
     private static Activator plugin;
+
+    private static final PluginLogger LOGGER =
+            new PluginLogger(Platform.getLog(FrameworkUtil.getBundle(Activator.class)), PLUGIN_ID);
 
     @Override
     public void start(BundleContext context) throws Exception {
@@ -20,6 +26,11 @@ public class Activator extends AbstractUIPlugin {
     public void stop(BundleContext context) throws Exception {
         plugin = null;
         super.stop(context);
+    }
+
+    /** Returns an Eclipse builtin logger. */
+    public static PluginLogger getLogger() {
+        return LOGGER;
     }
 
     /** Returns the shared instance. */

--- a/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/PromotionStartup.java
+++ b/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/PromotionStartup.java
@@ -13,6 +13,8 @@ import org.ruyisdk.promotion.views.WebsiteView;
  */
 public class PromotionStartup implements IStartup {
 
+    private static final PluginLogger LOGGER = Activator.getLogger();
+
     @Override
     public void earlyStartup() {
         PlatformUI.getWorkbench().getDisplay().asyncExec(() -> {
@@ -30,7 +32,7 @@ public class PromotionStartup implements IStartup {
                     try {
                         page.showView(WebsiteView.ID);
                     } catch (PartInitException e) {
-                        // ignore or log
+                        LOGGER.logInfo("Failed to open RuyiSDK Website View", e);
                     }
                 }
             }

--- a/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/PromotionStartup.java
+++ b/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/PromotionStartup.java
@@ -33,7 +33,7 @@ public class PromotionStartup implements IStartup {
                     try {
                         page.showView(WebsiteView.ID);
                     } catch (PartInitException e) {
-                        LOGGER.logInfo("Failed to open RuyiSDK Website View", e);
+                        LOGGER.logError("Failed to open RuyiSDK Website View", e);
                     }
                 }
             }

--- a/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/PromotionStartup.java
+++ b/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/PromotionStartup.java
@@ -1,0 +1,39 @@
+package org.ruyisdk.promotion;
+
+import org.eclipse.ui.IStartup;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.ruyisdk.promotion.views.WebsiteView;
+
+/**
+ * Automatically opens the RuyiSDK Website View on IDE startup.
+ */
+public class PromotionStartup implements IStartup {
+
+    @Override
+    public void earlyStartup() {
+        PlatformUI.getWorkbench().getDisplay().asyncExec(() -> {
+            final IWorkbench workbench = PlatformUI.getWorkbench();
+            if (workbench.isClosing()) {
+                return;
+            }
+            IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
+            if (window == null && workbench.getWorkbenchWindows().length > 0) {
+                window = workbench.getWorkbenchWindows()[0];
+            }
+            if (window != null) {
+                final IWorkbenchPage page = window.getActivePage();
+                if (page != null) {
+                    try {
+                        page.showView(WebsiteView.ID);
+                    } catch (PartInitException e) {
+                        // ignore or log
+                    }
+                }
+            }
+        });
+    }
+}

--- a/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/PromotionStartup.java
+++ b/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/PromotionStartup.java
@@ -6,6 +6,7 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
+import org.ruyisdk.core.util.PluginLogger;
 import org.ruyisdk.promotion.views.WebsiteView;
 
 /**

--- a/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/views/WebsiteView.java
+++ b/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/views/WebsiteView.java
@@ -20,6 +20,7 @@ import org.eclipse.ui.part.ViewPart;
  * Embedded browser view for the RuyiSDK website. Uses the platform's native engine.
  */
 public class WebsiteView extends ViewPart {
+    public static final String ID = "org.ruyisdk.promotion.view";
     private static final String RUYISDK_URL = "https://ruyisdk.cn/";
 
     private Browser browser;

--- a/plugins/org.ruyisdk.ruyi/plugin.xml
+++ b/plugins/org.ruyisdk.ruyi/plugin.xml
@@ -83,4 +83,37 @@
 		</menuContribution>
 	</extension>
 
+	<extension point="org.eclipse.ui.perspectiveExtensions">
+		<perspectiveExtension targetID="org.eclipse.cdt.ui.CPerspective">
+			<!-- Position Package Explorer on the top left (stacked with standard Project Explorer) -->
+			<view
+				id="org.ruyisdk.packages.view"
+				relative="org.eclipse.ui.navigator.ProjectExplorer"
+				relationship="stack"
+				visible="true" />
+			
+			<!-- Position Venv View on the bottom left (below the Project Explorer) -->
+			<view
+				id="org.ruyisdk.venv.view"
+				relative="org.eclipse.ui.navigator.ProjectExplorer"
+				relationship="bottom"
+				ratio="0.5"
+				visible="true" />
+			
+			<!-- Stack the Ruyi News View directly with standard Outline view on the far right -->
+			<view
+				id="org.ruyisdk.news.view"
+				relative="org.eclipse.ui.views.ContentOutline"
+				relationship="stack"
+				visible="true" />
+			
+			<!-- Stack the RuyiSDK Website View directly with the News View on the far right -->
+			<view
+				id="org.ruyisdk.promotion.view"
+				relative="org.ruyisdk.news.view"
+				relationship="stack"
+				visible="true" />
+		</perspectiveExtension>
+	</extension>
+
 </plugin>


### PR DESCRIPTION
Screenshot of the new layout in the default perspective:

<img width="600" alt="new layout" src="https://github.com/user-attachments/assets/3fce5b98-1139-4cab-877d-839334216f84" />

.

## Summary by Sourcery

Configure the RuyiSDK promotion and related views to appear automatically in the default CDT perspective and open the official website view on IDE startup.

New Features:
- Automatically open the RuyiSDK official website view when the IDE starts.
- Integrate RuyiSDK-specific views (Packages, Virtual Environments, News, Website) into the default CDT perspective layout.