### PR TITLE
feat(venv): support new sysroot configurations, since ruyi 0.49.0

### DIFF
--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCli.java
@@ -757,11 +757,18 @@ public class RuyiCli {
      * @param profile profile name (required)
      * @param withSysroot whether to use the included sysroot (may be null)
      * @param sysrootFrom optional toolchain for {@code --sysroot-from} (may be null)
+     * @param copySysrootFromDir optional source directory for {@code --copy-sysroot-from-dir} (may
+     *        be null)
+     * @param symlinkSysrootFromDir optional source directory for {@code --symlink-sysroot-from-dir}
+     *        (may be null)
+     * @param projectSysrootFromRootfs optional rootfs directory for
+     *        {@code --project-sysroot-from-rootfs} (may be null)
      * @param emulatorName optional emulator package name (may be null)
      * @param emulatorVersion optional emulator version (may be null)
      */
     public static void createVenv(String path, String toolchainName, String toolchainVersion,
-            String profile, Boolean withSysroot, String sysrootFrom, String emulatorName,
+            String profile, Boolean withSysroot, String sysrootFrom, String copySysrootFromDir,
+            String symlinkSysrootFromDir, String projectSysrootFromRootfs, String emulatorName,
             String emulatorVersion) {
         if (path == null || path.isBlank()) {
             throw RuyiCliException.invalidArgument("Empty venv path");
@@ -782,8 +789,10 @@ public class RuyiCli {
         }
         final var request = RuyiCliRequest.builder().ruyiInstallDir(requireInstallPathResult())
                 .porcelain(true).venv().profile(profile).dest(path).toolchain(toolchainAtom)
-                .sysrootFrom(sysrootFrom).withSysroot(withSysroot).emulator(emulatorAtom).end()
-                .build();
+                .sysrootFrom(sysrootFrom).copySysrootFromDir(copySysrootFromDir)
+                .symlinkSysrootFromDir(symlinkSysrootFromDir)
+                .projectSysrootFromRootfs(projectSysrootFromRootfs).withSysroot(withSysroot)
+                .emulator(emulatorAtom).end().build();
         request.execute();
     }
 

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliRequest.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliRequest.java
@@ -607,6 +607,9 @@ public class RuyiCliRequest {
         private String emulator;
         private Boolean withSysroot = null;
         private String sysrootFrom;
+        private String copySysrootFromDir;
+        private String symlinkSysrootFromDir;
+        private String projectSysrootFromRootfs;
         private String extraCommandsFrom;
 
         private VenvCommandBuilder(Builder parent) {
@@ -656,6 +659,24 @@ public class RuyiCliRequest {
             return this;
         }
 
+        /** Sets the directory from which to copy the sysroot. */
+        public VenvCommandBuilder copySysrootFromDir(String copySysrootFromDir) {
+            this.copySysrootFromDir = copySysrootFromDir;
+            return this;
+        }
+
+        /** Sets the directory from which to symlink the sysroot. */
+        public VenvCommandBuilder symlinkSysrootFromDir(String symlinkSysrootFromDir) {
+            this.symlinkSysrootFromDir = symlinkSysrootFromDir;
+            return this;
+        }
+
+        /** Sets the rootfs directory from which to project the sysroot. */
+        public VenvCommandBuilder projectSysrootFromRootfs(String projectSysrootFromRootfs) {
+            this.projectSysrootFromRootfs = projectSysrootFromRootfs;
+            return this;
+        }
+
         /** Sets the package from which to obtain extra commands. */
         public VenvCommandBuilder extraCommandsFrom(String extraCommandsFrom) {
             this.extraCommandsFrom = extraCommandsFrom;
@@ -686,6 +707,15 @@ public class RuyiCliRequest {
             }
             if (sysrootFrom != null && !sysrootFrom.isBlank()) {
                 parent.args("--sysroot-from", sysrootFrom);
+            }
+            if (copySysrootFromDir != null && !copySysrootFromDir.isBlank()) {
+                parent.args("--copy-sysroot-from-dir", copySysrootFromDir);
+            }
+            if (symlinkSysrootFromDir != null && !symlinkSysrootFromDir.isBlank()) {
+                parent.args("--symlink-sysroot-from-dir", symlinkSysrootFromDir);
+            }
+            if (projectSysrootFromRootfs != null && !projectSysrootFromRootfs.isBlank()) {
+                parent.args("--project-sysroot-from-rootfs", projectSysrootFromRootfs);
             }
             if (extraCommandsFrom != null && !extraCommandsFrom.isBlank()) {
                 parent.args("--extra-commands-from", extraCommandsFrom);

--- a/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliVersionSupport.java
+++ b/plugins/org.ruyisdk.ruyi/src/org/ruyisdk/ruyi/services/RuyiCliVersionSupport.java
@@ -8,7 +8,7 @@ import org.ruyisdk.core.ruyi.model.RuyiVersion;
  * {@link RuyiCli} or {@link RuyiCliRequest}, but {@link RuyiCliExecutor}.
  */
 public final class RuyiCliVersionSupport {
-    private static final RuyiVersion MIN_SUPPORTED_VERSION = new RuyiVersion(0, 47, 0);
+    private static final RuyiVersion MIN_SUPPORTED_VERSION = new RuyiVersion(0, 49, 0);
     private static final Pattern VERSION_PATTERN =
             Pattern.compile("(?m)^Ruyi\\s+(\\d+\\.\\d+\\.\\d+)\\b");
 
@@ -52,7 +52,7 @@ public final class RuyiCliVersionSupport {
      * Checks whether a parsed ruyi version is supported by this plugin.
      *
      * @param version parsed installed version
-     * @return true when version is 0.47.0 or newer, false otherwise
+     * @return true when version is {@link #MIN_SUPPORTED_VERSION} or newer, false otherwise
      */
     public static boolean isSupportedVersion(RuyiVersion version) {
         return version != null && version.compareTo(MIN_SUPPORTED_VERSION) >= 0;
@@ -68,7 +68,7 @@ public final class RuyiCliVersionSupport {
     }
 
     /**
-     * Validates that a parsed ruyi version is 0.47.0 or newer.
+     * Validates that a parsed ruyi version is {@link #MIN_SUPPORTED_VERSION} or newer.
      *
      * @param version parsed installed version
      * @throws RuyiCliException when version is unsupported

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvDetectionService.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/model/VenvDetectionService.java
@@ -132,14 +132,19 @@ public class VenvDetectionService {
 
     /** Creates a new venv via the Ruyi CLI. */
     public void createVenv(String path, String toolchainName, String toolchainVersion,
-            String profile, Boolean withSysroot, String sysrootFrom, String emulatorName,
+            String profile, Boolean withSysroot, String sysrootFrom, String copySysrootFromDir,
+            String symlinkSysrootFromDir, String projectSysrootFromRootfs, String emulatorName,
             String emulatorVersion) {
         LOGGER.logInfo(String.format(
-                "Creating venv: path=%s, profile=%s, toolchain=%s:%s, withSysroot=%s, sysrootFrom=%s, emulator=%s:%s",
+                "Creating venv: path=%s, profile=%s, toolchain=%s:%s, withSysroot=%s, sysrootFrom=%s, "
+                        + "copySysrootFromDir=%s, symlinkSysrootFromDir=%s, projectSysrootFromRootfs=%s, "
+                        + "emulator=%s:%s",
                 path, profile, toolchainName, toolchainVersion, withSysroot, sysrootFrom,
-                emulatorName, emulatorVersion));
+                copySysrootFromDir, symlinkSysrootFromDir, projectSysrootFromRootfs, emulatorName,
+                emulatorVersion));
         RuyiCli.createVenv(path, toolchainName, toolchainVersion, profile, withSysroot, sysrootFrom,
-                emulatorName, emulatorVersion);
+                copySysrootFromDir, symlinkSysrootFromDir, projectSysrootFromRootfs, emulatorName,
+                emulatorVersion);
         refreshWorkspaceProjects(null);
         notifyVenvInventoryChanged();
         LOGGER.logInfo("Venv creation finished: path=" + path);

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
@@ -48,6 +48,7 @@ public class VenvWizardViewModel {
     private int selectedSysrootPackageIndex = -1;
     private int selectedSysrootPackageVersionIndex = -1;
     private String sysrootPackageDisplayText = "";
+    private String sysrootDirectoryPath = "";
 
     private String venvLocation = "";
     private boolean venvLocationReadOnly = false;
@@ -64,7 +65,22 @@ public class VenvWizardViewModel {
         /** Use the sysroot included with the selected toolchain. */
         DEFAULT_SYSROOT,
         /** Use the sysroot from another installed package. */
-        FOREIGN_TOOLCHAIN
+        FOREIGN_TOOLCHAIN,
+        /** Copy sysroot from an existing directory. */
+        COPY_FROM_DIRECTORY,
+        /** Symlink sysroot to an existing directory. */
+        SYMLINK_FROM_DIRECTORY,
+        /** Project sysroot from a distro rootfs directory. */
+        PROJECT_FROM_ROOTFS
+    }
+
+    private static boolean usesSysrootDirectory(SysrootOption option) {
+        return switch (option) {
+            case SysrootOption.COPY_FROM_DIRECTORY -> true;
+            case SysrootOption.SYMLINK_FROM_DIRECTORY -> true;
+            case SysrootOption.PROJECT_FROM_ROOTFS -> true;
+            default -> false;
+        };
     }
 
     /** Creates a new view model instance. */
@@ -107,6 +123,10 @@ public class VenvWizardViewModel {
 
         if (sysrootOption == SysrootOption.FOREIGN_TOOLCHAIN) {
             if (!isSysrootPackageSelected()) {
+                return false;
+            }
+        } else if (usesSysrootDirectory(sysrootOption)) {
+            if (sysrootDirectoryPath == null || sysrootDirectoryPath.isBlank()) {
                 return false;
             }
         }
@@ -182,10 +202,22 @@ public class VenvWizardViewModel {
         sb.append('\n');
 
         sb.append("Sysroot: ");
-        if (sysrootOption == SysrootOption.FOREIGN_TOOLCHAIN && isSysrootPackageSelected()) {
-            final var pkg = getSysrootToolchains().get(selectedSysrootPackageIndex);
-            final var ver = pkg.getVersions().get(selectedSysrootPackageVersionIndex);
-            sb.append(String.format("copy from %s(%s)", pkg.getName(), ver));
+        if (sysrootOption == SysrootOption.DEFAULT_SYSROOT) {
+            sb.append("using included sysroot");
+        } else if (sysrootOption == SysrootOption.NONE_SYSROOT) {
+            sb.append("none");
+        } else if (sysrootOption == SysrootOption.FOREIGN_TOOLCHAIN) {
+            if (isSysrootPackageSelected()) {
+                final var pkg = getSysrootToolchains().get(selectedSysrootPackageIndex);
+                final var ver = pkg.getVersions().get(selectedSysrootPackageVersionIndex);
+                sb.append(String.format("copy from %s(%s)", pkg.getName(), ver));
+            }
+        } else if (sysrootOption == SysrootOption.COPY_FROM_DIRECTORY) {
+            sb.append("copy from directory: ").append(sysrootDirectoryPath);
+        } else if (sysrootOption == SysrootOption.SYMLINK_FROM_DIRECTORY) {
+            sb.append("symlink from directory: ").append(sysrootDirectoryPath);
+        } else if (sysrootOption == SysrootOption.PROJECT_FROM_ROOTFS) {
+            sb.append("project from rootfs: ").append(sysrootDirectoryPath);
         } else {
             sb.append(sysrootOption.toString());
         }
@@ -333,10 +365,12 @@ public class VenvWizardViewModel {
     }
 
     private void createVenv(String path, String toolchainName, String toolchainVersion,
-            String profile, Boolean withSysroot, String sysrootFrom, String emulatorName,
+            String profile, Boolean withSysroot, String sysrootFrom, String copySysrootFromDir,
+            String symlinkSysrootFromDir, String projectSysrootFromRootfs, String emulatorName,
             String emulatorVersion) {
         service.createVenv(path, toolchainName, toolchainVersion, profile, withSysroot, sysrootFrom,
-                emulatorName, emulatorVersion);
+                copySysrootFromDir, symlinkSysrootFromDir, projectSysrootFromRootfs, emulatorName,
+                emulatorVersion);
     }
 
     /** Creates a virtual environment using the current wizard selections. */
@@ -365,6 +399,9 @@ public class VenvWizardViewModel {
 
         Boolean withSysroot = null;
         String sysrootFromAtom = null;
+        String copySysrootFromDir = null;
+        String symlinkSysrootFromDir = null;
+        String projectSysrootFromRootfs = null;
         if (this.sysrootOption == SysrootOption.DEFAULT_SYSROOT) {
             withSysroot = true;
         } else if (this.sysrootOption == SysrootOption.NONE_SYSROOT) {
@@ -377,6 +414,24 @@ public class VenvWizardViewModel {
             final var pkg = getSysrootToolchains().get(selectedSysrootPackageIndex);
             final var ver = pkg.getVersions().get(selectedSysrootPackageVersionIndex);
             sysrootFromAtom = String.format("%s(%s)", pkg.getName(), ver);
+        } else if (this.sysrootOption == SysrootOption.COPY_FROM_DIRECTORY) {
+            if (sysrootDirectoryPath == null || sysrootDirectoryPath.isBlank()) {
+                throw RuyiCliException
+                        .invalidArgument("Copy sysroot from directory selected but no path set");
+            }
+            copySysrootFromDir = sysrootDirectoryPath;
+        } else if (this.sysrootOption == SysrootOption.SYMLINK_FROM_DIRECTORY) {
+            if (sysrootDirectoryPath == null || sysrootDirectoryPath.isBlank()) {
+                throw RuyiCliException
+                        .invalidArgument("Symlink sysroot from directory selected but no path set");
+            }
+            symlinkSysrootFromDir = sysrootDirectoryPath;
+        } else if (this.sysrootOption == SysrootOption.PROJECT_FROM_ROOTFS) {
+            if (sysrootDirectoryPath == null || sysrootDirectoryPath.isBlank()) {
+                throw RuyiCliException
+                        .invalidArgument("Project sysroot from rootfs selected but no path set");
+            }
+            projectSysrootFromRootfs = sysrootDirectoryPath;
         }
 
         String emulatorName = null;
@@ -394,7 +449,8 @@ public class VenvWizardViewModel {
         final var target = new File(parent, name);
         final var path = target.getPath();
         createVenv(path, toolchainName, toolchainVersion, profile, withSysroot, sysrootFromAtom,
-                emulatorName, emulatorVersion);
+                copySysrootFromDir, symlinkSysrootFromDir, projectSysrootFromRootfs, emulatorName,
+                emulatorVersion);
     }
 
     /** Returns available profiles. */
@@ -544,6 +600,9 @@ public class VenvWizardViewModel {
             setSelectedSysrootPackageIndex(-1);
             setSelectedSysrootPackageVersionIndex(-1);
         }
+        if (!usesSysrootDirectory(option)) {
+            setSysrootDirectoryPath("");
+        }
         recomputeDerivedState();
     }
 
@@ -587,6 +646,20 @@ public class VenvWizardViewModel {
     /** Returns the display text describing the selected sysroot package. */
     public String getSysrootPackageDisplayText() {
         return sysrootPackageDisplayText;
+    }
+
+    /** Returns the selected sysroot directory path for directory-based options. */
+    public String getSysrootDirectoryPath() {
+        return sysrootDirectoryPath;
+    }
+
+    /** Sets the selected sysroot directory path for directory-based options. */
+    public void setSysrootDirectoryPath(String path) {
+        final var normalized = path == null ? "" : path;
+        final var old = this.sysrootDirectoryPath;
+        this.sysrootDirectoryPath = normalized;
+        pcs.firePropertyChange("sysrootDirectoryPath", old, this.sysrootDirectoryPath);
+        recomputeDerivedState();
     }
 
     private void updateSysrootPackageDisplayText() {

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
@@ -22,11 +22,13 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.DirectoryDialog;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.Text;
 import org.ruyisdk.ruyi.services.PackageIndexUpdater;
 import org.ruyisdk.venv.model.Emulator;
 import org.ruyisdk.venv.model.Profile;
@@ -59,7 +61,12 @@ public class WizardConfigPage extends WizardPage {
     private Button sysrootDefaultRadio;
     private Button sysrootNoneRadio;
     private Button sysrootForeignRadio;
+    private Button sysrootCopyFromDirectoryRadio;
+    private Button sysrootSymlinkFromDirectoryRadio;
+    private Button sysrootProjectFromRootfsRadio;
     private Link sysrootPackageLink;
+    private Text sysrootDirectoryText;
+    private Button sysrootDirectoryBrowseButton;
 
     WizardConfigPage(VenvWizardViewModel viewModel) {
         super("configurationPage");
@@ -371,7 +378,7 @@ public class WizardConfigPage extends WizardPage {
         // sysroot
         {
             sysrootDefaultRadio = new Button(sysrootGroup, SWT.RADIO);
-            sysrootDefaultRadio.setText("Using included sysroot");
+            sysrootDefaultRadio.setText("Include sysroot from selected toolchain");
             {
                 final var gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
                 gridData.horizontalSpan = 2;
@@ -379,7 +386,7 @@ public class WizardConfigPage extends WizardPage {
             }
 
             sysrootNoneRadio = new Button(sysrootGroup, SWT.RADIO);
-            sysrootNoneRadio.setText("None sysroot (only for advanced users)");
+            sysrootNoneRadio.setText("Do not include sysroot");
             {
                 final var gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
                 gridData.horizontalSpan = 2;
@@ -387,7 +394,7 @@ public class WizardConfigPage extends WizardPage {
             }
 
             sysrootForeignRadio = new Button(sysrootGroup, SWT.RADIO);
-            sysrootForeignRadio.setText("Use sysroot from specified package:");
+            sysrootForeignRadio.setText("Copy sysroot from specified package:");
             sysrootForeignRadio.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
 
             sysrootPackageLink = new Link(sysrootGroup, SWT.NONE);
@@ -398,6 +405,57 @@ public class WizardConfigPage extends WizardPage {
                 @Override
                 public void widgetSelected(SelectionEvent e) {
                     openSysrootPackageDialog();
+                }
+            });
+
+            sysrootCopyFromDirectoryRadio = new Button(sysrootGroup, SWT.RADIO);
+            sysrootCopyFromDirectoryRadio.setText("Copy sysroot from directory");
+            {
+                final var gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+                gridData.horizontalSpan = 2;
+                sysrootCopyFromDirectoryRadio.setLayoutData(gridData);
+            }
+
+            sysrootSymlinkFromDirectoryRadio = new Button(sysrootGroup, SWT.RADIO);
+            sysrootSymlinkFromDirectoryRadio.setText("Symlink sysroot from directory");
+            {
+                final var gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+                gridData.horizontalSpan = 2;
+                sysrootSymlinkFromDirectoryRadio.setLayoutData(gridData);
+            }
+
+            sysrootProjectFromRootfsRadio = new Button(sysrootGroup, SWT.RADIO);
+            sysrootProjectFromRootfsRadio.setText("Project sysroot from rootfs directory");
+            {
+                final var gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+                gridData.horizontalSpan = 2;
+                sysrootProjectFromRootfsRadio.setLayoutData(gridData);
+            }
+
+            final var sysrootPathComposite = new Composite(sysrootGroup, SWT.NONE);
+            {
+                final var gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+                gridData.horizontalSpan = 2;
+                sysrootPathComposite.setLayoutData(gridData);
+            }
+            {
+                final var gridLayout = new GridLayout(2, false);
+                gridLayout.marginWidth = 0;
+                sysrootPathComposite.setLayout(gridLayout);
+            }
+
+            sysrootDirectoryText = new Text(sysrootPathComposite, SWT.BORDER);
+            sysrootDirectoryText.setMessage("Select source directory path");
+            sysrootDirectoryText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+            sysrootDirectoryText.setEnabled(false);
+
+            sysrootDirectoryBrowseButton = new Button(sysrootPathComposite, SWT.PUSH);
+            sysrootDirectoryBrowseButton.setText("Browse...");
+            sysrootDirectoryBrowseButton.setEnabled(false);
+            sysrootDirectoryBrowseButton.addSelectionListener(new SelectionAdapter() {
+                @Override
+                public void widgetSelected(SelectionEvent e) {
+                    openSysrootDirectoryDialog();
                 }
             });
         }
@@ -644,19 +702,39 @@ public class WizardConfigPage extends WizardPage {
                         WidgetProperties.buttonSelection().observe(sysrootNoneRadio));
                 sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.FOREIGN_TOOLCHAIN,
                         WidgetProperties.buttonSelection().observe(sysrootForeignRadio));
+                sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.COPY_FROM_DIRECTORY,
+                        WidgetProperties.buttonSelection().observe(sysrootCopyFromDirectoryRadio));
+                sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.SYMLINK_FROM_DIRECTORY,
+                        WidgetProperties.buttonSelection()
+                                .observe(sysrootSymlinkFromDirectoryRadio));
+                sysrootSelection.addOption(VenvWizardViewModel.SysrootOption.PROJECT_FROM_ROOTFS,
+                        WidgetProperties.buttonSelection().observe(sysrootProjectFromRootfsRadio));
             }
             final var sysrootOptionObservable = BeanProperties.value(VenvWizardViewModel.class,
                     "sysrootOption", VenvWizardViewModel.SysrootOption.class).observe(viewModel);
             final var displayTextObservable = BeanProperties
                     .value(VenvWizardViewModel.class, "sysrootPackageDisplayText", String.class)
                     .observe(viewModel);
+            final var sysrootDirectoryObservable = BeanProperties
+                    .value(VenvWizardViewModel.class, "sysrootDirectoryPath", String.class)
+                    .observe(viewModel);
 
             dbc.bindValue(sysrootSelection, sysrootOptionObservable);
+            dbc.bindValue(WidgetProperties.text(SWT.Modify).observe(sysrootDirectoryText),
+                    sysrootDirectoryObservable);
 
             sysrootOptionObservable.addValueChangeListener(e -> {
                 final var fromPkg = viewModel
                         .getSysrootOption() == VenvWizardViewModel.SysrootOption.FOREIGN_TOOLCHAIN;
+                final var fromDirectory = switch (viewModel.getSysrootOption()) {
+                    case VenvWizardViewModel.SysrootOption.COPY_FROM_DIRECTORY -> true;
+                    case VenvWizardViewModel.SysrootOption.SYMLINK_FROM_DIRECTORY -> true;
+                    case VenvWizardViewModel.SysrootOption.PROJECT_FROM_ROOTFS -> true;
+                    default -> false;
+                };
                 sysrootPackageLink.setEnabled(fromPkg);
+                sysrootDirectoryText.setEnabled(fromDirectory);
+                sysrootDirectoryBrowseButton.setEnabled(fromDirectory);
             });
 
             displayTextObservable.addValueChangeListener(e -> {
@@ -686,6 +764,20 @@ public class WizardConfigPage extends WizardPage {
     private void openSysrootPackageDialog() {
         final var dialog = new SysrootPackageSelectionDialog(getShell(), viewModel);
         dialog.open();
+    }
+
+    private void openSysrootDirectoryDialog() {
+        final var dialog = new DirectoryDialog(getShell());
+        dialog.setText("Select sysroot source directory");
+        dialog.setMessage("Choose a source directory for sysroot provisioning.");
+        final var currentPath = viewModel.getSysrootDirectoryPath();
+        if (currentPath != null && !currentPath.isBlank()) {
+            dialog.setFilterPath(currentPath);
+        }
+        final var selectedPath = dialog.open();
+        if (selectedPath != null) {
+            viewModel.setSysrootDirectoryPath(selectedPath);
+        }
     }
 
     private void performUpdateAndRefresh() {

--- a/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/services/RuyiCliVersionSupportTest.java
+++ b/tests/org.ruyisdk.ruyi.tests/src/org/ruyisdk/ruyi/services/RuyiCliVersionSupportTest.java
@@ -41,15 +41,10 @@ public class RuyiCliVersionSupportTest {
     }
 
     @Test
-    public void isSupportedVersionAccepts047BugfixRelease() {
-        assertTrue(RuyiCliVersionSupport.isSupportedVersion(new RuyiVersion(0, 47, 9)));
-    }
-
-    @Test
     public void isSupportedVersionAcceptsNewerMinorAndMajor() {
-        assertFalse(RuyiCliVersionSupport.isSupportedVersion(new RuyiVersion(0, 46, 9)));
-        assertTrue(RuyiCliVersionSupport.isSupportedVersion(new RuyiVersion(0, 47, 0)));
-        assertTrue(RuyiCliVersionSupport.isSupportedVersion(new RuyiVersion(0, 48, 0)));
+        assertFalse(RuyiCliVersionSupport.isSupportedVersion(new RuyiVersion(0, 48, 9)));
+        assertTrue(RuyiCliVersionSupport.isSupportedVersion(new RuyiVersion(0, 49, 0)));
+        assertTrue(RuyiCliVersionSupport.isSupportedVersion(new RuyiVersion(0, 50, 0)));
         assertTrue(RuyiCliVersionSupport.isSupportedVersion(new RuyiVersion(1, 0, 0)));
     }
 
@@ -62,7 +57,7 @@ public class RuyiCliVersionSupportTest {
             threw = true;
             Assertions.assertThat(e.getMessage()).isEqualTo(String.format(
                             "Installed ruyi version %s is unsupported. Minimum required version is %s",
-                            new RuyiVersion(0, 46, 3), new RuyiVersion(0, 47, 0)));
+                            new RuyiVersion(0, 46, 3), new RuyiVersion(0, 49, 0)));
         }
         assertTrue(threw);
     }


### PR DESCRIPTION
Screenshot for comparison:

<img height="300" alt="the first page of the wizard for venv configuration" src="https://github.com/user-attachments/assets/d6c729fe-ea1d-4521-9997-d38acad16804" />

.

## Summary by Sourcery

Update venv wizard and backend to support additional sysroot provisioning modes and require newer Ruyi CLI versions.

New Features:
- Add UI options in the venv configuration wizard to copy, symlink, or project a sysroot from a user-selected directory or rootfs.
- Allow specifying sysroot source directories when creating virtual environments, propagating them through the view model, detection service, and Ruyi CLI request builder to CLI flags.

Enhancements:
- Improve sysroot option labels and summary text in the wizard to better describe behavior and clarify when no sysroot is included.
- Reset and validate sysroot-related state when switching options to prevent incomplete configuration.

Tests:
- Update Ruyi CLI version support tests to reflect the new minimum supported version.

Chores:
- Raise the minimum supported Ruyi CLI version from 0.47.0 to 0.49.0 and align version checks and documentation comments.