### PR TITLE
feat(venv): async load package data; ViewModel owns data updates

### DIFF
--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
@@ -12,6 +12,10 @@ import java.util.List;
 import java.util.Set;
 import org.eclipse.core.databinding.observable.list.IObservableList;
 import org.eclipse.core.databinding.observable.list.WritableList;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.swt.widgets.Display;
 import org.ruyisdk.ruyi.services.RuyiCliException;
 import org.ruyisdk.venv.model.Emulator;
 import org.ruyisdk.venv.model.Profile;
@@ -31,19 +35,31 @@ public class VenvWizardViewModel {
     private boolean defaultSysrootOptionAvailable;
     private String summaryText = "";
 
-    private final List<Profile> profiles = new ArrayList<>();
+    private boolean dataLoading;
+    private String loadingMessage = "";
+    private String loadingErrorMessage = "";
+    private boolean dataLoadStarted;
+
+    private final IObservableList<Profile> profiles =
+            new WritableList<>(new ArrayList<>(), Profile.class);
     private int selectedProfileIndex = -1;
 
-    private final List<Toolchain> toolchains = new ArrayList<>();
+    private final IObservableList<Toolchain> toolchains =
+            new WritableList<>(new ArrayList<>(), Toolchain.class);
     private final List<Toolchain> allToolchains = new ArrayList<>();
     private int selectedToolchainIndex = -1;
     private int selectedToolchainVersionIndex = -1;
+    private final IObservableList<String> toolchainVersions =
+            new WritableList<>(new ArrayList<>(), String.class);
 
-    private final List<Emulator> emulators = new ArrayList<>();
+    private final IObservableList<Emulator> emulators =
+            new WritableList<>(new ArrayList<>(), Emulator.class);
     private final List<Emulator> allEmulators = new ArrayList<>();
     private int selectedEmulatorIndex = -1;
     private int selectedEmulatorVersionIndex = -1;
     private boolean emulatorEnabled = false;
+    private final IObservableList<String> emulatorVersions =
+            new WritableList<>(new ArrayList<>(), String.class);
 
     private SysrootOption sysrootOption = SysrootOption.DEFAULT_SYSROOT;
     private int selectedSysrootPackageIndex = -1;
@@ -245,35 +261,123 @@ public class VenvWizardViewModel {
         return sb.toString();
     }
 
-    private void loadLists() {
-        profiles.clear();
-        allToolchains.clear();
-        allEmulators.clear();
-        toolchains.clear();
-        emulators.clear();
+    /** Fetched package data, transferred from the background job to the UI thread. */
+    private record FetchedData(List<Profile> profiles, List<Toolchain> toolchains,
+            List<Emulator> emulators) {
+    }
 
+    private FetchedData fetchData() {
+        final var fetchedProfiles = new ArrayList<Profile>();
         final var profileInfos = service.listProfiles();
         if (profileInfos != null) {
             for (final var profileInfo : profileInfos) {
-                profiles.add(new Profile(profileInfo.getName(), profileInfo.getQuirks()));
+                fetchedProfiles.add(new Profile(profileInfo.getName(), profileInfo.getQuirks()));
             }
         }
 
+        final var fetchedToolchains = new ArrayList<Toolchain>();
         final var toolchainInfos = service.listToolchains();
         if (toolchainInfos != null) {
             for (final var toolchainInfo : toolchainInfos) {
-                allToolchains
+                fetchedToolchains
                         .add(new Toolchain(toolchainInfo.getName(), toolchainInfo.getVersions(),
                                 toolchainInfo.getQuirks(), toolchainInfo.hasIncludedSysroot()));
             }
         }
 
+        final var fetchedEmulators = new ArrayList<Emulator>();
         final var emulatorInfos = service.listEmulators();
         if (emulatorInfos != null) {
             for (final var emulatorInfo : emulatorInfos) {
-                allEmulators.add(new Emulator(emulatorInfo.getName(), emulatorInfo.getVersions(),
-                        emulatorInfo.getQuirks()));
+                fetchedEmulators.add(new Emulator(emulatorInfo.getName(),
+                        emulatorInfo.getVersions(), emulatorInfo.getQuirks()));
             }
+        }
+
+        return new FetchedData(fetchedProfiles, fetchedToolchains, fetchedEmulators);
+    }
+
+    private void applyFetchedData(FetchedData data) {
+        final Runnable update = () -> {
+            profiles.clear();
+            profiles.addAll(data.profiles());
+            allToolchains.clear();
+            allToolchains.addAll(data.toolchains());
+            allEmulators.clear();
+            allEmulators.addAll(data.emulators());
+            filterPackagesBySelectedProfile();
+            recomputeDerivedState();
+        };
+        // Observable lists may only be mutated on their own realm.
+        if (profiles.getRealm().isCurrent()) {
+            update.run();
+        } else {
+            profiles.getRealm().asyncExec(update);
+        }
+    }
+
+    /** Loads package lists from the Ruyi CLI and refreshes all view model data. */
+    public void loadAll() {
+        applyFetchedData(fetchData());
+    }
+
+    /**
+     * Loads package lists from the Ruyi CLI asynchronously, keeping the UI responsive. Progress and
+     * failures are reported through the {@code dataLoading}, {@code loadingMessage} and
+     * {@code loadingErrorMessage} properties. Does nothing if a load is already running.
+     */
+    public void loadAllAsync() {
+        if (dataLoading) {
+            return;
+        }
+        dataLoadStarted = true;
+
+        runOnUiThread(() -> {
+            setLoadingErrorMessage("");
+            setDataLoading(true);
+            setLoadingMessage("Loading package data...");
+        });
+
+        final var job = Job.create("Loading package data", monitor -> {
+            if (monitor.isCanceled()) {
+                runOnUiThread(() -> {
+                    setDataLoading(false);
+                    setLoadingMessage("Loading cancelled.");
+                });
+                return Status.CANCEL_STATUS;
+            }
+            try {
+                final var fetched = fetchData();
+                runOnUiThread(() -> {
+                    applyFetchedData(fetched);
+                    setDataLoading(false);
+                    setLoadingMessage("");
+                    setLoadingErrorMessage("");
+                });
+                return Status.OK_STATUS;
+            } catch (Exception e) {
+                final var message = e.getMessage() == null ? e.toString() : e.getMessage();
+                runOnUiThread(() -> {
+                    setDataLoading(false);
+                    setLoadingMessage("");
+                    setLoadingErrorMessage(message);
+                });
+                return new Status(IStatus.ERROR, "org.ruyisdk.venv", "Failed to load package data",
+                        e);
+            }
+        });
+        job.schedule();
+    }
+
+    private static void runOnUiThread(Runnable runnable) {
+        final var display = Display.getDefault();
+        if (display == null || display.isDisposed()) {
+            return;
+        }
+        if (display.getThread() == Thread.currentThread()) {
+            runnable.run();
+        } else {
+            display.asyncExec(runnable);
         }
     }
 
@@ -320,13 +424,6 @@ public class VenvWizardViewModel {
             return providedByPackage.isEmpty();
         }
         return providedByPackage.containsAll(neededByProfile);
-    }
-
-    /** Loads package lists from the Ruyi CLI and refreshes all view model data. */
-    public void loadAll() {
-        loadLists();
-        filterPackagesBySelectedProfile();
-        recomputeDerivedState();
     }
 
     private void installToolchain(String name, String version) {
@@ -474,8 +571,8 @@ public class VenvWizardViewModel {
                 emulatorVersion);
     }
 
-    /** Returns available profiles. */
-    public List<Profile> getProfiles() {
+    /** Returns available profiles as an observable list. */
+    public IObservableList<Profile> getProfiles() {
         return profiles;
     }
 
@@ -520,8 +617,8 @@ public class VenvWizardViewModel {
         setVenvNameInternal(defaultName, false);
     }
 
-    /** Returns available toolchains. */
-    public List<Toolchain> getToolchains() {
+    /** Returns available toolchains as an observable list. */
+    public IObservableList<Toolchain> getToolchains() {
         return toolchains;
     }
 
@@ -536,9 +633,25 @@ public class VenvWizardViewModel {
         this.selectedToolchainIndex = index;
         pcs.firePropertyChange("selectedToolchainIndex", old, this.selectedToolchainIndex);
         if (old != index) {
+            updateToolchainVersions();
             setSelectedToolchainVersionIndex(-1);
         }
         recomputeDerivedState();
+    }
+
+    private void updateToolchainVersions() {
+        toolchainVersions.clear();
+        if (selectedToolchainIndex >= 0 && selectedToolchainIndex < toolchains.size()) {
+            final var versions = toolchains.get(selectedToolchainIndex).getVersions();
+            if (versions != null) {
+                toolchainVersions.addAll(versions);
+            }
+        }
+    }
+
+    /** Returns the versions of the selected toolchain as an observable list. */
+    public IObservableList<String> getToolchainVersions() {
+        return toolchainVersions;
     }
 
     /** Returns the selected toolchain version index. */
@@ -555,8 +668,8 @@ public class VenvWizardViewModel {
         recomputeDerivedState();
     }
 
-    /** Returns available emulators. */
-    public List<Emulator> getEmulators() {
+    /** Returns available emulators as an observable list. */
+    public IObservableList<Emulator> getEmulators() {
         return emulators;
     }
 
@@ -571,9 +684,25 @@ public class VenvWizardViewModel {
         this.selectedEmulatorIndex = index;
         pcs.firePropertyChange("selectedEmulatorIndex", old, this.selectedEmulatorIndex);
         if (old != index) {
+            updateEmulatorVersions();
             setSelectedEmulatorVersionIndex(-1);
         }
         recomputeDerivedState();
+    }
+
+    private void updateEmulatorVersions() {
+        emulatorVersions.clear();
+        if (selectedEmulatorIndex >= 0 && selectedEmulatorIndex < emulators.size()) {
+            final var versions = emulators.get(selectedEmulatorIndex).getVersions();
+            if (versions != null) {
+                emulatorVersions.addAll(versions);
+            }
+        }
+    }
+
+    /** Returns the versions of the selected emulator as an observable list. */
+    public IObservableList<String> getEmulatorVersions() {
+        return emulatorVersions;
     }
 
     /** Returns the selected emulator version index. */
@@ -791,6 +920,47 @@ public class VenvWizardViewModel {
     /** Returns whether the configuration page is complete. */
     public boolean isConfigurationPageComplete() {
         return configurationPageComplete;
+    }
+
+    /** Returns whether package data is currently being loaded. */
+    public boolean isDataLoading() {
+        return dataLoading;
+    }
+
+    /** Sets whether package data is currently being loaded. */
+    public void setDataLoading(boolean loading) {
+        final var old = this.dataLoading;
+        this.dataLoading = loading;
+        pcs.firePropertyChange("dataLoading", old, this.dataLoading);
+    }
+
+    /** Returns the current loading progress message. */
+    public String getLoadingMessage() {
+        return loadingMessage;
+    }
+
+    /** Sets the current loading progress message. */
+    public void setLoadingMessage(String message) {
+        final var old = this.loadingMessage;
+        this.loadingMessage = message == null ? "" : message;
+        pcs.firePropertyChange("loadingMessage", old, this.loadingMessage);
+    }
+
+    /** Returns the last loading error message, or an empty string if none. */
+    public String getLoadingErrorMessage() {
+        return loadingErrorMessage;
+    }
+
+    /** Sets the last loading error message. */
+    public void setLoadingErrorMessage(String message) {
+        final var old = this.loadingErrorMessage;
+        this.loadingErrorMessage = message == null ? "" : message;
+        pcs.firePropertyChange("loadingErrorMessage", old, this.loadingErrorMessage);
+    }
+
+    /** Returns whether asynchronous data loading has been started at least once. */
+    public boolean isDataLoadStarted() {
+        return dataLoadStarted;
     }
 
     /** Adds a property change listener. */

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
@@ -305,7 +305,7 @@ public class VenvWizardViewModel {
             allToolchains.addAll(data.toolchains());
             allEmulators.clear();
             allEmulators.addAll(data.emulators());
-            filterPackagesBySelectedProfile();
+            repopulatePackagesByProfile();
             recomputeDerivedState();
         };
         // Observable lists may only be mutated on their own realm.
@@ -382,10 +382,12 @@ public class VenvWizardViewModel {
     }
 
     /**
-     * Filters toolchains and emulators to match the selected profile's quirks. When no profile is
-     * selected, all packages are shown.
+     * Rebuilds the toolchain and emulator lists to match the selected profile's quirks; when no
+     * profile is selected, all packages are shown. Then resets the toolchain, sysroot, and emulator
+     * selections since the lists changed. The selection setters also empty the toolchain and
+     * emulator version lists.
      */
-    private void filterPackagesBySelectedProfile() {
+    private void repopulatePackagesByProfile() {
         if (selectedProfileIndex < 0 || selectedProfileIndex >= profiles.size()) {
             toolchains.clear();
             toolchains.addAll(allToolchains);
@@ -409,7 +411,8 @@ public class VenvWizardViewModel {
             }
         }
 
-        // Reset selections since the lists changed
+        // Reset any other selections since the data changed. Version lists will be emptied by the
+        // selection setters.
         setSelectedToolchainIndex(-1);
         setSelectedSysrootPackageIndex(-1);
         setSelectedEmulatorIndex(-1);
@@ -587,7 +590,7 @@ public class VenvWizardViewModel {
         this.selectedProfileIndex = index;
         pcs.firePropertyChange("selectedProfileIndex", old, this.selectedProfileIndex);
         applyDefaultVenvNameForSelectedProfile();
-        filterPackagesBySelectedProfile();
+        repopulatePackagesByProfile();
         recomputeDerivedState();
     }
 
@@ -627,15 +630,18 @@ public class VenvWizardViewModel {
         return selectedToolchainIndex;
     }
 
-    /** Sets the selected toolchain index. */
+    /** Sets the selected toolchain index and updates the version list. */
     public void setSelectedToolchainIndex(int index) {
         final var old = this.selectedToolchainIndex;
         this.selectedToolchainIndex = index;
         pcs.firePropertyChange("selectedToolchainIndex", old, this.selectedToolchainIndex);
+
+        // If both values are -1, we don't need to update the already empty version list.
         if (old != index) {
             updateToolchainVersions();
             setSelectedToolchainVersionIndex(-1);
         }
+
         recomputeDerivedState();
     }
 
@@ -678,15 +684,18 @@ public class VenvWizardViewModel {
         return selectedEmulatorIndex;
     }
 
-    /** Sets the selected emulator index. */
+    /** Sets the selected emulator index and updates the version list. */
     public void setSelectedEmulatorIndex(int index) {
         final var old = this.selectedEmulatorIndex;
         this.selectedEmulatorIndex = index;
         pcs.firePropertyChange("selectedEmulatorIndex", old, this.selectedEmulatorIndex);
+
+        // If both values are -1, we don't need to update the already empty version list.
         if (old != index) {
             updateEmulatorVersions();
             setSelectedEmulatorVersionIndex(-1);
         }
+
         recomputeDerivedState();
     }
 

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
@@ -14,6 +14,7 @@ import org.ruyisdk.venv.viewmodel.VenvWizardViewModel;
 public class VenvWizard extends Wizard {
     private final VenvWizardViewModel viewModel;
 
+    private WizardLoadingPage loadingPage;
     private WizardConfigPage configurationPage;
     private WizardLocationPage locationPage;
 
@@ -31,8 +32,8 @@ public class VenvWizard extends Wizard {
 
     @Override
     public void addPages() {
-        viewModel.loadAll();
-
+        loadingPage = new WizardLoadingPage(viewModel);
+        addPage(loadingPage);
         configurationPage = new WizardConfigPage(viewModel);
         addPage(configurationPage);
         locationPage = new WizardLocationPage(viewModel);

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardConfigPage.java
@@ -1,19 +1,19 @@
 package org.ruyisdk.venv.views;
 
-import java.util.List;
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.UpdateValueStrategy;
 import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.core.databinding.conversion.Converter;
 import org.eclipse.core.databinding.observable.value.SelectObservableValue;
 import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
+import org.eclipse.jface.databinding.viewers.ObservableListContentProvider;
 import org.eclipse.jface.databinding.viewers.typed.ViewerProperties;
-import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerComparator;
+import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -73,6 +73,12 @@ public class WizardConfigPage extends WizardPage {
         this.viewModel = viewModel;
         setTitle("Venv Configuration");
         setDescription("Configure profile, toolchains and emulator options.");
+    }
+
+    @Override
+    public IWizardPage getPreviousPage() {
+        // The loading page is a transient first page; never go back to it.
+        return null;
     }
 
     @Override
@@ -226,7 +232,7 @@ public class WizardConfigPage extends WizardPage {
                 });
             }
 
-            profileTableViewer.setContentProvider(ArrayContentProvider.getInstance());
+            profileTableViewer.setContentProvider(new ObservableListContentProvider<Profile>());
 
             final var profileComparator = new ViewerComparator() {
                 private TableColumn sortColumn = nameColumn.getColumn();
@@ -319,7 +325,7 @@ public class WizardConfigPage extends WizardPage {
             tcVersions.setHeaderVisible(false);
             tcVersions.setLinesVisible(true);
 
-            toolchainNamesViewer.setContentProvider(ArrayContentProvider.getInstance());
+            toolchainNamesViewer.setContentProvider(new ObservableListContentProvider<Toolchain>());
             toolchainNamesViewer.setLabelProvider(new ColumnLabelProvider() {
                 @Override
                 public String getText(Object element) {
@@ -328,8 +334,9 @@ public class WizardConfigPage extends WizardPage {
             });
             toolchainNamesViewer.setInput(viewModel.getToolchains());
 
-            toolchainVersionsViewer.setContentProvider(ArrayContentProvider.getInstance());
+            toolchainVersionsViewer.setContentProvider(new ObservableListContentProvider<String>());
             toolchainVersionsViewer.setLabelProvider(new ColumnLabelProvider());
+            toolchainVersionsViewer.setInput(viewModel.getToolchainVersions());
         }
 
         // emulators
@@ -362,7 +369,7 @@ public class WizardConfigPage extends WizardPage {
             evData.widthHint = 300;
             emulatorVersions.setLayoutData(evData);
 
-            emulatorNamesViewer.setContentProvider(ArrayContentProvider.getInstance());
+            emulatorNamesViewer.setContentProvider(new ObservableListContentProvider<Emulator>());
             emulatorNamesViewer.setLabelProvider(new ColumnLabelProvider() {
                 @Override
                 public String getText(Object element) {
@@ -371,8 +378,9 @@ public class WizardConfigPage extends WizardPage {
             });
             emulatorNamesViewer.setInput(viewModel.getEmulators());
 
-            emulatorVersionsViewer.setContentProvider(ArrayContentProvider.getInstance());
+            emulatorVersionsViewer.setContentProvider(new ObservableListContentProvider<String>());
             emulatorVersionsViewer.setLabelProvider(new ColumnLabelProvider());
+            emulatorVersionsViewer.setInput(viewModel.getEmulatorVersions());
         }
 
         // sysroot
@@ -536,16 +544,6 @@ public class WizardConfigPage extends WizardPage {
                     });
             dbc.bindValue(toolchainSelection, toolchainIndexObservable, toolchainToIndex,
                     indexToToolchain);
-
-            toolchainIndexObservable.addValueChangeListener(e -> {
-                final var idx = viewModel.getSelectedToolchainIndex();
-                if (idx >= 0 && idx < viewModel.getToolchains().size()) {
-                    toolchainVersionsViewer
-                            .setInput(viewModel.getToolchains().get(idx).getVersions());
-                } else {
-                    toolchainVersionsViewer.setInput(List.of());
-                }
-            });
         }
 
         // toolchain versions
@@ -560,12 +558,8 @@ public class WizardConfigPage extends WizardPage {
                     .setConverter(new Converter<String, Integer>(String.class, Integer.class) {
                         @Override
                         public Integer convert(String fromObject) {
-                            final var idx = viewModel.getSelectedToolchainIndex();
-                            if (idx < 0 || idx >= viewModel.getToolchains().size()) {
-                                return Integer.valueOf(-1);
-                            }
-                            final var vers = viewModel.getToolchains().get(idx).getVersions();
-                            return Integer.valueOf(vers == null ? -1 : vers.indexOf(fromObject));
+                            return Integer
+                                    .valueOf(viewModel.getToolchainVersions().indexOf(fromObject));
                         }
                     });
             final var indexToToolchainVersion = new UpdateValueStrategy<Integer, String>();
@@ -573,15 +567,9 @@ public class WizardConfigPage extends WizardPage {
                     .setConverter(new Converter<Integer, String>(Integer.class, String.class) {
                         @Override
                         public String convert(Integer fromObject) {
-                            final var idx = viewModel.getSelectedToolchainIndex();
-                            if (idx < 0 || idx >= viewModel.getToolchains().size()) {
-                                return null;
-                            }
-                            final var vers = viewModel.getToolchains().get(idx).getVersions();
+                            final var vers = viewModel.getToolchainVersions();
                             final var verIdx = ((Integer) fromObject).intValue();
-                            return vers != null && verIdx >= 0 && verIdx < vers.size()
-                                    ? vers.get(verIdx)
-                                    : null;
+                            return verIdx >= 0 && verIdx < vers.size() ? vers.get(verIdx) : null;
                         }
                     });
             dbc.bindValue(toolchainVersionSelection, toolchainVersionIndexObservable,
@@ -633,16 +621,6 @@ public class WizardConfigPage extends WizardPage {
                     });
             dbc.bindValue(emulatorSelection, emulatorIndexObservable, emulatorToIndex,
                     indexToEmulator);
-
-            emulatorIndexObservable.addValueChangeListener(e -> {
-                final var idx = viewModel.getSelectedEmulatorIndex();
-                if (idx >= 0 && idx < viewModel.getEmulators().size()) {
-                    emulatorVersionsViewer
-                            .setInput(viewModel.getEmulators().get(idx).getVersions());
-                } else {
-                    emulatorVersionsViewer.setInput(List.of());
-                }
-            });
         }
 
         // emulator versions
@@ -657,12 +635,8 @@ public class WizardConfigPage extends WizardPage {
                     .setConverter(new Converter<String, Integer>(String.class, Integer.class) {
                         @Override
                         public Integer convert(String fromObject) {
-                            final var idx = viewModel.getSelectedEmulatorIndex();
-                            if (idx < 0 || idx >= viewModel.getEmulators().size()) {
-                                return Integer.valueOf(-1);
-                            }
-                            final var vers = viewModel.getEmulators().get(idx).getVersions();
-                            return Integer.valueOf(vers == null ? -1 : vers.indexOf(fromObject));
+                            return Integer
+                                    .valueOf(viewModel.getEmulatorVersions().indexOf(fromObject));
                         }
                     });
             final var indexToEmulatorVersion = new UpdateValueStrategy<Integer, String>();
@@ -670,26 +644,14 @@ public class WizardConfigPage extends WizardPage {
                     .setConverter(new Converter<Integer, String>(Integer.class, String.class) {
                         @Override
                         public String convert(Integer fromObject) {
-                            final var idx = viewModel.getSelectedEmulatorIndex();
-                            if (idx < 0 || idx >= viewModel.getEmulators().size()) {
-                                return null;
-                            }
-                            final var vers = viewModel.getEmulators().get(idx).getVersions();
+                            final var vers = viewModel.getEmulatorVersions();
                             final var verIdx = ((Integer) fromObject).intValue();
-                            return vers != null && verIdx >= 0 && verIdx < vers.size()
-                                    ? vers.get(verIdx)
-                                    : null;
+                            return verIdx >= 0 && verIdx < vers.size() ? vers.get(verIdx) : null;
                         }
                     });
             dbc.bindValue(emulatorVersionSelection, emulatorVersionIndexObservable,
                     emulatorVersionToIndex, indexToEmulatorVersion);
         }
-
-        // filter toolchains and emulators by quirks when profile changes
-        profileIndexObservable.addValueChangeListener(e -> {
-            toolchainNamesViewer.setInput(viewModel.getToolchains());
-            emulatorNamesViewer.setInput(viewModel.getEmulators());
-        });
 
         // sysroot
         {
@@ -791,11 +753,7 @@ public class WizardConfigPage extends WizardPage {
             return;
         }
 
+        // the observable lists fire change events that refresh the bound viewers
         viewModel.loadAll();
-        profileTableViewer.setInput(viewModel.getProfiles());
-        toolchainNamesViewer.setInput(viewModel.getToolchains());
-        toolchainVersionsViewer.setInput(List.of());
-        emulatorNamesViewer.setInput(viewModel.getEmulators());
-        emulatorVersionsViewer.setInput(List.of());
     }
 }

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardLoadingPage.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/WizardLoadingPage.java
@@ -1,0 +1,118 @@
+package org.ruyisdk.venv.views;
+
+import java.beans.PropertyChangeListener;
+import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.ProgressBar;
+import org.ruyisdk.venv.viewmodel.VenvWizardViewModel;
+
+/**
+ * Wizard page shown while package data is loaded asynchronously, keeping the UI responsive.
+ */
+public class WizardLoadingPage extends WizardPage {
+
+    private final VenvWizardViewModel viewModel;
+
+    private Composite container;
+    private Label messageLabel;
+    private ProgressBar progressBar;
+    private Button retryButton;
+
+    private final PropertyChangeListener listener = e -> updateState();
+
+    WizardLoadingPage(VenvWizardViewModel viewModel) {
+        super("loadingPage");
+        this.viewModel = viewModel;
+        setTitle("Loading");
+        setDescription("Fetching package data from the Ruyi package index.");
+        setPageComplete(false);
+    }
+
+    @Override
+    public void createControl(Composite parent) {
+        createLayouts(parent);
+        addControls();
+        registerEvents();
+    }
+
+    @Override
+    public void setVisible(boolean visible) {
+        super.setVisible(visible);
+        if (visible && !viewModel.isDataLoadStarted()) {
+            viewModel.loadAllAsync();
+        }
+    }
+
+    private void createLayouts(Composite parent) {
+        container = new Composite(parent, SWT.NONE);
+        container.setLayout(new GridLayout(1, false));
+
+        setControl(container);
+    }
+
+    private void addControls() {
+        messageLabel = new Label(container, SWT.WRAP);
+        messageLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+        messageLabel.setText("Package data will be loaded in the background.");
+
+        progressBar = new ProgressBar(container, SWT.INDETERMINATE);
+        progressBar.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+
+        retryButton = new Button(container, SWT.PUSH);
+        retryButton.setText("Retry");
+        retryButton.setLayoutData(new GridData(SWT.END, SWT.CENTER, false, false));
+        retryButton.setVisible(false);
+        retryButton.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                setErrorMessage(null);
+                retryButton.setVisible(false);
+                viewModel.loadAllAsync();
+            }
+        });
+    }
+
+    private void registerEvents() {
+        viewModel.addPropertyChangeListener(listener);
+        container.addDisposeListener(e -> viewModel.removePropertyChangeListener(listener));
+    }
+
+    private void updateState() {
+        if (container.isDisposed()) {
+            return;
+        }
+
+        final var errorMessage = viewModel.getLoadingErrorMessage();
+        if (viewModel.isDataLoading()) {
+            messageLabel.setText(viewModel.getLoadingMessage());
+            retryButton.setVisible(false);
+            setErrorMessage(null);
+            setPageComplete(false);
+        } else if (!errorMessage.isEmpty()) {
+            messageLabel.setText("Failed to load package data.");
+            retryButton.setVisible(true);
+            setErrorMessage(errorMessage);
+            setPageComplete(false);
+        } else if (viewModel.isDataLoadStarted()) {
+            messageLabel.setText("Package data loaded.");
+            retryButton.setVisible(false);
+            setErrorMessage(null);
+            setPageComplete(true);
+            advanceIfCurrent();
+        }
+        container.layout();
+    }
+
+    private void advanceIfCurrent() {
+        if (getContainer() != null && getContainer().getCurrentPage() == this) {
+            getContainer().showPage(getNextPage());
+        }
+    }
+}


### PR DESCRIPTION
Commit message:

```
New page: WizardLoadingPage
  - Loading data asynchronously with progress shown; auto-advances on success.
  - Back navigation to this page from "WizardConfigPage" is blocked.

VenvWizardViewModel:
  - For states required by "WizardLoadingPage", more properties have been added.
  - "IObservableList" tracks data changes and automatically notifies the view to update; selected toolchain/emulator versions are now exposed as observable string lists to make the logic in the View layer simpler.

WizardConfigPage:
  - Redundant viewer refreshes on "toolchains" and "emulators" removed; ViewModel's "filterPackagesBySelectedProfile()" does this work.

```

---

## Summary by Sourcery

Introduce an asynchronous loading flow for virtual environment package data and expose observable lists from the view model to keep the wizard UI responsive and auto-updating.

New Features:
- Add a transient WizardLoadingPage that asynchronously loads package data with progress, error handling, retry support, and auto-advance on success.

Enhancements:
- Refactor VenvWizardViewModel to fetch package data via observable lists, expose selected toolchain and emulator versions as observable string lists, and centralize filtering/derived state updates.
- Update WizardConfigPage to bind directly to observable lists for profiles, toolchains, and emulator versions, removing manual viewer refresh logic and blocking back navigation to the loading page.
- Adjust VenvWizard to start the wizard on the new loading page before proceeding to configuration and location pages.