### PR TITLE
feat(packages): remove redundant info from side panel; collect all remarks

### DIFF
--- a/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/PackageExplorerViewModel.java
+++ b/plugins/org.ruyisdk.packages/src/org/ruyisdk/packages/viewmodel/PackageExplorerViewModel.java
@@ -324,19 +324,13 @@ public class PackageExplorerViewModel extends BaseViewModel {
             if (node.getPackageRef() != null) {
                 sb.append("Reference: ").append(node.getPackageRef()).append("\n");
             }
-            sb.append("Status: ").append(node.isDownloaded() ? "Installed" : "Not installed")
-                    .append("\n");
         } else {
             sb.append("Name: ").append(node.getName()).append("\n");
             final var children = node.getChildren();
             if (children != null && !children.isEmpty()) {
                 sb.append("Children: ").append(children.size()).append("\n\n");
                 for (final var child : children) {
-                    sb.append("  - ").append(child.getName());
-                    if (child.isLeaf()) {
-                        sb.append(child.isDownloaded() ? "  [installed]" : "");
-                    }
-                    sb.append("\n");
+                    sb.append("  - ").append(child.getName()).append("\n");
                 }
             }
         }

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
@@ -112,19 +112,19 @@ public class RuyiCli {
     /** Package version information returned by package list porcelain output. */
     public static class PackageVersionInfo {
         private final String semver;
-        private final String remark;
+        private final List<String> remarks;
         private final boolean installed;
 
         /**
          * Creates an instance.
          *
          * @param semver package semantic version
-         * @param remark optional remark associated with this version
+         * @param remarks optional remarks associated with this version
          * @param installed true if this version is installed
          */
-        public PackageVersionInfo(String semver, String remark, boolean installed) {
+        public PackageVersionInfo(String semver, List<String> remarks, boolean installed) {
             this.semver = semver;
-            this.remark = remark;
+            this.remarks = remarks;
             this.installed = installed;
         }
 
@@ -132,8 +132,8 @@ public class RuyiCli {
             return semver;
         }
 
-        public String getRemark() {
-            return remark;
+        public List<String> getRemarks() {
+            return remarks;
         }
 
         public boolean isInstalled() {

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
@@ -124,7 +124,7 @@ public class RuyiCli {
          */
         public PackageVersionInfo(String semver, List<String> remarks, boolean installed) {
             this.semver = semver;
-            this.remarks = remarks;
+            this.remarks = remarks == null ? List.of() : new ArrayList<>(remarks);
             this.installed = installed;
         }
 
@@ -133,7 +133,7 @@ public class RuyiCli {
         }
 
         public List<String> getRemarks() {
-            return remarks;
+            return Collections.unmodifiableList(remarks);
         }
 
         public boolean isInstalled() {

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliParsingSupport.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliParsingSupport.java
@@ -9,6 +9,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -101,7 +103,7 @@ final class RuyiCliParsingSupport {
                 final var packageRef =
                         String.format("%s(%s)", packageEntry.getName(), version.getSemver());
                 versions.add(new RuyiCli.PackageTreeVersionInfo(
-                        formatVersionLabel(version.getSemver(), version.getRemark()), packageRef,
+                        formatVersionLabel(version.getSemver(), version.getRemarks()), packageRef,
                         version.isInstalled()));
             }
             packages.add(new RuyiCli.PackageTreePackageInfo(packageEntry.getName(), versions));
@@ -254,29 +256,28 @@ final class RuyiCliParsingSupport {
                 continue;
             }
 
-            final var remark = extractPrimaryRemark(versionObj.optJSONArray("remarks"));
+            final var remarks = extractRemarks(versionObj.optJSONArray("remarks"));
             final var isInstalled =
                     Boolean.TRUE.equals(optBooleanOrNull(versionObj, "is_installed"));
-            out.add(new RuyiCli.PackageVersionInfo(semver, remark, isInstalled));
+            out.add(new RuyiCli.PackageVersionInfo(semver, remarks, isInstalled));
         }
 
         return out;
     }
 
-    private static String extractPrimaryRemark(JSONArray remarksArray) {
+    private static List<String> extractRemarks(JSONArray remarksArray) {
         if (remarksArray == null || remarksArray.length() == 0) {
-            return null;
+            return List.of();
         }
-
-        final var remark = remarksArray.optString(0, "").trim();
-        return remark.isEmpty() ? null : remark;
+        final var remarks = IntStream.range(0, remarksArray.length())
+                .mapToObj(remarksArray::getString).collect(Collectors.toList());
+        return remarks;
     }
 
-    private static String formatVersionLabel(String semver, String remark) {
-        if (remark == null || remark.isBlank()) {
-            return semver;
-        }
-        return semver + " [" + remark + "]";
+    private static String formatVersionLabel(String semver, List<String> remarks) {
+        final var remarksString = remarks.stream().map(remark -> String.format("[%s]", remark))
+                .collect(Collectors.joining());
+        return remarksString.isBlank() ? semver : String.format("%s %s", semver, remarksString);
     }
 
     private static List<String> extractVersions(JSONArray versionsArray) {

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliParsingSupport.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliParsingSupport.java
@@ -269,9 +269,10 @@ final class RuyiCliParsingSupport {
         if (remarksArray == null || remarksArray.length() == 0) {
             return List.of();
         }
-        final var remarks = IntStream.range(0, remarksArray.length())
-                .mapToObj(remarksArray::getString).collect(Collectors.toList());
-        return remarks;
+
+        return IntStream.range(0, remarksArray.length())
+                .mapToObj(i -> remarksArray.optString(i, "")).filter(remark -> !remark.isBlank())
+                .collect(Collectors.toList());
     }
 
     private static String formatVersionLabel(String semver, List<String> remarks) {

--- a/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/services/RuyiCliParsingTest.java
+++ b/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/services/RuyiCliParsingTest.java
@@ -298,7 +298,7 @@ public class RuyiCliParsingTest {
         assertEquals(1, toolchainCategory.getPackages().size());
 
         var version = toolchainCategory.getPackages().get(0).getVersions().get(0);
-        assertEquals("1.0.0 [recommended][123]", version.getDisplayName());
+        assertEquals("1.0.0 [  recommended  ][123]", version.getDisplayName());
     }
 
     @Test

--- a/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/services/RuyiCliParsingTest.java
+++ b/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/services/RuyiCliParsingTest.java
@@ -286,6 +286,22 @@ public class RuyiCliParsingTest {
     }
 
     @Test
+    public void parsePackageTreeSkipsBlankRemarksAndHandlesNonStrings() {
+        String sample = """
+                        {"ty":"pkglistoutput-v1","category":"toolchain","name":"tc-remarks","vers":[{"semver":"1.0.0","remarks":["  recommended  ",""," ",null,123]}]}
+                        """;
+
+        var categories = RuyiCli.parsePackageTreeFromString(sample);
+        assertEquals(1, categories.size());
+
+        var toolchainCategory = categories.get(0);
+        assertEquals(1, toolchainCategory.getPackages().size());
+
+        var version = toolchainCategory.getPackages().get(0).getVersions().get(0);
+        assertEquals("1.0.0 [recommended][123]", version.getDisplayName());
+    }
+
+    @Test
     public void parsePackageTreeMergesPackagesUnderSameCategory() {
         String sample = """
                         {"ty":"pkglistoutput-v1","category":"toolchain","name":"tc-a","vers":[{"semver":"1.0.0"}]}

--- a/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/services/RuyiCliParsingTest.java
+++ b/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/services/RuyiCliParsingTest.java
@@ -250,6 +250,7 @@ public class RuyiCliParsingTest {
         String sample = """
                         {"ty":"log-v1","message":"skip"}
                         {"ty":"pkglistoutput-v1","category":"toolchain","name":"tc-a","vers":[{"semver":"1.0.0","remarks":["recommended"],"is_installed":true},{"semver":"1.1.0"}]}
+                        {"ty":"pkglistoutput-v1","category":"toolchain","name":"tc-multi-remarks","vers":[{"semver":"2.0.0","remarks":["recommended","stable"],"is_installed":false}]}
                         {"category":"emulator","name":"emu-a","vers":[{"semver":"0.9.0"}]}
                         """;
 
@@ -258,7 +259,7 @@ public class RuyiCliParsingTest {
 
         var toolchainCategory = categories.get(0);
         assertEquals("toolchain", toolchainCategory.getName());
-        assertEquals(1, toolchainCategory.getPackages().size());
+        assertEquals(2, toolchainCategory.getPackages().size());
 
         var toolchainPackage = toolchainCategory.getPackages().get(0);
         assertEquals("tc-a", toolchainPackage.getName());
@@ -272,6 +273,11 @@ public class RuyiCliParsingTest {
         var version110 = toolchainPackage.getVersions().get(1);
         assertEquals("1.1.0", version110.getDisplayName());
         assertFalse(version110.isInstalled());
+
+        var toolchainPackage1 = toolchainCategory.getPackages().get(1);
+        var version200 = toolchainPackage1.getVersions().get(0);
+        assertEquals("2.0.0 [recommended][stable]", version200.getDisplayName());
+        assertFalse(version200.isInstalled());
 
         var emulatorCategory = categories.get(1);
         assertEquals("emulator", emulatorCategory.getName());


### PR DESCRIPTION
Redundant info is "Status". The info will be in the version info.

## Summary by Sourcery

Collect all remarks for package versions from CLI output and surface them in version labels while streamlining the package explorer side panel information display.

New Features:
- Support multiple remarks per package version and display all of them in the version label

Enhancements:
- Simplify the package explorer side panel by removing installation status and child installation markers from the info pane

Tests:
- Extend CLI parsing tests to cover versions with multiple remarks and the updated display format