### PR TITLE
feat(venv): add "delete venv..." to right-click menu; feat(venv): add duplicate submenu to the "project" menu on the menubar 

### DIFF
--- a/plugins/org.ruyisdk.venv/plugin.xml
+++ b/plugins/org.ruyisdk.venv/plugin.xml
@@ -22,6 +22,10 @@
             id="org.ruyisdk.venv.commands.applyProjectVenv"
             name="Apply venv"
             description="Apply a venv to the selected project"/>
+        <command
+            id="org.ruyisdk.venv.commands.deleteProjectVenv"
+            name="Delete Venv"
+            description="Delete a venv under the selected project"/>
     </extension>
 
     <extension point="org.eclipse.ui.handlers">
@@ -31,6 +35,9 @@
         <handler
             class="org.ruyisdk.venv.handlers.ApplyProjectVenvHandler"
             commandId="org.ruyisdk.venv.commands.applyProjectVenv"/>
+        <handler
+            class="org.ruyisdk.venv.handlers.DeleteProjectVenvHandler"
+            commandId="org.ruyisdk.venv.commands.deleteProjectVenv"/>
     </extension>
 
     <extension point="org.eclipse.ui.menus">
@@ -65,10 +72,13 @@
                 </visibleWhen>
                 <command
                     commandId="org.ruyisdk.venv.commands.newProjectVenv"
-                    label="New Venv..."/>
+                    label="New venv..."/>
                 <command
                     commandId="org.ruyisdk.venv.commands.applyProjectVenv"
                     label="Apply venv..."/>
+                <command
+                    commandId="org.ruyisdk.venv.commands.deleteProjectVenv"
+                    label="Delete venv..."/>
             </menu>
         </menuContribution>
     </extension>

--- a/plugins/org.ruyisdk.venv/plugin.xml
+++ b/plugins/org.ruyisdk.venv/plugin.xml
@@ -54,6 +54,23 @@
         </menuContribution>
 
         <menuContribution
+            locationURI="menu:project?after=additions">
+            <menu
+                id="org.ruyisdk.venv.menu.projectMenuBar"
+                label="RuyiSDK">
+                <command
+                    commandId="org.ruyisdk.venv.commands.newProjectVenv"
+                    label="New venv..."/>
+                <command
+                    commandId="org.ruyisdk.venv.commands.applyProjectVenv"
+                    label="Apply venv..."/>
+                <command
+                    commandId="org.ruyisdk.venv.commands.deleteProjectVenv"
+                    label="Delete venv..."/>
+            </menu>
+        </menuContribution>
+
+        <menuContribution
             locationURI="popup:org.eclipse.ui.popup.any?after=additions">
             <menu
                 id="org.ruyisdk.venv.menu.projectContext"

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/handlers/DeleteProjectVenvHandler.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/handlers/DeleteProjectVenvHandler.java
@@ -1,0 +1,102 @@
+package org.ruyisdk.venv.handlers;
+
+import java.util.Arrays;
+import java.util.List;
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.window.Window;
+import org.eclipse.ui.dialogs.ElementListSelectionDialog;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.ruyisdk.core.util.PluginLogger;
+import org.ruyisdk.venv.Activator;
+import org.ruyisdk.venv.model.Venv;
+import org.ruyisdk.venv.viewmodel.ProjectVenvContextMenuViewModel;
+import org.ruyisdk.venv.viewmodel.VenvListViewModel;
+
+/**
+ * Handler deleting a venv selected from the project context menu.
+ */
+public class DeleteProjectVenvHandler extends AbstractHandler {
+
+    private static final PluginLogger LOGGER = Activator.getLogger();
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        final var selection = (IStructuredSelection) HandlerUtil.getCurrentSelection(event);
+        final var firstElement = selection.getFirstElement();
+        final var project = firstElement instanceof IProject ? (IProject) firstElement
+                : ((IAdaptable) firstElement).getAdapter(IProject.class);
+        final var projectPath = project.getLocation().toOSString();
+
+        final var activator = Activator.getDefault();
+        final var viewModel = new ProjectVenvContextMenuViewModel(activator.getDetectionService(),
+                activator.getConfigService());
+        final var candidates = viewModel.listProjectVenvs(projectPath);
+
+        if (candidates.isEmpty()) {
+            MessageDialog.openInformation(HandlerUtil.getActiveShell(event), "Delete venv",
+                    String.format("No virtual environments found under project \"%s\".",
+                            project.getName()));
+            return null;
+        }
+
+        final var dialog = new ElementListSelectionDialog(HandlerUtil.getActiveShell(event),
+                new LabelProvider() {
+                    @Override
+                    public String getText(Object element) {
+                        return VenvListViewModel.getDisplayPath((Venv) element);
+                    }
+                });
+        dialog.setTitle("Delete venv");
+        dialog.setMessage(String.format(
+                "Select virtual environment(s) to delete from project \"%s\":", project.getName()));
+        dialog.setElements(candidates.toArray(Venv[]::new));
+        dialog.setMultipleSelection(true);
+
+        if (dialog.open() != Window.OK) {
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        final List<Venv> selectedVenvs = (List<Venv>) (List<?>) Arrays.asList(dialog.getResult());
+        if (selectedVenvs.isEmpty()) {
+            return null;
+        }
+
+        final var venvPaths =
+                activator.getDetectionService().getVenvDirectoryPathsFromVenvs(selectedVenvs);
+
+        final String message;
+        if (venvPaths.size() == 1) {
+            message = String.format("""
+                This will delete the whole directory of the virtual environment:
+                %s
+
+                Continue?""", venvPaths.get(0));
+        } else {
+            message = String.format("""
+                This will delete the whole directories of the selected virtual environments:
+                %s
+
+                Continue?""", String.join("\n", venvPaths));
+        }
+
+        final var confirmed = MessageDialog.openConfirm(HandlerUtil.getActiveShell(event),
+                "Delete virtual environment", message);
+        if (!confirmed) {
+            return null;
+        }
+
+        LOGGER.logInfo(
+                String.format("Deleting venv(s) from project context menu: project=%s, count=%d",
+                        projectPath, selectedVenvs.size()));
+        viewModel.deleteVenvs(selectedVenvs);
+        return null;
+    }
+}

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/ProjectVenvContextMenuViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/ProjectVenvContextMenuViewModel.java
@@ -60,6 +60,16 @@ public class ProjectVenvContextMenuViewModel {
     }
 
     /**
+     * Deletes the given venvs.
+     *
+     * @param venvs venvs to delete
+     */
+    public void deleteVenvs(List<Venv> venvs) {
+        final var venvPaths = detectionService.getVenvDirectoryPathsFromVenvs(venvs);
+        detectionService.deleteVenvDirectoriesAsync(venvPaths).join();
+    }
+
+    /**
      * Returns display text for the apply-venv selection list.
      *
      * @param venv venv row


### PR DESCRIPTION
Screenshot:

<img width="200" alt="new items in menu bar's project menu" src="https://github.com/user-attachments/assets/74ee9c61-d245-44a3-b464-b798c08d7a8f" />

.

## Summary by Sourcery

Introduce project-level venv deletion and surface venv actions in the Project menu.

New Features:
- Add a command and handler to delete one or more virtual environments associated with a selected project, with confirmation and messaging when none are found.
- Expose venv management actions (new, apply, delete) in the main Project menu in addition to the project context menu.

Enhancements:
- Extend the project venv context menu view model with support for deleting selected virtual environments.