### PR TITLE
feat(venv): auto fill the only one open project in wizard

### DIFF
--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
@@ -600,6 +600,9 @@ public class VenvWizardViewModel {
                     projectRootPaths.add(path);
                 }
             }
+            if (venvLocation.isBlank() && projectRootPaths.size() == 1) {
+                setVenvLocation(projectRootPaths.get(0));
+            }
         };
         if (projectRootPaths.getRealm().isCurrent()) {
             update.run();

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardLocationPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardLocationPage.java
@@ -81,24 +81,10 @@ public class WizardLocationPage extends WizardPage {
 
         final var locationLabel = new Label(container, SWT.NONE);
         locationLabel.setText("Project:");
-        final var locationReadOnly = viewModel.isVenvLocationReadOnly();
-        final var initialLocation = viewModel.getVenvLocation();
+
         final var comboStyle = SWT.BORDER | SWT.DROP_DOWN | SWT.READ_ONLY;
         venvPathCombo = new Combo(container, comboStyle);
         venvPathCombo.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-        if (locationReadOnly) {
-            if (initialLocation != null && !initialLocation.isBlank()) {
-                venvPathCombo.add(initialLocation);
-                venvPathCombo.select(0);
-            }
-        } else {
-            if (initialLocation != null && !initialLocation.isBlank()) {
-                venvPathCombo.setText(initialLocation);
-            } else {
-                venvPathCombo.setText("");
-            }
-        }
-        venvPathCombo.setEnabled(!locationReadOnly);
         venvPathComboViewer = new ComboViewer(venvPathCombo);
     }
 
@@ -114,18 +100,25 @@ public class WizardLocationPage extends WizardPage {
 
         final var nameObservable = WidgetProperties.text(SWT.Modify).observe(venvNameText);
         final var pathObservable = WidgetProperties.comboSelection().observe(venvPathCombo);
+        final var pathReadOnlyObservable = BeanProperties
+                .value(VenvWizardViewModel.class, "venvLocationReadOnly", Boolean.class)
+                .observe(viewModel);
+        final var locationEnabledObservable = new ComputedValue<Boolean>() {
+            @Override
+            protected Boolean calculate() {
+                return !Boolean.TRUE.equals(pathReadOnlyObservable.getValue());
+            }
+        };
 
+        ViewerSupport.bind(venvPathComboViewer, viewModel.getProjectRootPaths(),
+                Properties.selfValue(String.class));
         dbc.bindValue(pathObservable, BeanProperties
                 .value(VenvWizardViewModel.class, "venvLocation", String.class).observe(viewModel));
         dbc.bindValue(nameObservable, BeanProperties
                 .value(VenvWizardViewModel.class, "venvName", String.class).observe(viewModel));
         dbc.bindValue(WidgetProperties.text().observe(summaryText), BeanProperties
                 .value(VenvWizardViewModel.class, "summaryText", String.class).observe(viewModel));
-
-        if (!viewModel.isVenvLocationReadOnly()) {
-            ViewerSupport.bind(venvPathComboViewer, viewModel.getProjectRootPaths(),
-                    Properties.selfValue(String.class));
-        }
+        dbc.bindValue(WidgetProperties.enabled().observe(venvPathCombo), locationEnabledObservable);
 
         final var completeObservable = new ComputedValue<Boolean>() {
             @Override


### PR DESCRIPTION
## Summary by Sourcery

Auto-populate and bind the virtual environment project location in the wizard when a single project is available, while keeping the location combo viewer synchronized and respecting read-only state.

New Features:
- Automatically set the virtual environment location to the only available project root path when exactly one project is open and no location has been chosen yet.

Enhancements:
- Always bind the project root paths to the project selection combo viewer and dynamically enable or disable it based on the view model's read-only flag.