### PR TITLE
feat(venv): disable option when no sysroot is in toolchain package; feat(venv): put both toolchain and sysroot in one column within wizard;

### DIFF
--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
@@ -28,6 +28,7 @@ public class VenvWizardViewModel {
     private final VenvDetectionService service;
 
     private boolean configurationPageComplete;
+    private boolean defaultSysrootOptionAvailable;
     private String summaryText = "";
 
     private final List<Profile> profiles = new ArrayList<>();
@@ -60,7 +61,10 @@ public class VenvWizardViewModel {
 
     /** Available sysroot selection strategies. */
     public enum SysrootOption {
-        /** Do not include a sysroot. */
+        /**
+         * Do not include a sysroot. Don't use this as fallback, otherwise new users may be
+         * confused.
+         */
         NONE_SYSROOT,
         /** Use the sysroot included with the selected toolchain. */
         DEFAULT_SYSROOT,
@@ -89,8 +93,25 @@ public class VenvWizardViewModel {
     }
 
     private void recomputeDerivedState() {
+        recomputeDefaultSysrootOptionAvailable();
+        enforceDefaultSysrootOptionAvailable();
         updateSummaryText();
         recomputeConfigurationPageComplete();
+    }
+
+    private void recomputeDefaultSysrootOptionAvailable() {
+        final var old = this.defaultSysrootOptionAvailable;
+        this.defaultSysrootOptionAvailable =
+                selectedToolchainIndex >= 0 && selectedToolchainIndex < toolchains.size()
+                        && toolchains.get(selectedToolchainIndex).hasIncludedSysroot();;
+        pcs.firePropertyChange("defaultSysrootOptionAvailable", old,
+                this.defaultSysrootOptionAvailable);
+    }
+
+    private void enforceDefaultSysrootOptionAvailable() {
+        if (sysrootOption == SysrootOption.DEFAULT_SYSROOT && !defaultSysrootOptionAvailable) {
+            setSysrootOption(SysrootOption.FOREIGN_TOOLCHAIN);
+        }
     }
 
     private void updateSummaryText() {
@@ -591,8 +612,16 @@ public class VenvWizardViewModel {
         return sysrootOption;
     }
 
+    /** Returns whether the selected toolchain can provide the default sysroot. */
+    public boolean isDefaultSysrootOptionAvailable() {
+        return defaultSysrootOptionAvailable;
+    }
+
     /** Sets the sysroot selection option. */
     public void setSysrootOption(SysrootOption option) {
+        if (option == SysrootOption.DEFAULT_SYSROOT && !defaultSysrootOptionAvailable) {
+            option = SysrootOption.FOREIGN_TOOLCHAIN;
+        }
         final var old = this.sysrootOption;
         this.sysrootOption = option;
         pcs.firePropertyChange("sysrootOption", old, this.sysrootOption);

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
@@ -103,7 +103,7 @@ public class VenvWizardViewModel {
         final var old = this.defaultSysrootOptionAvailable;
         this.defaultSysrootOptionAvailable =
                 selectedToolchainIndex >= 0 && selectedToolchainIndex < toolchains.size()
-                        && toolchains.get(selectedToolchainIndex).hasIncludedSysroot();;
+                        && toolchains.get(selectedToolchainIndex).hasIncludedSysroot();
         pcs.firePropertyChange("defaultSysrootOptionAvailable", old,
                 this.defaultSysrootOptionAvailable);
     }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
@@ -712,14 +712,20 @@ public class WizardConfigPage extends WizardPage {
             }
             final var sysrootOptionObservable = BeanProperties.value(VenvWizardViewModel.class,
                     "sysrootOption", VenvWizardViewModel.SysrootOption.class).observe(viewModel);
+            final var defaultSysrootOptionAvailableObservable =
+                    BeanProperties.value(VenvWizardViewModel.class, "defaultSysrootOptionAvailable",
+                            Boolean.class).observe(viewModel);
             final var displayTextObservable = BeanProperties
                     .value(VenvWizardViewModel.class, "sysrootPackageDisplayText", String.class)
                     .observe(viewModel);
             final var sysrootDirectoryObservable = BeanProperties
                     .value(VenvWizardViewModel.class, "sysrootDirectoryPath", String.class)
                     .observe(viewModel);
+            final var sysrootDefaultEnabled =
+                    WidgetProperties.enabled().observe(sysrootDefaultRadio);
 
             dbc.bindValue(sysrootSelection, sysrootOptionObservable);
+            dbc.bindValue(sysrootDefaultEnabled, defaultSysrootOptionAvailableObservable);
             dbc.bindValue(WidgetProperties.text(SWT.Modify).observe(sysrootDirectoryText),
                     sysrootDirectoryObservable);
 

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
@@ -148,6 +148,22 @@ public class WizardConfigPage extends WizardPage {
             profileComposite.setLayout(gridLayout);
         }
 
+        emulatorHeader = new Composite(leftColumn, SWT.NONE);
+        emulatorHeader.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+        {
+            final var gridLayout = new GridLayout(2, false);
+            gridLayout.marginWidth = 0;
+            emulatorHeader.setLayout(gridLayout);
+        }
+
+        emulatorComposite = new Composite(leftColumn, SWT.NONE);
+        emulatorComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        {
+            final var gridLayout = new GridLayout(2, false);
+            gridLayout.marginWidth = 0;
+            emulatorComposite.setLayout(gridLayout);
+        }
+
         toolchainComposite = new Composite(rightColumn, SWT.NONE);
         toolchainComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         {
@@ -156,25 +172,9 @@ public class WizardConfigPage extends WizardPage {
             toolchainComposite.setLayout(gridLayout);
         }
 
-        emulatorHeader = new Composite(rightColumn, SWT.NONE);
-        emulatorHeader.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
-        {
-            final var gridLayout = new GridLayout(2, false);
-            gridLayout.marginWidth = 0;
-            emulatorHeader.setLayout(gridLayout);
-        }
-
-        emulatorComposite = new Composite(rightColumn, SWT.NONE);
-        emulatorComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-        {
-            final var gridLayout = new GridLayout(2, false);
-            gridLayout.marginWidth = 0;
-            emulatorComposite.setLayout(gridLayout);
-        }
-
-        sysrootGroup = new Group(leftColumn, SWT.NONE);
+        sysrootGroup = new Group(rightColumn, SWT.NONE);
         sysrootGroup.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-        sysrootGroup.setText("");
+        sysrootGroup.setText("Sysroot Provisioning Options");
         {
             // columns: radio buttons, a package info link.
             final var gridLayout = new GridLayout(2, false);


### PR DESCRIPTION
Comparison of the state of radio buttons for the presence of sysroot:

<img width="500" alt="Screenshot of two the same page in venv wizard that demonstrate the code change" src="https://github.com/user-attachments/assets/9c63b1a2-3f42-455d-9494-55ce5485557f" />

.

## Summary by Sourcery

Update the venv wizard to better handle sysroot availability and reorganize the configuration UI.

New Features:
- Expose whether the selected toolchain provides a default sysroot as a view model property and bind it to the sysroot default option control.

Enhancements:
- Automatically fall back from the default sysroot option when the selected toolchain has no included sysroot, preventing invalid configurations.
- Rearrange the wizard layout so emulator and sysroot options share a column and label the sysroot options group for clearer provisioning choices.