### PR TITLE
feat(promotion): add "remind me later"

### DIFF
--- a/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/PromotionStartup.java
+++ b/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/PromotionStartup.java
@@ -1,5 +1,7 @@
 package org.ruyisdk.promotion;
 
+import java.util.concurrent.TimeUnit;
+import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.ui.IStartup;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
@@ -16,6 +18,9 @@ import org.ruyisdk.promotion.views.WebsiteView;
 public class PromotionStartup implements IStartup {
 
     private static final PluginLogger LOGGER = Activator.getLogger();
+    private static final Activator ACTIVATOR = Activator.getDefault();
+    private static final String QUESTIONNAIRE_REMIND_UNTIL_KEY = "questionnaire.remindUntilMillis";
+    private static final long REMIND_DURATION_MILLIS = TimeUnit.DAYS.toMillis(1);
 
     @Override
     public void earlyStartup() {
@@ -37,9 +42,38 @@ public class PromotionStartup implements IStartup {
                         LOGGER.logError("Failed to open RuyiSDK Website View", e);
                     }
                 }
-
-                new QuestionnaireDialog(window.getShell()).open();
+                if (shouldShowQuestionnaireDialog()) {
+                    final int result = new QuestionnaireDialog(window.getShell()).open();
+                    if (result == IDialogConstants.OK_ID) {
+                        setQuestionnaireRemindUntil();
+                    } else {
+                        clearQuestionnaireRemindUntil();
+                    }
+                }
             }
         });
+    }
+
+    private boolean shouldShowQuestionnaireDialog() {
+        if (ACTIVATOR == null) {
+            return true;
+        }
+        final var remindUntilMillis =
+                ACTIVATOR.getPreferenceStore().getLong(QUESTIONNAIRE_REMIND_UNTIL_KEY);
+        return System.currentTimeMillis() >= remindUntilMillis;
+    }
+
+    private void setQuestionnaireRemindUntil() {
+        if (ACTIVATOR != null) {
+            final var remindUntilMillis = System.currentTimeMillis() + REMIND_DURATION_MILLIS;
+            ACTIVATOR.getPreferenceStore().setValue(QUESTIONNAIRE_REMIND_UNTIL_KEY,
+                    remindUntilMillis);
+        }
+    }
+
+    private void clearQuestionnaireRemindUntil() {
+        if (ACTIVATOR != null) {
+            ACTIVATOR.getPreferenceStore().setValue(QUESTIONNAIRE_REMIND_UNTIL_KEY, 0L);
+        }
     }
 }

--- a/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/dialogs/QuestionnaireDialog.java
+++ b/plugins/org.ruyisdk.promotion/src/org/ruyisdk/promotion/dialogs/QuestionnaireDialog.java
@@ -75,7 +75,7 @@ public class QuestionnaireDialog extends Dialog {
 
     @Override
     protected void createButtonsForButtonBar(Composite parent) {
-        createButton(parent, IDialogConstants.OK_ID, IDialogConstants.OK_LABEL, true);
+        createButton(parent, IDialogConstants.OK_ID, "Remind me later", true);
     }
 
     @Override


### PR DESCRIPTION
## Summary by Sourcery

Add a snooze mechanism for the promotion questionnaire dialog that respects a user-specific "remind me later" preference.

New Features:
- Introduce a "Remind me later" option for the promotion questionnaire dialog to postpone future prompts for a defined period.

Enhancements:
- Persist questionnaire reminder state using plugin preferences so the dialog is only shown after the snooze period expires.