### PR TITLE
docs: add notice about beta release version number sorting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:  # manual release trigger
     inputs:
       version:
-        description: The version number to release. Use "vX.Y.Z-beta.N" for beta releases, or "vX.Y.Z" for final releases. For beta releases, N is considered in natural sort order during comparison.
+        description: The version number to release. Use "vX.Y.Z-beta.N" for beta releases, or "vX.Y.Z" for final releases. For beta releases, N is compared as an integer (for example, vX.Y.Z-beta.10 is greater than vX.Y.Z-beta.2).
         required: true
         type: string
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:  # manual release trigger
     inputs:
       version:
-        description: The version number to release. Use "vX.Y.Z-beta.N" for beta releases, or "vX.Y.Z" for final releases.
+        description: The version number to release. Use "vX.Y.Z-beta.N" for beta releases, or "vX.Y.Z" for final releases. For beta releases, N is considered in natural sort order during comparison.
         required: true
         type: string
 

--- a/docs/developer/CONTRIBUTING.md
+++ b/docs/developer/CONTRIBUTING.md
@@ -27,7 +27,7 @@
 Steps:
 
 - Update hard-coded version number by running `./mvnw tycho-versions:set-version -DnewVersion=X.Y.Z-SNAPSHOT` and make a commit:
-  - Use tag `vX.Y.Z-beta.N` for beta versions. N is considered in natural sort order during comparison.
+  - Use tag `vX.Y.Z-beta.N` for beta versions. N is compared as an integer (for example, vX.Y.Z-beta.10 is greater than vX.Y.Z-beta.2).
   - Use tag `vX.Y.Z` for final versions.
   - The tag `continuous` is used by the CI, so developers should NOT touch it.
   - Do NOT use any other string as the tag name.

--- a/docs/developer/CONTRIBUTING.md
+++ b/docs/developer/CONTRIBUTING.md
@@ -27,7 +27,7 @@
 Steps:
 
 - Update hard-coded version number by running `./mvnw tycho-versions:set-version -DnewVersion=X.Y.Z-SNAPSHOT` and make a commit:
-  - Use tag `vX.Y.Z-beta.N` for beta versions.
+  - Use tag `vX.Y.Z-beta.N` for beta versions. N is considered in natural sort order during comparison.
   - Use tag `vX.Y.Z` for final versions.
   - The tag `continuous` is used by the CI, so developers should NOT touch it.
   - Do NOT use any other string as the tag name.


### PR DESCRIPTION
1 < 2 < 10.

## Summary by Sourcery

Clarify how beta release version numbers are compared and sorted across CI and contributor documentation.

CI:
- Update CI workflow input description to explain natural sort ordering for beta version suffix N.

Documentation:
- Document that beta tag suffix N in version strings is compared using natural sort order in CONTRIBUTING guide.