### PR TITLE
fix(venv): filter out non-sysroot toolchain in sysroot selection dialog

### DIFF
--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
@@ -48,6 +48,8 @@ public class RuyiCli {
         // "flavors" is the old name for "quirks":
         // https://github.com/ruyisdk/ruyi/blob/ff18bb37e092d875e04ddcb3320c79798c4b2315/ruyi/ruyipkg/pkg_manifest.py#L88-L109
         private final List<String> quirks;
+        // "toolchain.included_sysroot"
+        private final boolean hasIncludedSysroot;
 
         /**
          * Creates an instance.
@@ -55,11 +57,14 @@ public class RuyiCli {
          * @param name toolchain package name
          * @param versions available toolchain versions
          * @param quirks quirk (flavor) identifiers provided by this toolchain
+         * @param hasIncludedSysroot true if this toolchain metadata declares an included sysroot
          */
-        public ToolchainInfo(String name, List<String> versions, List<String> quirks) {
+        public ToolchainInfo(String name, List<String> versions, List<String> quirks,
+                boolean hasIncludedSysroot) {
             this.name = name;
             this.versions = versions == null ? new ArrayList<>() : new ArrayList<>(versions);
             this.quirks = quirks == null ? new ArrayList<>() : new ArrayList<>(quirks);
+            this.hasIncludedSysroot = hasIncludedSysroot;
         }
 
         public String getName() {
@@ -72,6 +77,11 @@ public class RuyiCli {
 
         public List<String> getQuirks() {
             return Collections.unmodifiableList(quirks);
+        }
+
+        /** Returns whether this toolchain metadata declares an included sysroot. */
+        public boolean hasIncludedSysroot() {
+            return hasIncludedSysroot;
         }
     }
 

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliParsingSupport.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliParsingSupport.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -141,16 +142,17 @@ final class RuyiCliParsingSupport {
     }
 
     static List<RuyiCli.ToolchainInfo> parseToolchainsFromString(String input) {
-        final var packages = parsePackageInfos(input, "toolchain", "toolchain");
+        final var packages = parsePackageInfos(input, "toolchain", "toolchain", true);
         final var out = new ArrayList<RuyiCli.ToolchainInfo>();
         for (final var info : packages) {
-            out.add(new RuyiCli.ToolchainInfo(info.name, info.versions, info.quirks));
+            out.add(new RuyiCli.ToolchainInfo(info.name, info.versions, info.quirks,
+                    info.hasIncludedSysroot));
         }
         return out;
     }
 
     static List<RuyiCli.EmulatorInfo> parseEmulatorsFromString(String input) {
-        final var packages = parsePackageInfos(input, "emulator", "emulator");
+        final var packages = parsePackageInfos(input, "emulator", "emulator", false);
         final var out = new ArrayList<RuyiCli.EmulatorInfo>();
         for (final var info : packages) {
             out.add(new RuyiCli.EmulatorInfo(info.name, info.versions, info.quirks));
@@ -202,7 +204,7 @@ final class RuyiCliParsingSupport {
     }
 
     private static List<PackageInfo> parsePackageInfos(String input, String expectedCategory,
-            String metadataKey) {
+            String metadataKey, boolean detectIncludedSysroot) {
         final var out = new ArrayList<PackageInfo>();
         if (input == null || input.isBlank()) {
             return out;
@@ -233,7 +235,9 @@ final class RuyiCliParsingSupport {
             }
 
             final var quirks = extractPackageQuirks(o.optJSONArray("vers"), metadataKey);
-            out.add(new PackageInfo(name.trim(), versions, quirks));
+            final var hasIncludedSysroot = detectIncludedSysroot
+                    && extractPackageHasIncludedSysroot(o.optJSONArray("vers"), metadataKey);
+            out.add(new PackageInfo(name.trim(), versions, quirks, hasIncludedSysroot));
         }
         return out;
     }
@@ -329,6 +333,20 @@ final class RuyiCliParsingSupport {
 
         return new ArrayList<>(quirksSet);
     }
+
+    private static boolean extractPackageHasIncludedSysroot(JSONArray vers, String metadataKey) {
+        if (vers == null) {
+            return false;
+        }
+
+        return IntStream.range(0, vers.length())
+                .mapToObj(i -> Optional.ofNullable(vers.optJSONObject(i)))
+                .map(optV -> optV.map(v -> v.optJSONObject("pm"))
+                        .map(pm -> pm.optJSONObject(metadataKey))
+                        .map(metadata -> metadata.optString("included_sysroot", "")).orElse(""))
+                .anyMatch(sysroot -> !sysroot.isBlank());
+    }
+
 
     private static void collectJsonArrayStrings(JSONArray arr, LinkedHashSet<String> target) {
         if (arr == null) {
@@ -569,11 +587,14 @@ final class RuyiCliParsingSupport {
         private final String name;
         private final List<String> versions;
         private final List<String> quirks;
+        private final boolean hasIncludedSysroot;
 
-        private PackageInfo(String name, List<String> versions, List<String> quirks) {
+        private PackageInfo(String name, List<String> versions, List<String> quirks,
+                boolean hasIncludedSysroot) {
             this.name = name;
             this.versions = versions;
             this.quirks = quirks;
+            this.hasIncludedSysroot = hasIncludedSysroot;
         }
     }
 }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/Toolchain.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/Toolchain.java
@@ -9,9 +9,11 @@ public class Toolchain {
     private String name;
     private List<String> versions = new ArrayList<>();
     private List<String> quirks = new ArrayList<>();
+    private boolean hasIncludedSysroot;
 
-    /** Creates a toolchain with the given versions and quirks. */
-    public Toolchain(String name, List<String> versions, List<String> quirks) {
+    /** Creates a toolchain with the given versions, quirks, and sysroot capability. */
+    public Toolchain(String name, List<String> versions, List<String> quirks,
+            boolean hasIncludedSysroot) {
         this.name = name;
         if (versions != null) {
             this.versions.addAll(versions);
@@ -19,6 +21,7 @@ public class Toolchain {
         if (quirks != null) {
             this.quirks.addAll(quirks);
         }
+        this.hasIncludedSysroot = hasIncludedSysroot;
     }
 
     /** Returns the toolchain name. */
@@ -55,5 +58,15 @@ public class Toolchain {
         if (quirks != null) {
             this.quirks.addAll(quirks);
         }
+    }
+
+    /** Returns whether this toolchain provides an included sysroot. */
+    public boolean hasIncludedSysroot() {
+        return hasIncludedSysroot;
+    }
+
+    /** Sets whether this toolchain provides an included sysroot. */
+    public void setHasIncludedSysroot(boolean hasIncludedSysroot) {
+        this.hasIncludedSysroot = hasIncludedSysroot;
     }
 }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
@@ -132,11 +132,12 @@ public class VenvWizardViewModel {
     }
 
     private boolean isSysrootPackageSelected() {
+        final var sysrootToolchains = getSysrootToolchains();
         if (!(selectedSysrootPackageIndex >= 0
-                && selectedSysrootPackageIndex < toolchains.size())) {
+                && selectedSysrootPackageIndex < sysrootToolchains.size())) {
             return false;
         }
-        final var versions = toolchains.get(selectedSysrootPackageIndex).getVersions();
+        final var versions = sysrootToolchains.get(selectedSysrootPackageIndex).getVersions();
         return versions != null && selectedSysrootPackageVersionIndex >= 0
                 && selectedSysrootPackageVersionIndex < versions.size();
     }
@@ -182,7 +183,7 @@ public class VenvWizardViewModel {
 
         sb.append("Sysroot: ");
         if (sysrootOption == SysrootOption.FOREIGN_TOOLCHAIN && isSysrootPackageSelected()) {
-            final var pkg = toolchains.get(selectedSysrootPackageIndex);
+            final var pkg = getSysrootToolchains().get(selectedSysrootPackageIndex);
             final var ver = pkg.getVersions().get(selectedSysrootPackageVersionIndex);
             sb.append(String.format("copy from %s(%s)", pkg.getName(), ver));
         } else {
@@ -208,8 +209,9 @@ public class VenvWizardViewModel {
         final var toolchainInfos = service.listToolchains();
         if (toolchainInfos != null) {
             for (final var toolchainInfo : toolchainInfos) {
-                allToolchains.add(new Toolchain(toolchainInfo.getName(),
-                        toolchainInfo.getVersions(), toolchainInfo.getQuirks()));
+                allToolchains
+                        .add(new Toolchain(toolchainInfo.getName(), toolchainInfo.getVersions(),
+                                toolchainInfo.getQuirks(), toolchainInfo.hasIncludedSysroot()));
             }
         }
 
@@ -318,13 +320,15 @@ public class VenvWizardViewModel {
         if (sysrootOption != SysrootOption.FOREIGN_TOOLCHAIN) {
             throw RuyiCliException.invalidArgument("No need to install package for sysroot");
         }
-        if (selectedSysrootPackageIndex < 0 || selectedSysrootPackageIndex >= toolchains.size()
+        final var sysrootToolchains = getSysrootToolchains();
+        if (selectedSysrootPackageIndex < 0
+                || selectedSysrootPackageIndex >= sysrootToolchains.size()
                 || selectedSysrootPackageVersionIndex < 0) {
             throw RuyiCliException.invalidArgument("Sysroot enabled but not selected");
         }
-        final var name = toolchains.get(selectedSysrootPackageIndex).getName();
-        final var version = toolchains.get(selectedSysrootPackageIndex).getVersions()
-                .get(selectedSysrootPackageVersionIndex);
+        final var pkg = sysrootToolchains.get(selectedSysrootPackageIndex);
+        final var name = pkg.getName();
+        final var version = pkg.getVersions().get(selectedSysrootPackageVersionIndex);
         installPackageForSysroot(name, version);
     }
 
@@ -370,7 +374,7 @@ public class VenvWizardViewModel {
                 throw RuyiCliException
                         .invalidArgument("Sysroot from package selected but no package chosen");
             }
-            final var pkg = toolchains.get(selectedSysrootPackageIndex);
+            final var pkg = getSysrootToolchains().get(selectedSysrootPackageIndex);
             final var ver = pkg.getVersions().get(selectedSysrootPackageVersionIndex);
             sysrootFromAtom = String.format("%s(%s)", pkg.getName(), ver);
         }
@@ -550,6 +554,10 @@ public class VenvWizardViewModel {
 
     /** Sets the selected sysroot package index within the toolchains list. */
     public void setSelectedSysrootPackageIndex(int index) {
+        final var sysrootToolchains = getSysrootToolchains();
+        if (index < -1 || index >= sysrootToolchains.size()) {
+            index = -1;
+        }
         final var old = this.selectedSysrootPackageIndex;
         this.selectedSysrootPackageIndex = index;
         pcs.firePropertyChange("selectedSysrootPackageIndex", old,
@@ -584,13 +592,18 @@ public class VenvWizardViewModel {
     private void updateSysrootPackageDisplayText() {
         final var old = this.sysrootPackageDisplayText;
         if (isSysrootPackageSelected()) {
-            final var pkg = toolchains.get(selectedSysrootPackageIndex);
+            final var pkg = getSysrootToolchains().get(selectedSysrootPackageIndex);
             final var ver = pkg.getVersions().get(selectedSysrootPackageVersionIndex);
             this.sysrootPackageDisplayText = String.format("%s(%s)", pkg.getName(), ver);
         } else {
             this.sysrootPackageDisplayText = "";
         }
         pcs.firePropertyChange("sysrootPackageDisplayText", old, this.sysrootPackageDisplayText);
+    }
+
+    /** Returns toolchains that can act as sysroot sources. */
+    public List<Toolchain> getSysrootToolchains() {
+        return toolchains.stream().filter(Toolchain::hasIncludedSysroot).toList();
     }
 
     /** Returns the configured venv parent directory. */

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/SysrootPackageSelectionDialog.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/SysrootPackageSelectionDialog.java
@@ -87,7 +87,7 @@ class SysrootPackageSelectionDialog extends Dialog {
                 return ((Toolchain) element).getName();
             }
         });
-        packageNamesViewer.setInput(viewModel.getToolchains());
+        packageNamesViewer.setInput(viewModel.getSysrootToolchains());
 
         packageVersionsViewer = new TableViewer(container, SWT.BORDER | SWT.FULL_SELECTION);
         {
@@ -127,7 +127,8 @@ class SysrootPackageSelectionDialog extends Dialog {
                             if (fromObject == null) {
                                 return Integer.valueOf(-1);
                             }
-                            return Integer.valueOf(viewModel.getToolchains().indexOf(fromObject));
+                            return Integer
+                                    .valueOf(viewModel.getSysrootToolchains().indexOf(fromObject));
                         }
                     });
             final var indexToToolchain = new UpdateValueStrategy<Integer, Toolchain>();
@@ -136,8 +137,9 @@ class SysrootPackageSelectionDialog extends Dialog {
                         @Override
                         public Toolchain convert(Integer fromObject) {
                             final var idx = ((Integer) fromObject).intValue();
-                            if (idx >= 0 && idx < viewModel.getToolchains().size()) {
-                                return viewModel.getToolchains().get(idx);
+                            final var toolchains = viewModel.getSysrootToolchains();
+                            if (idx >= 0 && idx < toolchains.size()) {
+                                return toolchains.get(idx);
                             }
                             return null;
                         }
@@ -163,10 +165,11 @@ class SysrootPackageSelectionDialog extends Dialog {
                         @Override
                         public Integer convert(String fromObject) {
                             final var idx = viewModel.getSelectedSysrootPackageIndex();
-                            if (idx < 0 || idx >= viewModel.getToolchains().size()) {
+                            final var toolchains = viewModel.getSysrootToolchains();
+                            if (idx < 0 || idx >= toolchains.size()) {
                                 return Integer.valueOf(-1);
                             }
-                            final var vers = viewModel.getToolchains().get(idx).getVersions();
+                            final var vers = toolchains.get(idx).getVersions();
                             return Integer.valueOf(vers == null ? -1 : vers.indexOf(fromObject));
                         }
                     });
@@ -176,10 +179,11 @@ class SysrootPackageSelectionDialog extends Dialog {
                         @Override
                         public String convert(Integer fromObject) {
                             final var idx = viewModel.getSelectedSysrootPackageIndex();
-                            if (idx < 0 || idx >= viewModel.getToolchains().size()) {
+                            final var toolchains = viewModel.getSysrootToolchains();
+                            if (idx < 0 || idx >= toolchains.size()) {
                                 return null;
                             }
-                            final var vers = viewModel.getToolchains().get(idx).getVersions();
+                            final var vers = toolchains.get(idx).getVersions();
                             final var verIdx = ((Integer) fromObject).intValue();
                             return vers != null && verIdx >= 0 && verIdx < vers.size()
                                     ? vers.get(verIdx)
@@ -202,8 +206,9 @@ class SysrootPackageSelectionDialog extends Dialog {
             return;
         }
         final var selectedPackageIndex = viewModel.getSelectedSysrootPackageIndex();
-        if (selectedPackageIndex >= 0 && selectedPackageIndex < viewModel.getToolchains().size()) {
-            final var toolchain = viewModel.getToolchains().get(selectedPackageIndex);
+        final var toolchains = viewModel.getSysrootToolchains();
+        if (selectedPackageIndex >= 0 && selectedPackageIndex < toolchains.size()) {
+            final var toolchain = toolchains.get(selectedPackageIndex);
             packageVersionsViewer.setInput(toolchain.getVersions());
 
             final var selectedVersionIndex = viewModel.getSelectedSysrootPackageVersionIndex();

--- a/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/services/RuyiCliParsingTest.java
+++ b/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/services/RuyiCliParsingTest.java
@@ -33,9 +33,11 @@ public class RuyiCliParsingTest {
         assertEquals(2, tcs.get(0).getVersions().size());
         assertEquals("1.0.0", tcs.get(0).getVersions().get(0));
         assertEquals("1.1.0", tcs.get(0).getVersions().get(1));
+        assertFalse(tcs.get(0).hasIncludedSysroot());
         assertEquals("tc-b", tcs.get(1).getName());
         assertEquals(1, tcs.get(1).getVersions().size());
         assertEquals("2.0.0", tcs.get(1).getVersions().get(0));
+        assertFalse(tcs.get(1).hasIncludedSysroot());
     }
 
     /**
@@ -246,6 +248,28 @@ public class RuyiCliParsingTest {
     }
 
     @Test
+    public void parseToolchainsDetectsIncludedSysroot() {
+        String sample = """
+                        {"ty":"pkglistoutput-v1","category":"toolchain","name":"tc-sysroot","vers":[{"semver":"1.0.0","pm":{"toolchain":{"included_sysroot":"riscv64-unknown-linux-gnu/sysroot"}}}]}
+                        """;
+
+        List<RuyiCli.ToolchainInfo> tcs = RuyiCli.parseToolchainsFromString(sample);
+        assertEquals(1, tcs.size());
+        assertTrue(tcs.get(0).hasIncludedSysroot());
+    }
+
+    @Test
+    public void parseToolchainsDetectsMissingIncludedSysroot() {
+        String sample = """
+                        {"ty":"pkglistoutput-v1","category":"toolchain","name":"tc-nosysroot","vers":[{"semver":"1.0.0","pm":{"toolchain":{"quirks":["rv64ilp32"]}}}]}
+                        """;
+
+        List<RuyiCli.ToolchainInfo> tcs = RuyiCli.parseToolchainsFromString(sample);
+        assertEquals(1, tcs.size());
+        assertFalse(tcs.get(0).hasIncludedSysroot());
+    }
+
+    @Test
     public void parsePackageTreeBuildsTreeAndPreservesVersionMetadata() {
         String sample = """
                         {"ty":"log-v1","message":"skip"}
@@ -406,7 +430,7 @@ public class RuyiCliParsingTest {
 
     @Test
     public void toolchainInfoQuirksListIsUnmodifiable() {
-        var ti = new RuyiCli.ToolchainInfo("tc", List.of("1.0"), List.of("q"));
+        var ti = new RuyiCli.ToolchainInfo("tc", List.of("1.0"), List.of("q"), false);
         boolean threw = false;
         try {
             ti.getQuirks().add("x");
@@ -418,9 +442,16 @@ public class RuyiCliParsingTest {
 
     @Test
     public void toolchainInfoNullQuirksBecomesEmpty() {
-        var ti = new RuyiCli.ToolchainInfo("tc", List.of("1.0"), null);
+        var ti = new RuyiCli.ToolchainInfo("tc", List.of("1.0"), null, false);
         assertNotNull(ti.getQuirks());
         assertTrue(ti.getQuirks().isEmpty());
+        assertFalse(ti.hasIncludedSysroot());
+    }
+
+    @Test
+    public void toolchainInfoStoresIncludedSysrootCapability() {
+        var ti = new RuyiCli.ToolchainInfo("tc", List.of("1.0"), List.of(), true);
+        assertTrue(ti.hasIncludedSysroot());
     }
 
     @Test


### PR DESCRIPTION
"xscc" should not be there.

## Summary by Sourcery

Restrict sysroot selection to toolchains that declare an included sysroot and propagate this capability from CLI parsing through to the venv UI.

Bug Fixes:
- Exclude toolchains without an included sysroot from the sysroot package selection dialog to prevent invalid selections and confusing entries like non-sysroot toolchains appearing as sysroot sources.

Enhancements:
- Extend toolchain metadata and venv Toolchain model to track whether a toolchain provides an included sysroot and expose a filtered sysroot toolchain list in the view model.

Tests:
- Add and update parsing tests to cover detection and propagation of the included sysroot capability and adapt existing ToolchainInfo tests to the new constructor signature.