### PR TITLE
fix(venv): observables must not be used by other threads; encapsulation

### DIFF
--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 import org.eclipse.core.databinding.observable.list.IObservableList;
 import org.eclipse.core.databinding.observable.list.WritableList;
 import org.eclipse.core.runtime.IStatus;
@@ -433,145 +434,147 @@ public class VenvWizardViewModel {
         service.installPackage(name, version);
     }
 
-    /** Installs the currently-selected toolchain package. */
-    public void installToolchain() {
-        if (selectedToolchainIndex < 0 || selectedToolchainIndex >= toolchains.size()
-                || selectedToolchainVersionIndex < 0) {
-            throw RuyiCliException.invalidArgument("No toolchain selected");
-        }
-        final var name = toolchains.get(selectedToolchainIndex).getName();
-        final var version = toolchains.get(selectedToolchainIndex).getVersions()
-                .get(selectedToolchainVersionIndex);
-        installToolchain(name, version);
-    }
-
     private void installEmulator(String name, String version) {
         service.installPackage(name, version);
-    }
-
-    /** Installs the currently-selected emulator package when enabled. */
-    public void installEmulator() {
-        if (!emulatorEnabled) {
-            throw RuyiCliException.invalidArgument("Emulator disabled");
-        }
-        if (selectedEmulatorIndex < 0 || selectedEmulatorIndex >= emulators.size()
-                || selectedEmulatorVersionIndex < 0) {
-            throw RuyiCliException.invalidArgument("Emulator enabled but not selected");
-        }
-        final var name = emulators.get(selectedEmulatorIndex).getName();
-        final var version = emulators.get(selectedEmulatorIndex).getVersions()
-                .get(selectedEmulatorVersionIndex);
-        installEmulator(name, version);
     }
 
     private void installPackageForSysroot(String name, String version) {
         service.installPackage(name, version);
     }
 
-    /** Installs the currently-selected sysroot package when enabled. */
-    public void installPackageForSysroot() {
-        if (sysrootOption != SysrootOption.FOREIGN_TOOLCHAIN) {
-            throw RuyiCliException.invalidArgument("No need to install package for sysroot");
-        }
-        final var sysrootToolchains = getSysrootToolchains();
-        if (selectedSysrootPackageIndex < 0
-                || selectedSysrootPackageIndex >= sysrootToolchains.size()
-                || selectedSysrootPackageVersionIndex < 0) {
-            throw RuyiCliException.invalidArgument("Sysroot enabled but not selected");
-        }
-        final var pkg = sysrootToolchains.get(selectedSysrootPackageIndex);
-        final var name = pkg.getName();
-        final var version = pkg.getVersions().get(selectedSysrootPackageVersionIndex);
-        installPackageForSysroot(name, version);
+    /** Data required by the finalization operations, resolved on the realm thread in advance. */
+    private static final class FinalizationData {
+        private String toolchainName;
+        private String toolchainVersion;
+        private String profile;
+        private SysrootOption sysrootOption;
+        private String sysrootPackageName;
+        private String sysrootPackageVersion;
+        private String sysrootDirectory;
+        private boolean emulatorEnabled;
+        private String emulatorName;
+        private String emulatorVersion;
+        private String venvLocation;
+        private String venvName;
     }
 
-    private void createVenv(String path, String toolchainName, String toolchainVersion,
-            String profile, Boolean withSysroot, String sysrootFrom, String copySysrootFromDir,
-            String symlinkSysrootFromDir, String projectSysrootFromRootfs, String emulatorName,
-            String emulatorVersion) {
-        service.createVenv(path, toolchainName, toolchainVersion, profile, withSysroot, sysrootFrom,
-                copySysrootFromDir, symlinkSysrootFromDir, projectSysrootFromRootfs, emulatorName,
-                emulatorVersion);
-    }
+    private FinalizationData finalizationData;
 
-    /** Creates a virtual environment using the current wizard selections. */
-    public void createVenv() {
-        final var parent = this.venvLocation;
-        if (parent == null || parent.isBlank()) {
+    /**
+     * Serialize everything needed by the finalization operations. Must be called on the realm of
+     * the observable lists (i.e. the UI thread) before {@link #doFinalization(Consumer)} is invoked
+     * from another thread.
+     */
+    public void buildFinalizationData() {
+        final var data = new FinalizationData();
+
+        if (venvLocation == null || venvLocation.isBlank()) {
             throw RuyiCliException.invalidArgument("Venv parent path is empty");
         }
-        final var name = this.venvName;
-        if (name == null || name.isBlank()) {
+        data.venvLocation = venvLocation;
+        if (venvName == null || venvName.isBlank()) {
             throw RuyiCliException.invalidArgument("Venv name is empty");
         }
+        data.venvName = venvName;
 
         if (selectedToolchainIndex < 0 || selectedToolchainIndex >= toolchains.size()
                 || selectedToolchainVersionIndex < 0) {
             throw RuyiCliException.invalidArgument("No toolchain selected");
         }
-        final var toolchainName = toolchains.get(selectedToolchainIndex).getName();
-        final var toolchainVersion = toolchains.get(selectedToolchainIndex).getVersions()
-                .get(selectedToolchainVersionIndex);
+        final var toolchain = toolchains.get(selectedToolchainIndex);
+        data.toolchainName = toolchain.getName();
+        data.toolchainVersion = toolchain.getVersions().get(selectedToolchainVersionIndex);
 
-        String profile = null;
         if (selectedProfileIndex >= 0 && selectedProfileIndex < profiles.size()) {
-            profile = profiles.get(selectedProfileIndex).getName();
+            data.profile = profiles.get(selectedProfileIndex).getName();
         }
 
-        Boolean withSysroot = null;
-        String sysrootFromAtom = null;
-        String copySysrootFromDir = null;
-        String symlinkSysrootFromDir = null;
-        String projectSysrootFromRootfs = null;
-        if (this.sysrootOption == SysrootOption.DEFAULT_SYSROOT) {
-            withSysroot = true;
-        } else if (this.sysrootOption == SysrootOption.NONE_SYSROOT) {
-            withSysroot = false;
-        } else if (this.sysrootOption == SysrootOption.FOREIGN_TOOLCHAIN) {
+        data.sysrootOption = sysrootOption;
+        if (sysrootOption == SysrootOption.FOREIGN_TOOLCHAIN) {
             if (!isSysrootPackageSelected()) {
                 throw RuyiCliException
                         .invalidArgument("Sysroot from package selected but no package chosen");
             }
             final var pkg = getSysrootToolchains().get(selectedSysrootPackageIndex);
-            final var ver = pkg.getVersions().get(selectedSysrootPackageVersionIndex);
-            sysrootFromAtom = String.format("%s(%s)", pkg.getName(), ver);
-        } else if (this.sysrootOption == SysrootOption.COPY_FROM_DIRECTORY) {
+            data.sysrootPackageName = pkg.getName();
+            data.sysrootPackageVersion = pkg.getVersions().get(selectedSysrootPackageVersionIndex);
+        } else if (usesSysrootDirectory(sysrootOption)) {
             if (sysrootDirectoryPath == null || sysrootDirectoryPath.isBlank()) {
                 throw RuyiCliException
-                        .invalidArgument("Copy sysroot from directory selected but no path set");
+                        .invalidArgument("Sysroot directory option selected but no path set");
             }
-            copySysrootFromDir = sysrootDirectoryPath;
-        } else if (this.sysrootOption == SysrootOption.SYMLINK_FROM_DIRECTORY) {
-            if (sysrootDirectoryPath == null || sysrootDirectoryPath.isBlank()) {
-                throw RuyiCliException
-                        .invalidArgument("Symlink sysroot from directory selected but no path set");
-            }
-            symlinkSysrootFromDir = sysrootDirectoryPath;
-        } else if (this.sysrootOption == SysrootOption.PROJECT_FROM_ROOTFS) {
-            if (sysrootDirectoryPath == null || sysrootDirectoryPath.isBlank()) {
-                throw RuyiCliException
-                        .invalidArgument("Project sysroot from rootfs selected but no path set");
-            }
-            projectSysrootFromRootfs = sysrootDirectoryPath;
+            data.sysrootDirectory = sysrootDirectoryPath;
         }
 
-        String emulatorName = null;
-        String emulatorVersion = null;
+        data.emulatorEnabled = emulatorEnabled;
         if (emulatorEnabled) {
             if (selectedEmulatorIndex < 0 || selectedEmulatorIndex >= emulators.size()
                     || selectedEmulatorVersionIndex < 0) {
                 throw RuyiCliException.invalidArgument("Emulator enabled but not selected");
             }
-            emulatorName = emulators.get(selectedEmulatorIndex).getName();
-            emulatorVersion = emulators.get(selectedEmulatorIndex).getVersions()
-                    .get(selectedEmulatorVersionIndex);
+            final var emulator = emulators.get(selectedEmulatorIndex);
+            data.emulatorName = emulator.getName();
+            data.emulatorVersion = emulator.getVersions().get(selectedEmulatorVersionIndex);
         }
 
-        final var target = new File(parent, name);
-        final var path = target.getPath();
-        createVenv(path, toolchainName, toolchainVersion, profile, withSysroot, sysrootFromAtom,
-                copySysrootFromDir, symlinkSysrootFromDir, projectSysrootFromRootfs, emulatorName,
-                emulatorVersion);
+        finalizationData = data;
+    }
+
+    /**
+     * Creates the virtual environment and installs its dependencies from the data recorded by
+     * {@link #buildFinalizationData()}, reporting each step through {@code stepReporter}. May be
+     * called from any thread since it only touches the snapshotted plain values. The
+     * {@link #finalizationData} field is cleared before returning.
+     *
+     * @param stepReporter callback receiving a short description of each step, e.g. for
+     *        {@code IProgressMonitor#subTask}
+     */
+    public void doFinalization(Consumer<String> stepReporter) {
+        if (finalizationData == null) {
+            throw RuyiCliException.invalidArgument("Finalization data not ready");
+        }
+        final var data = finalizationData;
+        finalizationData = null;
+
+        stepReporter.accept("install toolchain");
+        installToolchain(data.toolchainName, data.toolchainVersion);
+
+        if (data.sysrootOption == SysrootOption.FOREIGN_TOOLCHAIN) {
+            stepReporter.accept("install package for sysroot");
+            installPackageForSysroot(data.sysrootPackageName, data.sysrootPackageVersion);
+        }
+
+        if (data.emulatorEnabled) {
+            stepReporter.accept("install emulator");
+            installEmulator(data.emulatorName, data.emulatorVersion);
+        }
+
+        stepReporter.accept("create venv");
+
+        Boolean withSysroot = null;
+        String sysrootFromPackage = null;
+        String copySysrootFromDir = null;
+        String symlinkSysrootFromDir = null;
+        String projectSysrootFromRootfs = null;
+        if (data.sysrootOption == SysrootOption.DEFAULT_SYSROOT) {
+            withSysroot = true;
+        } else if (data.sysrootOption == SysrootOption.NONE_SYSROOT) {
+            withSysroot = false;
+        } else if (data.sysrootOption == SysrootOption.FOREIGN_TOOLCHAIN) {
+            sysrootFromPackage =
+                    String.format("%s(%s)", data.sysrootPackageName, data.sysrootPackageVersion);
+        } else if (data.sysrootOption == SysrootOption.COPY_FROM_DIRECTORY) {
+            copySysrootFromDir = data.sysrootDirectory;
+        } else if (data.sysrootOption == SysrootOption.SYMLINK_FROM_DIRECTORY) {
+            symlinkSysrootFromDir = data.sysrootDirectory;
+        } else if (data.sysrootOption == SysrootOption.PROJECT_FROM_ROOTFS) {
+            projectSysrootFromRootfs = data.sysrootDirectory;
+        }
+
+        final var path = new File(data.venvLocation, data.venvName).getPath();
+        service.createVenv(path, data.toolchainName, data.toolchainVersion, data.profile,
+                withSysroot, sysrootFromPackage, copySysrootFromDir, symlinkSysrootFromDir,
+                projectSysrootFromRootfs, data.emulatorName, data.emulatorVersion);
     }
 
     /** Returns available profiles as an observable list. */

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/viewmodel/VenvWizardViewModel.java
@@ -442,20 +442,14 @@ public class VenvWizardViewModel {
         service.installPackage(name, version);
     }
 
-    /** Data required by the finalization operations, resolved on the realm thread in advance. */
-    private static final class FinalizationData {
-        private String toolchainName;
-        private String toolchainVersion;
-        private String profile;
-        private SysrootOption sysrootOption;
-        private String sysrootPackageName;
-        private String sysrootPackageVersion;
-        private String sysrootDirectory;
-        private boolean emulatorEnabled;
-        private String emulatorName;
-        private String emulatorVersion;
-        private String venvLocation;
-        private String venvName;
+    /**
+     * Data required by the finalization operations, resolved on the realm thread in advance. A null
+     * String component means the corresponding wizard option was not selected.
+     */
+    private static record FinalizationData(String toolchainName, String toolchainVersion,
+            String profile, SysrootOption sysrootOption, String sysrootPackageName,
+            String sysrootPackageVersion, String sysrootDirectory, boolean emulatorEnabled,
+            String emulatorName, String emulatorVersion, String venvLocation, String venvName) {
     }
 
     private FinalizationData finalizationData;
@@ -466,58 +460,60 @@ public class VenvWizardViewModel {
      * from another thread.
      */
     public void buildFinalizationData() {
-        final var data = new FinalizationData();
-
         if (venvLocation == null || venvLocation.isBlank()) {
             throw RuyiCliException.invalidArgument("Venv parent path is empty");
         }
-        data.venvLocation = venvLocation;
         if (venvName == null || venvName.isBlank()) {
             throw RuyiCliException.invalidArgument("Venv name is empty");
         }
-        data.venvName = venvName;
 
         if (selectedToolchainIndex < 0 || selectedToolchainIndex >= toolchains.size()
                 || selectedToolchainVersionIndex < 0) {
             throw RuyiCliException.invalidArgument("No toolchain selected");
         }
         final var toolchain = toolchains.get(selectedToolchainIndex);
-        data.toolchainName = toolchain.getName();
-        data.toolchainVersion = toolchain.getVersions().get(selectedToolchainVersionIndex);
+        final var toolchainName = toolchain.getName();
+        final var toolchainVersion = toolchain.getVersions().get(selectedToolchainVersionIndex);
 
+        String profile = null;
         if (selectedProfileIndex >= 0 && selectedProfileIndex < profiles.size()) {
-            data.profile = profiles.get(selectedProfileIndex).getName();
+            profile = profiles.get(selectedProfileIndex).getName();
         }
 
-        data.sysrootOption = sysrootOption;
+        String sysrootPackageName = null;
+        String sysrootPackageVersion = null;
+        String sysrootDirectory = null;
         if (sysrootOption == SysrootOption.FOREIGN_TOOLCHAIN) {
             if (!isSysrootPackageSelected()) {
                 throw RuyiCliException
                         .invalidArgument("Sysroot from package selected but no package chosen");
             }
             final var pkg = getSysrootToolchains().get(selectedSysrootPackageIndex);
-            data.sysrootPackageName = pkg.getName();
-            data.sysrootPackageVersion = pkg.getVersions().get(selectedSysrootPackageVersionIndex);
+            sysrootPackageName = pkg.getName();
+            sysrootPackageVersion = pkg.getVersions().get(selectedSysrootPackageVersionIndex);
         } else if (usesSysrootDirectory(sysrootOption)) {
             if (sysrootDirectoryPath == null || sysrootDirectoryPath.isBlank()) {
                 throw RuyiCliException
                         .invalidArgument("Sysroot directory option selected but no path set");
             }
-            data.sysrootDirectory = sysrootDirectoryPath;
+            sysrootDirectory = sysrootDirectoryPath;
         }
 
-        data.emulatorEnabled = emulatorEnabled;
+        String emulatorName = null;
+        String emulatorVersion = null;
         if (emulatorEnabled) {
             if (selectedEmulatorIndex < 0 || selectedEmulatorIndex >= emulators.size()
                     || selectedEmulatorVersionIndex < 0) {
                 throw RuyiCliException.invalidArgument("Emulator enabled but not selected");
             }
             final var emulator = emulators.get(selectedEmulatorIndex);
-            data.emulatorName = emulator.getName();
-            data.emulatorVersion = emulator.getVersions().get(selectedEmulatorVersionIndex);
+            emulatorName = emulator.getName();
+            emulatorVersion = emulator.getVersions().get(selectedEmulatorVersionIndex);
         }
 
-        finalizationData = data;
+        finalizationData = new FinalizationData(toolchainName, toolchainVersion, profile,
+                sysrootOption, sysrootPackageName, sysrootPackageVersion, sysrootDirectory,
+                emulatorEnabled, emulatorName, emulatorVersion, venvLocation, venvName);
     }
 
     /**
@@ -537,16 +533,16 @@ public class VenvWizardViewModel {
         finalizationData = null;
 
         stepReporter.accept("install toolchain");
-        installToolchain(data.toolchainName, data.toolchainVersion);
+        installToolchain(data.toolchainName(), data.toolchainVersion());
 
-        if (data.sysrootOption == SysrootOption.FOREIGN_TOOLCHAIN) {
+        if (data.sysrootOption() == SysrootOption.FOREIGN_TOOLCHAIN) {
             stepReporter.accept("install package for sysroot");
-            installPackageForSysroot(data.sysrootPackageName, data.sysrootPackageVersion);
+            installPackageForSysroot(data.sysrootPackageName(), data.sysrootPackageVersion());
         }
 
-        if (data.emulatorEnabled) {
+        if (data.emulatorEnabled()) {
             stepReporter.accept("install emulator");
-            installEmulator(data.emulatorName, data.emulatorVersion);
+            installEmulator(data.emulatorName(), data.emulatorVersion());
         }
 
         stepReporter.accept("create venv");
@@ -556,25 +552,25 @@ public class VenvWizardViewModel {
         String copySysrootFromDir = null;
         String symlinkSysrootFromDir = null;
         String projectSysrootFromRootfs = null;
-        if (data.sysrootOption == SysrootOption.DEFAULT_SYSROOT) {
+        if (data.sysrootOption() == SysrootOption.DEFAULT_SYSROOT) {
             withSysroot = true;
-        } else if (data.sysrootOption == SysrootOption.NONE_SYSROOT) {
+        } else if (data.sysrootOption() == SysrootOption.NONE_SYSROOT) {
             withSysroot = false;
-        } else if (data.sysrootOption == SysrootOption.FOREIGN_TOOLCHAIN) {
-            sysrootFromPackage =
-                    String.format("%s(%s)", data.sysrootPackageName, data.sysrootPackageVersion);
-        } else if (data.sysrootOption == SysrootOption.COPY_FROM_DIRECTORY) {
-            copySysrootFromDir = data.sysrootDirectory;
-        } else if (data.sysrootOption == SysrootOption.SYMLINK_FROM_DIRECTORY) {
-            symlinkSysrootFromDir = data.sysrootDirectory;
-        } else if (data.sysrootOption == SysrootOption.PROJECT_FROM_ROOTFS) {
-            projectSysrootFromRootfs = data.sysrootDirectory;
+        } else if (data.sysrootOption() == SysrootOption.FOREIGN_TOOLCHAIN) {
+            sysrootFromPackage = String.format("%s(%s)", data.sysrootPackageName(),
+                    data.sysrootPackageVersion());
+        } else if (data.sysrootOption() == SysrootOption.COPY_FROM_DIRECTORY) {
+            copySysrootFromDir = data.sysrootDirectory();
+        } else if (data.sysrootOption() == SysrootOption.SYMLINK_FROM_DIRECTORY) {
+            symlinkSysrootFromDir = data.sysrootDirectory();
+        } else if (data.sysrootOption() == SysrootOption.PROJECT_FROM_ROOTFS) {
+            projectSysrootFromRootfs = data.sysrootDirectory();
         }
 
-        final var path = new File(data.venvLocation, data.venvName).getPath();
-        service.createVenv(path, data.toolchainName, data.toolchainVersion, data.profile,
+        final var path = new File(data.venvLocation(), data.venvName()).getPath();
+        service.createVenv(path, data.toolchainName(), data.toolchainVersion(), data.profile(),
                 withSysroot, sysrootFromPackage, copySysrootFromDir, symlinkSysrootFromDir,
-                projectSysrootFromRootfs, data.emulatorName, data.emulatorVersion);
+                projectSysrootFromRootfs, data.emulatorName(), data.emulatorVersion());
     }
 
     /** Returns available profiles as an observable list. */

--- a/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
+++ b/plugins/org.ruyisdk.venv/src/org/ruyisdk/venv/views/VenvWizard.java
@@ -48,25 +48,21 @@ public class VenvWizard extends Wizard {
 
     @Override
     public boolean performFinish() {
+        // Prepare data here, then use data in the worker thread.
+        // Forked runnable must not touch observables.
+        try {
+            viewModel.buildFinalizationData();
+        } catch (PluginException e) {
+            StatusManager.getManager()
+                    .handle(new Status(IStatus.ERROR, "org.ruyisdk.venv",
+                            "Unable to complete virtual environment setup.", e),
+                            StatusManager.LOG | StatusManager.BLOCK);
+            return false;
+        }
         try {
             getContainer().run(true, true, monitor -> {
                 try {
-                    monitor.subTask("install toolchain");
-                    viewModel.installToolchain();
-
-                    if (viewModel
-                            .getSysrootOption() == VenvWizardViewModel.SysrootOption.FOREIGN_TOOLCHAIN) {
-                        monitor.subTask("install package for sysroot");
-                        viewModel.installPackageForSysroot();
-                    }
-
-                    if (viewModel.isEmulatorEnabled()) {
-                        monitor.subTask("install emulator");
-                        viewModel.installEmulator();
-                    }
-
-                    monitor.subTask("create venv");
-                    viewModel.createVenv();
+                    viewModel.doFinalization(monitor::subTask);
                 } catch (PluginException e) {
                     throw new InvocationTargetException(e);
                 }


### PR DESCRIPTION
commit message:

```
Let ViewModel handles the progress of venv setup. I call it "finalization".

log:
  Unable to complete virtual environment setup.
  assertion failed: Getter called outside realm of observable org.eclipse.core.databinding.observable.list.WritableList@...

```

.

## Summary by Sourcery

Isolate virtual environment finalization logic into the view model to safely run on a worker thread while keeping UI observables on their realm.

Bug Fixes:
- Prevent cross-thread access to observable lists during virtual environment setup by snapshotting required data on the UI thread.

Enhancements:
- Introduce a FinalizationData snapshot and doFinalization API on the view model to centralize venv creation and dependency installation with step reporting from a progress monitor.